### PR TITLE
[SPARK-17445] Reference an ASF page as the main place to find third-party packages

### DIFF
--- a/_layouts/global.html
+++ b/_layouts/global.html
@@ -113,7 +113,7 @@
           <li><a href="{{site.url}}mllib/">MLlib (machine learning)</a></li>
           <li><a href="{{site.url}}graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -184,7 +184,7 @@
         <li><a href="{{site.url}}mllib/">MLlib (machine learning)</a></li>
         <li><a href="{{site.url}}graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/community.html
+++ b/site/community.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/examples.html
+++ b/site/examples.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/faq.html
+++ b/site/faq.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -101,7 +101,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -181,7 +181,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/index.html
+++ b/site/index.html
@@ -100,7 +100,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -180,7 +180,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -101,7 +101,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -181,7 +181,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -101,7 +101,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -181,7 +181,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-east-agenda-posted.html
+++ b/site/news/spark-summit-east-agenda-posted.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/research.html
+++ b/site/research.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -101,7 +101,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -181,7 +181,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -101,7 +101,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -181,7 +181,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="http://spark-packages.org">Third-Party Packages</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -178,7 +178,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="http://spark-packages.org">Third-Party Packages</a>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
     </div>
   </div>
 


### PR DESCRIPTION
Redirect third party packages link to https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects
