### PR TITLE
[SPARK-18073][WIP] Migrate wiki to spark.apache.org web site, part 1

### DIFF
--- a/_layouts/global.html
+++ b/_layouts/global.html
@@ -113,7 +113,7 @@
           <li><a href="{{site.baseurl}}/mllib/">MLlib (machine learning)</a></li>
           <li><a href="{{site.baseurl}}/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="{{site.baseurl}}/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -185,7 +185,7 @@
         <li><a href="{{site.baseurl}}/mllib/">MLlib (machine learning)</a></li>
         <li><a href="{{site.baseurl}}/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="{{site.baseurl}}/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/_layouts/global.html
+++ b/_layouts/global.html
@@ -131,12 +131,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="{{site.baseurl}}/community.html">Mailing Lists</a></li>
+          <li><a href="{{site.baseurl}}/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="{{site.baseurl}}/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="{{site.baseurl}}/community.html#events">Events and Meetups</a></li>
           <li><a href="{{site.baseurl}}/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="{{site.baseurl}}/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="{{site.baseurl}}/faq.html">FAQ</a></li>

--- a/_layouts/global.html
+++ b/_layouts/global.html
@@ -135,7 +135,7 @@
           <li><a href="{{site.baseurl}}/community.html#events">Events and Meetups</a></li>
           <li><a href="{{site.baseurl}}/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="{{site.baseurl}}/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/_layouts/global.html
+++ b/_layouts/global.html
@@ -136,7 +136,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="{{site.baseurl}}/community.html#events">Events and Meetups</a></li>
           <li><a href="{{site.baseurl}}/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="{{site.baseurl}}/powered-by.html">Powered By</a></li>
           <li><a href="{{site.baseurl}}/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/committers.md
+++ b/committers.md
@@ -61,7 +61,7 @@ navigation:
 <h3>Becoming a Committer</h3>
 
 To get started contributing to Spark, learn 
-[how to contribute](https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark) – 
+<a href="{{site.baseurl}}/contributing.html">how to contribute</a> – 
 anyone can submit patches, documentation and examples to the project.
 
 The PMC regularly adds new committers from the active contributors, based on their contributions 
@@ -89,7 +89,7 @@ platform support for specific OSes, storage systems, etc.
 <h3>Review Process</h3>
 
 All contributions should be reviewed before merging as described in 
-[Contributing to Spark](https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark). 
+<a href="{{site.baseurl}}/contributing.html">Contributing to Spark</a>. 
 In particular, if you are working on an area of the codebase you are unfamiliar with, look at the 
 Git history for that code to see who reviewed patches before. You can do this using 
 `git log --format=full <filename>`, by examining the "Commit" field to see who committed each patch.

--- a/committers.md
+++ b/committers.md
@@ -141,7 +141,7 @@ follow-up can be well communicated to all Spark developers.
 
 <h3>Policy on Backporting Bug Fixes</h3>
 
-From `pwendell` at https://www.mail-archive.com/dev@spark.apache.org/msg10284.html:
+From <a href="https://www.mail-archive.com/dev@spark.apache.org/msg10284.html">`pwendell`</a>:
 
 The trade off when backporting is you get to deliver the fix to people running older versions 
 (great!), but you risk introducing new or even worse bugs in maintenance releases (bad!). 

--- a/committers.md
+++ b/committers.md
@@ -1,0 +1,167 @@
+---
+layout: global
+title: Committers
+type: "page singular"
+navigation:
+  weight: 5
+  show: true
+---
+<h2>Current Committers</h2>
+
+|Name|Organization|
+|----|------------|
+|Michael Armbrust|Databricks|
+|Joseph Bradley|Databricks|
+|Felix Cheung|Automattic|
+|Mosharaf Chowdhury|University of Michigan, Ann Arbor|
+|Jason Dai|Intel|
+|Tathagata Das|Databricks|
+|Ankur Dave|UC Berkeley|
+|Aaron Davidson|Databricks|
+|Thomas Dudziak|Facebook|
+|Robert Evans|Yahoo!|
+|Wenchen Fan|Databricks|
+|Joseph Gonzalez|UC Berkeley|
+|Thomas Graves|Yahoo!|
+|Stephen Haberman|Bizo|
+|Mark Hamstra|ClearStory Data|
+|Herman van Hovell|QuestTec B.V.|
+|Yin Huai|Databricks|
+|Shane Huang|Intel|
+|Andy Konwinski|Databricks|
+|Ryan LeCompte|Quantifind|
+|Haoyuan Li|Alluxio, UC Berkeley|
+|Xiao Li|IBM|
+|Davies Liu|Databricks|
+|Cheng Lian|Databricks|
+|Yanbo Liang|Hortonworks|
+|Sean McNamara|Webtrends|
+|Xiangrui Meng|Databricks|
+|Mridul Muralidharam|Hortonworks|
+|Andrew Or|Princeton University|
+|Kay Ousterhout|UC Berkeley|
+|Sean Owen|Cloudera|
+|Nick Pentreath|IBM|
+|Imran Rashid|Cloudera|
+|Charles Reiss|UC Berkeley|
+|Josh Rosen|Databricks|
+|Sandy Ryza|Clover Health|
+|Kousuke Saruta|NTT Data|
+|Prashant Sharma|IBM|
+|Ram Sriharsha|Databricks|
+|DB Tsai|Netflix|
+|Marcelo Vanzin|Cloudera|
+|Shivaram Venkataraman|UC Berkeley|
+|Patrick Wendell|Databricks|
+|Andrew Xia|Alibaba|
+|Reynold Xin|Databricks|
+|Matei Zaharia|Databricks, Stanford|
+|Shixiong Zhu|Databricks|
+
+<h3>Becoming a Committer</h3>
+
+To get started contributing to Spark, learn 
+[how to contribute](https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark) – 
+anyone can submit patches, documentation and examples to the project.
+
+The PMC regularly adds new committers from the active contributors, based on their contributions 
+to Spark. The qualifications for new committers include:
+
+1. Sustained contributions to Spark: Committers should have a history of major contributions to 
+Spark. An ideal committer will have contributed broadly throughout the project, and have 
+contributed at least one major component where they have taken an "ownership" role. An ownership 
+role means that existing contributors feel that they should run patches for this component by 
+this person.
+2. Quality of contributions: Committers more than any other community member should submit simple, 
+well-tested, and well-designed patches. In addition, they should show sufficient expertise to be 
+able to review patches, including making sure they fit within Spark's engineering practices 
+(testability, documentation, API stability, code style, etc). The committership is collectively 
+responsible for the software quality and maintainability of Spark.
+3. Community involvement: Committers should have a constructive and friendly attitude in all 
+community interactions. They should also be active on the dev and user list and help mentor 
+newer contributors and users. In design discussions, committers should maintain a professional 
+and diplomatic approach, even in the face of disagreement.
+
+The type and level of contributions considered may vary by project area -- for example, we 
+greatly encourage contributors who want to work on mainly the documentation, or mainly on 
+platform support for specific OSes, storage systems, etc.
+
+<h3>Review Process</h3>
+
+All contributions should be reviewed before merging as described in 
+[Contributing to Spark](https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark). 
+In particular, if you are working on an area of the codebase you are unfamiliar with, look at the 
+Git history for that code to see who reviewed patches before. You can do this using 
+`git log --format=full <filename>`, by examining the "Commit" field to see who committed each patch.
+
+<h3>How to Merge a Pull Request</h3>
+
+Changes pushed to the master branch on Apache cannot be removed; that is, we can't force-push to 
+it. So please don't add any test commits or anything like that, only real patches.
+
+All merges should be done using the 
+[dev/merge_spark_pr.py](https://github.com/apache/spark/blob/master/dev/merge_spark_pr.py) 
+script, which squashes the pull request's changes into one commit. To use this script, you 
+will need to add a git remote called "apache" at https://git-wip-us.apache.org/repos/asf/spark.git, 
+as well as one called "apache-github" at `git://github.com/apache/spark`. For the `apache` repo, 
+you can authenticate using your ASF username and password. Ask Patrick if you have trouble with 
+this or want help doing your first merge.
+
+The script is fairly self explanatory and walks you through steps and options interactively.
+
+If you want to amend a commit before merging – which should be used for trivial touch-ups – 
+then simply let the script wait at the point where it asks you if you want to push to Apache. 
+Then, in a separate window, modify the code and push a commit. Run `git rebase -i HEAD~2` and 
+"squash" your new commit. Edit the commit message just after to remove your commit message. 
+You can verify the result is one change with `git log`. Then resume the script in the other window.
+
+Also, please remember to set Assignee on JIRAs where applicable when they are resolved. The script 
+can't do this automatically.
+
+<!--
+<h3>Minimize use of MINOR, BUILD, and HOTFIX with no JIRA</h3>
+
+From pwendell at https://www.mail-archive.com/dev@spark.apache.org/msg09565.html:
+It would be great if people could create JIRA's for any and all merged pull requests. The reason is 
+that when patches get reverted due to build breaks or other issues, it is very difficult to keep 
+track of what is going on if there is no JIRA. 
+Here is a list of 5 patches we had to revert recently that didn't include a JIRA:
+    Revert "[MINOR] [BUILD] Use custom temp directory during build."
+    Revert "[SQL] [TEST] [MINOR] Uses a temporary log4j.properties in HiveThriftServer2Test to ensure expected logging behavior"
+    Revert "[BUILD] Always run SQL tests in master build."
+    Revert "[MINOR] [CORE] Warn users who try to cache RDDs with dynamic allocation on."
+    Revert "[HOT FIX] [YARN] Check whether `/lib` exists before listing its files"
+
+The cost overhead of creating a JIRA relative to other aspects of development is very small. 
+If it's really a documentation change or something small, that's okay.
+
+But anything affecting the build, packaging, etc. These all need to have a JIRA to ensure that 
+follow-up can be well communicated to all Spark developers.
+-->
+
+<h3>Policy on Backporting Bug Fixes</h3>
+
+From `pwendell` at https://www.mail-archive.com/dev@spark.apache.org/msg10284.html:
+
+The trade off when backporting is you get to deliver the fix to people running older versions 
+(great!), but you risk introducing new or even worse bugs in maintenance releases (bad!). 
+The decision point is when you have a bug fix and it's not clear whether it is worth backporting.
+
+I think the following facets are important to consider:
+- Backports are an extremely valuable service to the community and should be considered for 
+any bug fix.
+- Introducing a new bug in a maintenance release must be avoided at all costs. It over time would 
+erode confidence in our release process.
+- Distributions or advanced users can always backport risky patches on their own, if they see fit.
+
+For me, the consequence of these is that we should backport in the following situations:
+- Both the bug and the fix are well understood and isolated. Code being modified is well tested.
+- The bug being addressed is high priority to the community.
+- The backported fix does not vary widely from the master branch fix.
+
+We tend to avoid backports in the converse situations:
+- The bug or fix are not well understood. For instance, it relates to interactions between complex 
+components or third party libraries (e.g. Hadoop libraries). The code is not well tested outside 
+of the immediate bug being fixed.
+- The bug is not clearly a high priority for the community.
+- The backported fix is widely different from the master branch fix.

--- a/community.md
+++ b/community.md
@@ -191,7 +191,7 @@ Spark Meetups are grass-roots events organized and hosted by leaders and champio
 
 <h3>Powered By</h3>
 
-<p>Our wiki has a list of <a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">projects and organizations powered by Spark</a>.</p>
+<p>Our wiki has a list of <a href="{{site.baseurl}}/powered-by.html">projects and organizations powered by Spark</a>.</p>
 
 <a name="history"></a>
 <h3>Project History</h3>

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,511 @@
+---
+layout: global
+title: Contributing to Spark
+type: "page singular"
+navigation:
+  weight: 5
+  show: true
+---
+
+This guide documents the best way to make various types of contribution to Apache Spark, 
+including what is required before submitting a code change.
+
+Contributing to Spark doesn't just mean writing code. Helping new users on the mailing list, 
+testing releases, and improving documentation are also welcome. In fact, proposing significant 
+code changes usually requires first gaining experience and credibility within the community by h
+elping in other ways. This is also a guide to becoming an effective contributor.
+
+So, this guide organizes contributions in order that they should probably be considered by new 
+contributors who intend to get involved long-term. Build some track record of helping others, 
+rather than just open pull requests.
+
+<h2>Contributing by Helping Other Users</h2>
+
+A great way to contribute to Spark is to help answer user questions on the `user@spark.apache.org` 
+mailing list or on StackOverflow. There are always many new Spark users; taking a few minutes to 
+help answer a question is a very valuable community service.
+
+Contributors should subscribe to this list and follow it in order to keep up to date on what's 
+happening in Spark. Answering questions is an excellent and visible way to help the community, 
+which also demonstrates your expertise.
+
+See the <a href="{{site.baseurl}}/mailing-lists.html">Mailing Lists guide</a> for guidelines 
+about how to effectively participate in discussions on the mailing list, as well as forums 
+like StackOverflow.
+
+<h2>Contributing by Testing Releases</h2>
+
+Spark's release process is community-oriented, and members of the community can vote on new 
+releases on the `dev@spark.apache.org` mailing list. Spark users are invited to subscribe to 
+this list to receive announcements, and test their workloads on newer release and provide 
+feedback on any performance or correctness issues found in the newer release.
+
+<h2>Contributing by Reviewing Changes</h2>
+
+Changes to Spark source code are proposed, reviewed and committed via Github (described later) at 
+http://github.com/apache/spark/pulls. Anyone can view and comment on active changes here. 
+Reviewing others' changes is a good way to learn how the change process works and gain exposure 
+to activity in various parts of the code. You can help by reviewing the changes and asking 
+questions or pointing out issues -- as simple as typos or small issues of style.
+See also https://spark-prs.appspot.com/ for a convenient way to view and filter open PRs.
+
+<h2>Contributing Documentation Changes</h2>
+
+To propose a change to _release_ documentation (that is, docs that appear under 
+https://spark.apache.org/docs/), edit the Markdown source files in Spark's 
+<a href="https://github.com/apache/spark/tree/master/docs">`docs/`</a> directory, 
+whose `README` file shows how to build the documentation locally to test your changes.
+The process to propose a doc change is otherwise the same as the process for proposing code 
+changes below. 
+
+To propose a change to the rest of the documentation (that is, docs that do _not_ appear under 
+https://spark.apache.org/docs/), similarly, edit the Markdown in the https://github.com/apache/spark-website
+repository and open a pull request.
+
+<h2>Contributing User Libraries to Spark</h2>
+
+Just as Java and Scala applications can access a huge selection of libraries and utilities, 
+none of which are part of Java or Scala themselves, Spark aims to support a rich ecosystem of 
+libraries. Many new useful utilities or features belong outside of Spark rather than in the core. 
+For example: language support probably has to be a part of core Spark, but, useful machine 
+learning algorithms can happily exist outside of MLlib.
+
+To that end, large and independent new functionality is often rejected for inclusion in Spark 
+itself, but, can and should be hosted as a separate project and repository, and included in 
+the http://spark-packages.org/ collection.
+
+<h2>Contributing Bug Reports</h2>
+
+Ideally, bug reports are accompanied by a proposed code change to fix the bug. This isn't 
+always possible, as those who discover a bug may not have the experience to fix it. A bug 
+may be reported by creating a JIRA but without creating a pull request (see below).
+
+Bug reports are only useful however if they include enough information to understand, isolate 
+and ideally reproduce the bug. Simply encountering an error does not mean a bug should be 
+reported; as below, search JIRA and search and inquire on the Spark user / dev mailing lists 
+first. Unreproducible bugs, or simple error reports, may be closed.
+
+It is possible to propose new features as well. These are generally not helpful unless 
+accompanied by detail, such as a design document and/or code change. Large new contributions 
+should consider http://spark-packages.org first (see above), or be discussed on the mailing 
+list first. Feature requests may be rejected, or closed after a long period of inactivity.
+
+<h2>Contributing to JIRA Maintenance</h2>
+
+Given the sheer volume of issues raised in the Apache Spark JIRA, inevitably some issues are 
+duplicates, or become obsolete and eventually fixed otherwise, or can't be reproduced, or could 
+benefit from more detail, and so on. It's useful to help identify these issues and resolve them, 
+either by advancing the discussion or even resolving the JIRA. Most contributors are able to 
+directly resolve JIRAs. Use judgment in determining whether you are quite confident the issue 
+should be resolved, although changes can be easily undone. If in doubt, just leave a comment 
+on the JIRA.
+
+When resolving JIRAs, observe a few useful conventions:
+
+- Resolve as **Fixed** if there's a change you can point to that resolved the issue
+  - Set Fix Version(s), if and only if the resolution is Fixed
+  - Set Assignee to the person who most contributed to the resolution, which is usually the person 
+  who opened the PR that resolved the issue.
+  - In case several people contributed, prefer to assign to the more 'junior', non-committer contributor
+- For issues that can't be reproduced against master as reported, resolve as **Cannot Reproduce**
+  - Fixed is reasonable too, if it's clear what other previous pull request resolved it. Link to it.
+- If the issue is the same as or a subset of another issue, resolved as **Duplicate**
+  - Make sure to link to the JIRA it duplicates
+  - Prefer to resolve the issue that has less activity or discussion as the duplicate
+- If the issue seems clearly obsolete and applies to issues or components that have changed 
+radically since it was opened, resolve as **Not a Problem**
+- If the issue doesn't make sense – not actionable, for example, a non-Spark issue, resolve 
+as **Invalid**
+- If it's a coherent issue, but there is a clear indication that there is not support or interest 
+in acting on it, then resolve as **Won't Fix**
+- Umbrellas are frequently marked **Done** if they are just container issues that don't correspond 
+to an actionable change of their own
+
+<h2>Preparing to Contribute Code Changes</h2>
+
+<h3>Choosing What to Contribute</h3>
+
+Spark is an exceptionally busy project, with a new JIRA or pull request every few hours on average. 
+Review can take hours or days of committer time. Everyone benefits if contributors focus on 
+changes that are useful, clear, easy to evaluate, and already pass basic checks.
+
+Sometimes, a contributor will already have a particular new change or bug in mind. If seeking 
+ideas, consult the list of starter tasks in JIRA, or ask the user@spark.apache.org mailing list.
+
+Before proceeding, contributors should evaluate if the proposed change is likely to be relevant, 
+new and actionable:
+
+- Is it clear that code must change? Proposing a JIRA and pull request is appropriate only when a 
+clear problem or change has been identified. If simply having trouble using Spark, use the mailing 
+lists first, rather than consider filing a JIRA or proposing a change. When in doubt, email 
+`user@spark.apache.org` first about the possible change
+- Search the `user@spark.apache.org` and `dev@spark.apache.org` mailing list 
+<a href="{{site.baseurl}}/community.html#mailing-lists">archives</a> for 
+related discussions. Use http://search-hadoop.com/?q=&fc_project=Spark or similar search tools. 
+Often, the problem has been discussed before, with a resolution that doesn't require a code 
+change, or recording what kinds of changes will not be accepted as a resolution.
+- Search JIRA for existing issues: https://issues.apache.org/jira/browse/SPARK 
+- Type `spark [search terms]` at the top right search box. If a logically similar issue already 
+exists, then contribute to the discussion on the existing JIRA and pull request first, instead of 
+creating a new one.
+- Is the scope of the change matched to the contributor's level of experience? Anyone is qualified 
+to suggest a typo fix, but refactoring core scheduling logic requires much more understanding of 
+Spark. Some changes require building up experience first (see above).
+
+<h3>MLlib-specific Contribution Guidelines</h3>
+
+While a rich set of algorithms is an important goal for MLLib, scaling the project requires 
+that maintainability, consistency, and code quality come first. New algorithms should:
+
+- Be widely known
+- Be used and accepted (academic citations and concrete use cases can help justify this)
+- Be highly scalable
+- Be well documented
+- Have APIs consistent with other algorithms in MLLib that accomplish the same thing
+- Come with a reasonable expectation of developer support.
+- Have `@Since` annotation on public classes, methods, and variables.
+
+<h3>Code Review Criteria</h3>
+
+Before considering how to contribute code, it's useful to understand how code is reviewed, 
+and why changes may be rejected. Simply put, changes that have many or large positives, and 
+few negative effects or risks, are much more likely to be merged, and merged quickly. 
+Risky and less valuable changes are very unlikely to be merged, and may be rejected outright 
+rather than receive iterations of review.
+
+<h4>Positives</h4>
+
+- Fixes the root cause of a bug in existing functionality
+- Adds functionality or fixes a problem needed by a large number of users
+- Simple, targeted
+- Maintains or improves consistency across Python, Java, Scala
+- Easily tested; has tests
+- Reduces complexity and lines of code
+- Change has already been discussed and is known to committers
+
+<h4>Negatives, Risks</h4>
+
+- Band-aids a symptom of a bug only
+- Introduces complex new functionality, especially an API that needs to be supported
+- Adds complexity that only helps a niche use case
+- Adds user-space functionality that does not need to be maintained in Spark, but could be hosted 
+externally and indexed by http://spark-packages.org 
+- Changes a public API or semantics (rarely allowed)
+- Adds large dependencies
+- Changes versions of existing dependencies
+- Adds a large amount of code
+- Makes lots of modifications in one "big bang" change
+
+<h2>Contributing Code Changes</h2>
+
+Please review the preceding section before proposing a code change. This section documents how to do so.
+
+**When you contribute code, you affirm that the contribution is your original work and that you 
+license the work to the project under the project's open source license. Whether or not you state 
+this explicitly, by submitting any copyrighted material via pull request, email, or other means 
+you agree to license the material under the project's open source license and warrant that you 
+have the legal authority to do so.**
+
+<h3>JIRA</h3>
+
+Generally, Spark uses JIRA to track logical issues, including bugs and improvements, and uses 
+Github pull requests to manage the review and merge of specific code changes. That is, JIRAs are 
+used to describe _what_ should be fixed or changed, and high-level approaches, and pull requests 
+describe _how_ to implement that change in the project's source code. For example, major design 
+decisions are discussed in JIRA.
+
+1. Find the existing Spark JIRA that the change pertains to.
+    1. Do not create a new JIRA if creating a change to address an existing issue in JIRA; add to 
+    the existing discussion and work instead
+    1. Look for existing pull requests that are linked from the JIRA, to understand if someone is 
+    already working on the JIRA
+1. If the change is new, then it usually needs a new JIRA. However, trivial changes, where the
+what should change is virtually the same as the how it should change do not require a JIRA. 
+Example: `Fix typos in Foo scaladoc`
+1. If required, create a new JIRA:
+    1. Provide a descriptive Title. "Update web UI" or "Problem in scheduler" is not sufficient.
+    "Kafka Streaming support fails to handle empty queue in YARN cluster mode" is good.
+    1. Write a detailed Description. For bug reports, this should ideally include a short 
+    reproduction of the problem. For new features, it may include a design document.
+    1. Set required fields:
+        1. **Issue Type**. Generally, Bug, Improvement and New Feature are the only types used in Spark.
+        1. **Priority**. Set to Major or below; higher priorities are generally reserved for 
+        committers to set. JIRA tends to unfortunately conflate "size" and "importance" in its 
+        Priority field values. Their meaning is roughly:
+             1. Blocker: pointless to release without this change as the release would be unusable 
+             to a large minority of users
+             1. Critical: a large minority of users are missing important functionality without 
+             this, and/or a workaround is difficult
+             1. Major: a small minority of users are missing important functionality without this, 
+             and there is a workaround
+             1. Minor: a niche use case is missing some support, but it does not affect usage or 
+             is easily worked around
+             1. Trivial: a nice-to-have change but unlikely to be any problem in practice otherwise 
+        1. **Component**
+        1. **Affects Version**. For Bugs, assign at least one version that is known to exhibit the 
+        problem or need the change
+    1. Do not set the following fields:
+        1. **Fix Version**. This is assigned by committers only when resolved.
+        1. **Target Version**. This is assigned by committers to indicate a PR has been accepted for 
+        possible fix by the target version.
+    1. Do not include a patch file; pull requests are used to propose the actual change.
+1. If the change is a large change, consider inviting discussion on the issue at 
+`dev@spark.apache.org` first before proceeding to implement the change.
+
+<h3>Pull Request</h3>
+
+1. <a href="https://help.github.com/articles/fork-a-repo/">Fork</a> the Github repository at 
+http://github.com/apache/spark if you haven't already
+1. Clone your fork, create a new branch, push commits to the branch.
+1. Consider whether documentation or tests need to be added or updated as part of the change, 
+and add them as needed.
+1. Run all tests with ./dev/run-tests to verify that the code still compiles, passes tests, and 
+passes style checks. If style checks fail, review the Code Style Guide below.
+1. <a href="https://help.github.com/articles/using-pull-requests/">Open a pull request</a> against 
+the master branch of apache/spark. (Only in special cases would the PR be opened against other branches.)
+     1. The PR title should be of the form `[SPARK-xxxx][COMPONENT] Title`, where `SPARK-xxxx` is 
+     the relevant JIRA number, `COMPONENT `is one of the PR categories shown at 
+     https://spark-prs.appspot.com/ and Title may be the JIRA's title or a more specific title 
+     describing the PR itself.
+     1. If the pull request is still a work in progress, and so is not ready to be merged, 
+     but needs to be pushed to Github to facilitate review, then add `[WIP]` after the component.
+     1. Consider identifying committers or other contributors who have worked on the code being 
+     changed. Find the file(s) in Github and click "Blame" to see a line-by-line annotation of 
+     who changed the code last. You can add `@username` in the PR description to ping them 
+     immediately.
+     1. Please state that the contribution is your original work and that you license the work 
+     to the project under the project's open source license.
+1. The related JIRA, if any, will be marked as "In Progress" and your pull request will 
+automatically be linked to it. There is no need to be the Assignee of the JIRA to work on it, 
+though you are welcome to comment that you have begun work.
+1. The Jenkins automatic pull request builder will test your changes
+     1. If it is your first contribution, Jenkins will wait for confirmation before building 
+     your code and post "Can one of the admins verify this patch?"
+     1. A committer can authorize testing with a comment like "ok to test"
+     1. A committer can automatically allow future pull requests from a contributor to be 
+     tested with a comment like "Jenkins, add to whitelist"
+1. After about 2 hours, Jenkins will post the results of the test to the pull request, along 
+with a link to the full results on Jenkins.
+1. Watch for the results, and investigate and fix failures promptly
+     1. Fixes can simply be pushed to the same branch from which you opened your pull request
+     1. Jenkins will automatically re-test when new commits are pushed
+     1. If the tests failed for reasons unrelated to the change (e.g. Jenkins outage), then a 
+     committer can request a re-test with "Jenkins, retest this please". 
+     Ask if you need a test restarted.
+
+<h3>The Review Process</h3>
+
+- Other reviewers, including committers, may comment on the changes and suggest modifications. 
+Changes can be added by simply pushing more commits to the same branch.
+- Lively, polite, rapid technical debate is encouraged from everyone in the community. The outcome 
+may be a rejection of the entire change.
+- Reviewers can indicate that a change looks suitable for merging with a comment such as: "I think 
+this patch looks good". Spark uses the LGTM convention for indicating the strongest level of 
+technical sign-off on a patch: simply comment with the word "LGTM". It specifically means: "I've 
+looked at this thoroughly and take as much ownership as if I wrote the patch myself". If you 
+comment LGTM you will be expected to help with bugs or follow-up issues on the patch. Consistent, 
+judicious use of LGTMs is a great way to gain credibility as a reviewer with the broader community.
+- Sometimes, other changes will be merged which conflict with your pull request's changes. The 
+PR can't be merged until the conflict is resolved. This can be resolved with `git fetch origin` 
+followed by `git merge origin/master` and resolving the conflicts by hand, then pushing the result 
+to your branch.
+- Try to be responsive to the discussion rather than let days pass between replies
+
+<h3>Closing Your Pull Request / JIRA</h3>
+
+- If a change is accepted, it will be merged and the pull request will automatically be closed, 
+along with the associated JIRA if any
+  - Note that in the rare case you are asked to open a pull request against a branch besides 
+  `master`, that you will actually have to close the pull request manually
+  - The JIRA will be Assigned to the primary contributor to the change as a way of giving credit. 
+  If the JIRA isn't closed and/or Assigned promptly, comment on the JIRA.
+- If your pull request is ultimately rejected, please close it promptly
+  - ... because committers can't close PRs directly
+  - Pull requests will be automatically closed by an automated process at Apache after about a 
+  week if a committer has made a comment like "mind closing this PR?" This means that the 
+  committer is specifically requesting that it be closed.
+- If a pull request has gotten little or no attention, consider improving the description or 
+the change itself and ping likely reviewers again after a few days. Consider proposing a 
+change that's easier to include, like a smaller and/or less invasive change.
+- If it has been reviewed but not taken up after weeks, after soliciting review from the 
+most relevant reviewers, or, has met with neutral reactions, the outcome may be considered a 
+"soft no". It is helpful to withdraw and close the PR in this case.
+- If a pull request is closed because it is deemed not the right approach to resolve a JIRA, 
+then leave the JIRA open. However if the review makes it clear that the issue identified in 
+the JIRA is not going to be resolved by any pull request (not a problem, won't fix) then also 
+resolve the JIRA.
+
+<a name="code-style-guide"></a>
+<h2>Code Style Guide</h2>
+
+Please follow the style of the existing codebase.
+
+- For Python code, Apache Spark follows 
+<a href="http://legacy.python.org/dev/peps/pep-0008/">PEP 8</a> with one exception: 
+lines can be up to 100 characters in length, not 79.
+- For Java code, Apache Spark follows 
+<a href="http://www.oracle.com/technetwork/java/codeconvtoc-136057.html">Oracle's Java code conventions</a>. 
+Many Scala guidelines below also apply to Java.
+- For Scala code, Apache Spark follows the official 
+<a href="http://docs.scala-lang.org/style/">Scala style guide</a>, but with the following changes, below.
+
+<h3>Line Length</h3>
+
+Limit lines to 100 characters. The only exceptions are import statements (although even for 
+those, try to keep them under 100 chars).
+
+<h3>Indentation</h3>
+
+Use 2-space indentation in general. For function declarations, use 4 space indentation for its 
+parameters when they don't fit in a single line. For example:
+
+```scala
+// Correct:
+if (true) {
+  println("Wow!")
+}
+ 
+// Wrong:
+if (true) {
+    println("Wow!")
+}
+ 
+// Correct:
+def newAPIHadoopFile[K, V, F <: NewInputFormat[K, V]](
+    path: String,
+    fClass: Class[F],
+    kClass: Class[K],
+    vClass: Class[V],
+    conf: Configuration = hadoopConfiguration): RDD[(K, V)] = {
+  // function body
+}
+ 
+// Wrong
+def newAPIHadoopFile[K, V, F <: NewInputFormat[K, V]](
+  path: String,
+  fClass: Class[F],
+  kClass: Class[K],
+  vClass: Class[V],
+  conf: Configuration = hadoopConfiguration): RDD[(K, V)] = {
+  // function body
+}
+```
+
+<h3>Code documentation style</h3>
+
+For Scala doc / Java doc comment before classes, objects and methods, use Java docs style 
+instead of Scala docs style.
+
+```scala
+/** This is a correct one-liner, short description. */
+ 
+/**
+ * This is correct multi-line JavaDoc comment. And
+ * this is my second line, and if I keep typing, this would be
+ * my third line.
+ */
+ 
+/** In Spark, we don't use the ScalaDoc style so this
+  * is not correct.
+  */
+```
+ 
+For inline comment with the code, use `//` and not `/*  .. */`.
+
+```scala
+// This is a short, single line comment
+ 
+// This is a multi line comment.
+// Bla bla bla
+ 
+/*
+ * Do not use this style for multi line comments. This
+ * style of comment interferes with commenting out
+ * blocks of code, and also makes code comments harder
+ * to distinguish from Scala doc / Java doc comments.
+ */
+ 
+/**
+ * Do not use scala doc style for inline comments.
+ */
+```
+
+<h3>Imports</h3>
+
+Always import packages using absolute paths (e.g. `scala.util.Random`) instead of relative ones 
+(e.g. `util.Random`). In addition, sort imports in the following order 
+(use alphabetical order within each group):
+- `java.*` and `javax.*`
+- `scala.*`
+- Third-party libraries (`org.*`, `com.*`, etc)
+- Project classes (`org.apache.spark.*`)
+
+The <a href="https://plugins.jetbrains.com/plugin/7350">IntelliJ import organizer plugin</a> 
+can organize imports for you. Use this configuration for the plugin (configured under 
+Preferences / Editor / Code Style / Scala Imports Organizer):
+
+```scala
+import java.*
+import javax.*
+ 
+import scala.*
+ 
+import *
+ 
+import org.apache.spark.*
+```
+
+<h3>Infix Methods</h3>
+
+Don't use infix notation for methods that aren't operators. For example, instead of 
+`list map func`, use `list.map(func)`, or instead of `string contains "foo"`, use 
+`string.contains("foo")`. This is to improve familiarity to developers coming from other languages.
+
+<h3>Curly Braces</h3>
+
+Put curly braces even around one-line `if`, `else` or loop statements. The only exception is if 
+you are using `if/else` as an one-line ternary operator.
+
+```scala
+// Correct:
+if (true) {
+  println("Wow!")
+}
+ 
+// Correct:
+if (true) statement1 else statement2
+ 
+// Wrong:
+if (true)
+  println("Wow!")
+Return Types
+Always specify the return types of methods where possible. If a method has no return type, specify Unit instead in accordance with the Scala style guide. Return types for variables are not required unless the definition involves huge code blocks with potentially ambiguous return values.
+// Correct:
+def getSize(partitionId: String): Long = { ... }
+def compute(partitionId: String): Unit = { ... }
+ 
+// Wrong:
+def getSize(partitionId: String) = { ... }
+def compute(partitionId: String) = { ... }
+def compute(partitionId: String) { ... }
+ 
+// Correct:
+val name = "black-sheep"
+val path: Option[String] =
+  try {
+    Option(names)
+      .map { ns => ns.split(",") }
+      .flatMap { ns => ns.filter(_.nonEmpty).headOption }
+      .map { n => "prefix" + n + "suffix" }
+      .flatMap { n => if (n.hashCode % 3 == 0) Some(n + n) else None }
+  } catch {
+    case e: SomeSpecialException =>
+      computePath(names)
+  }
+ ```
+
+<h3>If in Doubt</h3>
+
+If you're not sure about the right style for something, try to follow the style of the existing 
+codebase. Look at whether there are other examples in the code that use your feature. Feel free 
+to ask on the `dev@spark.apache.org` list as well.

--- a/contributing.md
+++ b/contributing.md
@@ -42,8 +42,9 @@ feedback on any performance or correctness issues found in the newer release.
 
 <h2>Contributing by Reviewing Changes</h2>
 
-Changes to Spark source code are proposed, reviewed and committed via Github (described later) at 
-http://github.com/apache/spark/pulls. Anyone can view and comment on active changes here. 
+Changes to Spark source code are proposed, reviewed and committed via 
+<a href="http://github.com/apache/spark/pulls">Github pull requests</a> (described later). 
+Anyone can view and comment on active changes here. 
 Reviewing others' changes is a good way to learn how the change process works and gain exposure 
 to activity in various parts of the code. You can help by reviewing the changes and asking 
 questions or pointing out issues -- as simple as typos or small issues of style.
@@ -52,15 +53,16 @@ See also https://spark-prs.appspot.com/ for a convenient way to view and filter 
 <h2>Contributing Documentation Changes</h2>
 
 To propose a change to _release_ documentation (that is, docs that appear under 
-https://spark.apache.org/docs/), edit the Markdown source files in Spark's 
+<a href="https://spark.apache.org/docs/">https://spark.apache.org/docs/</a>), 
+edit the Markdown source files in Spark's 
 <a href="https://github.com/apache/spark/tree/master/docs">`docs/`</a> directory, 
 whose `README` file shows how to build the documentation locally to test your changes.
 The process to propose a doc change is otherwise the same as the process for proposing code 
 changes below. 
 
 To propose a change to the rest of the documentation (that is, docs that do _not_ appear under 
-https://spark.apache.org/docs/), similarly, edit the Markdown in the https://github.com/apache/spark-website
-repository and open a pull request.
+<a href="https://spark.apache.org/docs/">https://spark.apache.org/docs/</a>), similarly, edit the Markdown in the 
+<a href="https://github.com/apache/spark-website">spark-website repository</a> and open a pull request.
 
 <h2>Contributing User Libraries to Spark</h2>
 
@@ -72,7 +74,7 @@ learning algorithms can happily exist outside of MLlib.
 
 To that end, large and independent new functionality is often rejected for inclusion in Spark 
 itself, but, can and should be hosted as a separate project and repository, and included in 
-the http://spark-packages.org/ collection.
+the <a href="http://spark-packages.org/">spark-packages.org</a> collection.
 
 <h2>Contributing Bug Reports</h2>
 
@@ -87,7 +89,8 @@ first. Unreproducible bugs, or simple error reports, may be closed.
 
 It is possible to propose new features as well. These are generally not helpful unless 
 accompanied by detail, such as a design document and/or code change. Large new contributions 
-should consider http://spark-packages.org first (see above), or be discussed on the mailing 
+should consider <a href="http://spark-packages.org/">spark-packages.org</a> first (see above), 
+or be discussed on the mailing 
 list first. Feature requests may be rejected, or closed after a long period of inactivity.
 
 <h2>Contributing to JIRA Maintenance</h2>
@@ -130,7 +133,7 @@ Review can take hours or days of committer time. Everyone benefits if contributo
 changes that are useful, clear, easy to evaluate, and already pass basic checks.
 
 Sometimes, a contributor will already have a particular new change or bug in mind. If seeking 
-ideas, consult the list of starter tasks in JIRA, or ask the user@spark.apache.org mailing list.
+ideas, consult the list of starter tasks in JIRA, or ask the `user@spark.apache.org` mailing list.
 
 Before proceeding, contributors should evaluate if the proposed change is likely to be relevant, 
 new and actionable:
@@ -141,10 +144,12 @@ lists first, rather than consider filing a JIRA or proposing a change. When in d
 `user@spark.apache.org` first about the possible change
 - Search the `user@spark.apache.org` and `dev@spark.apache.org` mailing list 
 <a href="{{site.baseurl}}/community.html#mailing-lists">archives</a> for 
-related discussions. Use http://search-hadoop.com/?q=&fc_project=Spark or similar search tools. 
+related discussions. Use <a href="http://search-hadoop.com/?q=&fc_project=Spark">search-hadoop.com</a> 
+or similar search tools. 
 Often, the problem has been discussed before, with a resolution that doesn't require a code 
 change, or recording what kinds of changes will not be accepted as a resolution.
-- Search JIRA for existing issues: https://issues.apache.org/jira/browse/SPARK 
+- Search JIRA for existing issues: 
+<a href="https://issues.apache.org/jira/browse/SPARK">https://issues.apache.org/jira/browse/SPARK</a> 
 - Type `spark [search terms]` at the top right search box. If a logically similar issue already 
 exists, then contribute to the discussion on the existing JIRA and pull request first, instead of 
 creating a new one.
@@ -189,7 +194,7 @@ rather than receive iterations of review.
 - Introduces complex new functionality, especially an API that needs to be supported
 - Adds complexity that only helps a niche use case
 - Adds user-space functionality that does not need to be maintained in Spark, but could be hosted 
-externally and indexed by http://spark-packages.org 
+externally and indexed by <a href="http://spark-packages.org/">spark-packages.org</a> 
 - Changes a public API or semantics (rarely allowed)
 - Adds large dependencies
 - Changes versions of existing dependencies
@@ -255,18 +260,18 @@ Example: `Fix typos in Foo scaladoc`
 <h3>Pull Request</h3>
 
 1. <a href="https://help.github.com/articles/fork-a-repo/">Fork</a> the Github repository at 
-http://github.com/apache/spark if you haven't already
+<a href="http://github.com/apache/spark">http://github.com/apache/spark</a> if you haven't already
 1. Clone your fork, create a new branch, push commits to the branch.
 1. Consider whether documentation or tests need to be added or updated as part of the change, 
 and add them as needed.
-1. Run all tests with ./dev/run-tests to verify that the code still compiles, passes tests, and 
+1. Run all tests with `./dev/run-tests` to verify that the code still compiles, passes tests, and 
 passes style checks. If style checks fail, review the Code Style Guide below.
 1. <a href="https://help.github.com/articles/using-pull-requests/">Open a pull request</a> against 
-the master branch of apache/spark. (Only in special cases would the PR be opened against other branches.)
+the `master` branch of `apache/spark`. (Only in special cases would the PR be opened against other branches.)
      1. The PR title should be of the form `[SPARK-xxxx][COMPONENT] Title`, where `SPARK-xxxx` is 
      the relevant JIRA number, `COMPONENT `is one of the PR categories shown at 
-     https://spark-prs.appspot.com/ and Title may be the JIRA's title or a more specific title 
-     describing the PR itself.
+     <a href="https://spark-prs.appspot.com/">spark-prs.appspot.com</a> and 
+     Title may be the JIRA's title or a more specific title describing the PR itself.
      1. If the pull request is still a work in progress, and so is not ready to be merged, 
      but needs to be pushed to Github to facilitate review, then add `[WIP]` after the component.
      1. Consider identifying committers or other contributors who have worked on the code being 

--- a/contributing.md
+++ b/contributing.md
@@ -478,8 +478,15 @@ if (true) statement1 else statement2
 // Wrong:
 if (true)
   println("Wow!")
-Return Types
-Always specify the return types of methods where possible. If a method has no return type, specify Unit instead in accordance with the Scala style guide. Return types for variables are not required unless the definition involves huge code blocks with potentially ambiguous return values.
+```
+
+<h3>Return Types</h3>
+
+Always specify the return types of methods where possible. If a method has no return type, specify 
+`Unit` instead in accordance with the Scala style guide. Return types for variables are not 
+required unless the definition involves huge code blocks with potentially ambiguous return values.
+
+```scala
 // Correct:
 def getSize(partitionId: String): Long = { ... }
 def compute(partitionId: String): Unit = { ... }
@@ -502,7 +509,7 @@ val path: Option[String] =
     case e: SomeSpecialException =>
       computePath(names)
   }
- ```
+```
 
 <h3>If in Doubt</h3>
 

--- a/documentation.md
+++ b/documentation.md
@@ -178,7 +178,7 @@ Slides, videos and EC2-based exercises from each of these are available online:
 
 <ul><li>
 The <a href="https://cwiki.apache.org/confluence/display/SPARK/Wiki+Homepage">Spark wiki</a> contains
-information for developers, such as architecture documents and how to <a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">contribute</a> to Spark.
+information for developers, such as architecture documents and how to <a href="{{site.baseurl}}/contributing.html">">contribute</a> to Spark.
 </li></ul>
 
 <h3>Research Papers</h3>

--- a/faq.md
+++ b/faq.md
@@ -15,7 +15,7 @@ Spark is a fast and general processing engine compatible with Hadoop data. It ca
 
 <p class="question">Who is using Spark in production?</p>
 
-<p class="answer">As of 2016, surveys show that more than 1000 organizations are using Spark in production. Some of them are listed on the <a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By page</a> and at the <a href="http://spark-summit.org">Spark Summit</a>.</p>
+<p class="answer">As of 2016, surveys show that more than 1000 organizations are using Spark in production. Some of them are listed on the <a href="{{site.baseurl}}/powered-by.html">Powered By page</a> and at the <a href="http://spark-summit.org">Spark Summit</a>.</p>
 
 
 <p class="question">How large a cluster can Spark scale to?</p>

--- a/faq.md
+++ b/faq.md
@@ -67,7 +67,7 @@ Please also refer to our
 
 <p class="question">How can I contribute to Spark?</p>
 
-<p class="answer">See the <a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">Contributing to Spark wiki</a> for more information.</p>
+<p class="answer">See the <a href="{{site.baseurl}}/contributing.html">Contributing to Spark wiki</a> for more information.</p>
 
 <p class="question">Where can I get more help?</p>
 

--- a/graphx/index.md
+++ b/graphx/index.md
@@ -87,7 +87,7 @@ subproject: GraphX
     </p>
     <p>
       GraphX is in the alpha stage and welcomes contributions. If you'd like to submit a change to GraphX,
-      read <a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">how to
+      read <a href="{{site.baseurl}}/contributing.html">how to
       contribute to Spark</a> and send us a patch!
     </p>
   </div>

--- a/index.md
+++ b/index.md
@@ -162,8 +162,7 @@ navigation:
 
     <p>
       If you'd like to participate in Spark, or contribute to the libraries on top of it, learn
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">how to
-        contribute</a>.
+      <a href="{{site.baseurl}}/contributing.html">how to contribute</a>.
     </p>
   </div>
 

--- a/index.md
+++ b/index.md
@@ -156,7 +156,7 @@ navigation:
 
     <p>
       The project's
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">committers</a>
+      <a href="{{site.baseurl}}/committers.html">committers</a>
       come from 19 organizations.
     </p>
 

--- a/index.md
+++ b/index.md
@@ -130,9 +130,7 @@ navigation:
     <p>
       Spark is used at a wide range of organizations to process large datasets.
       You can find example use cases at the <a href="http://spark-summit.org/summit-2013/">Spark Summit</a>
-      conference, or on the
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a>
-      page.
+      conference, or on the <a href="{{site.baseurl}}/powered-by.html">Powered By</a> page.
     </p>
 
     <p>

--- a/mllib/index.md
+++ b/mllib/index.md
@@ -114,7 +114,7 @@ subproject: MLlib
     </p>
     <p>
       MLlib is still a rapidly growing project and welcomes contributions. If you'd like to submit an algorithm to MLlib,
-      read <a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">how to
+      read <a href="{{site.baseurl}}/contributing.html">how to
       contribute to Spark</a> and send us a patch!
     </p>
   </div>

--- a/news/_posts/2013-09-05-spark-user-survey-and-powered-by-page.md
+++ b/news/_posts/2013-09-05-spark-user-survey-and-powered-by-page.md
@@ -13,6 +13,6 @@ meta:
 ---
 As we continue developing Spark, we would love to get feedback from users and hear what you'd like us to work on next. We've decided that a good way to do that is a survey -- we hope to run this at regular intervals. If you have a few minutes to participate, <a href="https://docs.google.com/forms/d/1eMXp4GjcIXglxJe5vYYBzXKVm-6AiYt1KThJwhCjJiY/viewform">fill in the survey here</a>. Your time is greatly appreciated.
 
-In parallel, we are starting a <a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">"powered by" page</a> on the Apache Spark wiki for organizations that are using, or contributing to, Spark. Sign up if you'd like to support the project! This is a great way to let the world know you're using Spark, and can also be helpful to generate leads for recruiting. You can also add yourself when you fill the survey.
+In parallel, we are starting a <a href="{{site.baseurl}}/powered-by.html">"powered by" page</a> on the Apache Spark wiki for organizations that are using, or contributing to, Spark. Sign up if you'd like to support the project! This is a great way to let the world know you're using Spark, and can also be helpful to generate leads for recruiting. You can also add yourself when you fill the survey.
 
 Thanks for taking the time to give feedback.

--- a/powered-by.md
+++ b/powered-by.md
@@ -11,9 +11,9 @@ navigation:
 
 Organizations creating products and projects for use with Apache Spark, along with associated 
 marketing materials, should take care to respect the trademark in "Apache Spark" and its logo. 
-Please refer to http://www.apache.org/foundation/marks/ and 
-http://www.apache.org/foundation/marks/faq/ for comprehensive and authoritative guidance on 
-proper usage of ASF trademarks.
+Please refer to <a href="http://www.apache.org/foundation/marks/">ASF Trademarks Guidance</a> and 
+associated <a href="http://www.apache.org/foundation/marks/faq/">FAQ</a> 
+for comprehensive and authoritative guidance on proper usage of ASF trademarks.
 
 Names that do not include "Spark" at all have no potential trademark issue with the Spark project. 
 This is recommended.

--- a/powered-by.md
+++ b/powered-by.md
@@ -1,0 +1,239 @@
+---
+layout: global
+title: Powered By Spark
+type: "page singular"
+navigation:
+  weight: 5
+  show: true
+---
+
+<h2>Project and Product names using "Spark"</h2>
+
+Organizations creating products and projects for use with Apache Spark, along with associated 
+marketing materials, should take care to respect the trademark in "Apache Spark" and its logo. 
+Please refer to http://www.apache.org/foundation/marks/ and 
+http://www.apache.org/foundation/marks/faq/ for comprehensive and authoritative guidance on 
+proper usage of ASF trademarks.
+
+Names that do not include "Spark" at all have no potential trademark issue with the Spark project. 
+This is recommended.
+
+Names like "Spark BigCoProduct" are not OK, as are names including "Spark" in general. 
+The above links, however, describe some exceptions, like for names such as "BigCoProduct, 
+powered by Apache Spark" or "BigCoProduct for Apache Spark".
+
+It is common practice to create software identifiers (Maven coordinates, module names, etc.) 
+like "spark-foo". These are permitted. Nominative use of trademarks in descriptions is also 
+always allowed, as in "BigCoProduct is a widget for Apache Spark".
+
+<h2>Companies and Organizations</h2>
+
+To add yourself to the list, please email `dev@spark.apache.org` with your organization name, URL, 
+a list of which Spark components you are using, and a short description of your use case.
+
+- <a href="http://amplab.cs.berkeley.edu">UC Berkeley AMPLab</a> - Big data research lab that 
+initially launched Spark
+  - We're building a variety of open source projects on Spark
+  - We have both graduate students and a team of professional software engineers working on the stack
+- <a href="http://4quant.com">4Quant</a>
+- <a href="http://www.actnowib.com">Act Now</a>
+  - Spark powers NOW APPS, a big data, real-time, predictive analytics platform. We use Spark SQL, 
+  MLlib and GraphX components for both batch ETL and analytics applied to telecommunication data, 
+  providing faster and more meaningful insights and actionable data to the operators.
+- <a href="http://adatao.com">Adatao, Inc.</a> - Data Intelligence for All
+  - Visual, Real-Time, Predictive Analytics on Spark+Hadoop, with built-in support for R, Python, 
+  SQL, and Natural Language.
+  - Team of ex-Googlers and Yahoos with large-scale infrastructure experience 
+  (including both flavors of MapReduce at Google and Yahoo) and PhD's in ML/Data Mining
+  - Determined that Spark, among the many alternatives, answered the right problem statements with 
+  the right design
+- <a href="http://www.agilelab.it">Agile Lab</a>
+  - enhancing big data. 360 customer view, log analysis, BI
+- <a href="http://www.taobao.com/">Alibaba Taobao</a>
+  - We built one of the world's first Spark on YARN production clusters.
+  - See our blog posts (in Chinese) about Spark at Taobao: 
+  <a href="http://rdc.taobao.org/?tag=spark">http://rdc.taobao.org/?tag=spark</a>
+- <a href="http://alpinenow.com/">Alpine Data Labs</a>
+- <a href="http://amazon.com">Amazon</a>
+- <a href="http://www.amrita.edu/cyber/">Amrita Center for Cyber Security Systems and Networks</a>
+- <a href="http://www.art.com/">Art.com</a>
+  - Trending analytics and personalization
+- <a href="http://www.asiainfo.com">AsiaInfo</a>
+  - We are using Spark Core, Streaming, MLlib and Graphx. We leverage Spark and Hadoop ecosystem 
+  to build cost effective data center solution for our customer in telco industry as well as 
+  other industrial sectors.
+- <a href="http://www.atigeo.com">Atigeo</a> – integrated Spark in xPatterns, our big data 
+analytics platform, as a replacement for Hadoop MR
+- <a href="https://atp.io">atp</a>
+  - Predictive models and learning algorithms to improve the relevance of programmatic marketing.
+  - Components used: Spark SQL, MLLib.
+- <a href="http://www.autodesk.com">Autodesk</a>
+- <a href="http://www.baidu.com">Baidu</a>
+- <a href="http://www.bakdata.com/">Bakdata</a> – using Spark (and Shark) to perform interactive 
+exploration of large datasets
+- <a href="http://http//www.bigindustries.be/">Big Industries</a> - using Spark Streaming: The 
+Big Content Platform is a business-to-business content asset management service providing a 
+searchable, aggregated source of live news feeds, public domain media and archives of content.
+- <a href="http://www.bizo.com">Bizo</a>
+  - Check out our talk on <a href="http://www.meetup.com/spark-users/events/139804022/">Spark at Bizo</a> 
+  at Spark user meetup
+- <a href="http://www.celtra.com">Celtra</a>
+- <a href="http://www.clearstorydata.com">ClearStory Data</a> – ClearStory's platform and 
+integrated Data Intelligence application leverages Spark to speed analysis across internal 
+and external data sources, driving holistic and actionable insights.
+- <a href="https://www.concur.com">Concur</a>
+  - Spark SQL, MLlib
+  - Using Spark for travel and expenses analytics and personalization<
+- <a href="http://www.contentsquare.com">Content Square</a>
+  - We use Spark to regularly read raw data, convert them into Parquet, and process them to 
+  create advanced analytics dashboards: aggregation, sampling, statistics computations, 
+  anomaly detection, machine learning.
+- <a href="http://www.conviva.com">Conviva</a> – Experience Live
+  - See our talk at <a href="http://ampcamp.berkeley.edu/3/">AmpCamp</a> on how we are 
+  <a href="http://www.youtube.com/watch?feature=player_detailpage&v=YaayAatdRNs">using Spark to 
+  provide real time video optimization</a>
+- <a href="https://www.creditkarma.com/">Credit Karma</a>
+  - We create personalized experiences using Spark.
+- <a href="http://databricks.com">Databricks</a>
+  - Formed by the creators of Apache Spark and Shark, Databricks is working to greatly expand these 
+  open source projects and transform big data analysis in the process. We're deeply committed to 
+  keeping all work on these systems open source.
+  - We provided a hosted service to run Spark, 
+  <a href="http://www.databricks.com/cloud">Databricks Cloud</a>, and partner to 
+  <a href="http://databricks.com/support/">support Apache Spark</a> with other Hadoop and big 
+  data companies.
+- <a href="http://dianping.com">Dianping.com</a>
+- <a href="http://www.digby.com">Digby</a>
+- <a href="http://www.drawbrid.ge/">Drawbridge</a>
+- <a href="http://www.ebay.com/">eBay Inc.</a>
+  - Using Spark core for log transaction aggregation and analytics
+- <a href="http://labs.elsevier.com">Elsevier Labs</a>
+  - Use Case: Building Machine Reading Pipeline, Knowledge Graphs, Content as a Service, Content 
+  and Event Analytics, Content/Event based Predictive Models and Big Data Processing.
+  - We use Scala and Python over Databricks Notebooks for most of our work.
+- <a href="http://www.eurecom.fr/en">EURECOM</a>
+- <a href="http://www.exabeam.com">Exabeam</a>
+- <a href="http://www.faimdata.com/">Faimdata</a>
+  - Build eCommerce and data intelligence solutions to the retail industry on top of 
+  Spark/Shark/Spark Streaming
+- <a href="http://falkonry.com">Falkonry</a>
+- <a href="http://www.flytxt.com">Flytxt</a>
+  - Big Data analytics for subscriber profiling and personalization in telecommunications domain. 
+  We are using Spark Core and MLlib.
+- <a href="http://www.jeremyfreeman.net">Freeman Lab at HHMI</a>
+  - We are using Spark for analyzing and visualizing patterns in large-scale recordings of brain 
+  activity in real time
+- <a href="http://www.fundacionctic.org">Fundacion CTIC</a>
+- <a href="http://graphflow.com">GraphFlow, Inc.</a>
+- <a href="http://www.groupon.com/app/subscriptions/new_zip?division_p=san-francisco">Groupon</a>
+- <a href="http://www.guavus.com/">Guavus</a>
+  - Stream processing of network machine data
+- <a href="http://www.hitachi-solutions.com/">Hitachi Solutions</a>
+- <a href="http://hivedata.com/">The Hive</a>
+- <a href="http://www.research.ibm.com/labs/almaden/index.shtml">IBM Almaden</a>
+- <a href="http://www.infoobjects.com">InfoObjects</a>
+  - Award winning Big Data consulting company with focus on Spark and Hadoop
+- <a href="http://en.inspur.com">Inspur</a>
+- <a href="http://www.sehir.edu.tr/en/">Istanbul Sehir University</a>
+- <a href="http://www.kenshoo.com/">Kenshoo</a>
+  - Digital marketing solutions and predictive media optimization
+- <a href="http://www.kelkoo.co.uk">Kelkoo</a>
+  - Using Spark Core, SQL, and Streaming. Product recommendations, BI and analytics, 
+  real-time malicious activity filtering, and data mining.
+- <a href="http://www.knoldus.com">Knoldus Software LLC</a>
+- <a href="http://eng.localytics.com">Localytics</a>
+  - Batch, real-time, and predictive analytics driving our mobile app analytics and marketing 
+  automation product.
+  - Components used: Spark, Spark Streaming, MLLib.
+- <a href="http://magine.com">Magine TV</a>
+- <a href="http://mediacrossing.com">MediaCrossing</a> – Digital Media Trading Experts in the 
+New York and Boston areas
+  - We are using Spark as a drop-in replacement for Hadoop Map/Reduce to get the right answer 
+  to our queries in a much shorter amount of time.
+- <a href="http://www.myfitnesspal.com/">MyFitnessPal</a>
+  - Using Spark to clean-up user entered food data using both explicit and implicit user signals 
+  with the final goal of identifying high-quality food items.
+  - Using Spark to build different recommendation systems for recipes and foods.
+- <a href="http://deepspace.jpl.nasa.gov/">NASA JPL - Deep Space Network</a>
+- <a href="http://www.163.com/">Netease</a>
+- <a href="http://www.nflabs.com">NFLabs</a>
+- <a href="http://nsn.com">Nokia Solutions and Networks</a>
+- <a href="http://www.nttdata.com/global/en/">NTT DATA</a>
+- <a href="http://www.nubetech.co">Nube Technologies</a>
+  - Nube provides solutions for data curation at scale helping customer targeting, accurate 
+  inventory and efficient analysis.
+- <a href="http://ooyala.com">Ooyala, Inc.</a> – Powering personalized video experiences 
+across all screens
+  - See our blog post on how we use 
+  <a href="http://engineering.ooyala.com/blog/fast-spark-queries-memory-datasets">Spark for 
+  Fast Queries</a>
+  - See our presentation on 
+  <a href="http://www.slideshare.net/EvanChan2/cassandra2013-spark-talk-final">Cassandra, Spark, 
+  and Shark</a>
+- <a href="http://www.opentable.com/">Opentable</a>
+  - Using Apache Spark for log processing and ETL. The data obtained feeds the recommender 
+  system powered by Spark MLLIB Matrix Factorization. We are evaluating the use of Spark 
+  Streaming for real-time analytics.
+- <a href="http://pantera.io">PanTera</a>
+  - PanTera is a tool for exploring large datasets. It uses Spark to create XY and geographic 
+  scatterplots from millions to billions of datapoints.
+  - Components we are using: Spark Core (Scala API), Spark SQL, and GraphX
+- <a href="http://www.peerialism.com">Peerialism</a>
+- <a href="http://www.planbmedia.com">PlanBMedia</a>
+- <a href="http://prediction.io/">PredicitionIo</a> - PredictionIO currently offers two engine 
+templates for Apache Spark MLlib for recommendation (MLlib ALS) and classification (MLlib Naive 
+Bayes). With these templates, you can create a custom predictive engine for production deployment 
+efficiently.
+- <a href="http://premise.com">Premise</a>
+- <a href="http://www.quantifind.com">Quantifind</a>
+- <a href="http://radius.com">Radius Intelligence</a>
+  - Using Scala, Spark and MLLib for Radius Marketing and Sales intelligence platform including 
+  data aggregation, data processing, data clustering, data analysis and predictive modeling of all 
+  US businesses.
+- <a href="http://www.realimpactanalytics.com/">Real Impact Analytics</a>
+  - Building large scale analytics platforms for telecoms operators
+- <a href="http://rocketfuel.com/">RocketFuel</a>
+- <a href="http://www.rondhuit.com/">RONDHUIT</a>
+  - Machine Learning with Apache Mahout and Spark 
+  <a href="http://www.rondhuit.com/services/training/mahout-ML.html">http://www.rondhuit.com/services/training/mahout-ML.html</a>
+- <a href="http://www.sailthru.com/">Sailthru</a>
+  - Uses Spark to build predictive models and recommendation systems for marketing automation 
+  and personalization.
+- <a href="http://www.sisa.samsung.com/">Samsung Research America</a>
+- <a href="http://www.shopify.com/">Shopify</a>
+- <a href="http://www.simba.com/">Simba Technologies</a>
+  - BI/reporting/ETL for Spark and beyond
+- <a href="http://www.sinnia.com">Sinnia</a>
+- <a href="http://www.sktelecom.com/en/main/index.do">SK Telecom</a>
+  - SK Telecom analyses mobile usage patterns of customer with Spark and Shark.
+- <a href="http://socialmetrix.com/">Socialmetrix</a>
+- <a href="http://www.sohu.com">Sohu</a>
+- <a href="http://www.stratio.com/">Stratio</a>
+  - Offers an open-source Big Data platform centered around Apache Spark.
+- <a href="https://www.taboola.com/">Taboola</a> – Powering 'Content You May Like' around the web
+- <a href="http://www.techbase.com.tr">Techbase</a>
+- <a href="http://tencent.com/">Tencent</a>
+- <a href="http://www.tetraconcepts.com/">Tetra Concepts</a>
+- <a href="http://www.trendmicro.com/us/index.html">TrendMicro</a>
+- <a href="http://engineering.tripadvisor.com/using-apache-spark-for-massively-parallel-nlp/">TripAdvisor</a>
+- <a href="http://truedash.io">truedash</a>
+  - Automatic pulling of all your data in to Spark for enterprise visualisation, predictive 
+  analytics and data exploration at a low cost.
+- <a href="http://www.trueffect.com">TruEffect Inc</a>
+- <a href="http://www.tuplejump.com">Tuplejump</a>
+  - Software development partners for Apache Spark and Cassandra projects
+- <a href="http://www.ucsc.edu">UC Santa Cruz</a>
+- <a href="http://missouri.edu/">University of Missouri Data Analytics and Discover Lab</a>
+- <a href="http://videoamp.com/">VideoAmp</a>
+  - Intelligent video ads for online and television viewing audiences.
+- <a href="http://www.vistarmedia.com">Vistar Media</a>
+  - Location technology company enabling brands to reach on-the-go consumers
+- <a href="http://www.yahoo.com">Yahoo!</a>
+- <a href="http://www.yandex.com">Yandex</a>
+  - Using Spark in 
+  <a href="http://www.searchenginejournal.com/yandex-islands-markup-issues-implementation/71891/">Yandex Islands</a>, 
+  to process islands identified from a search robor
+- <a href="http://www.zaloni.com/products/">Zaloni</a>
+  - Zaloni's data lake management platform (Bedrock) and self-service data preparation solution 
+  (Mica) leverage Spark for fast execution of transformations and data exploration.
+  

--- a/site/committers.html
+++ b/site/committers.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/committers.html
+++ b/site/committers.html
@@ -1,0 +1,517 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>
+     Committers | Apache Spark
+    
+  </title>
+
+  
+
+  
+
+  <!-- Bootstrap core CSS -->
+  <link href="/css/cerulean.min.css" rel="stylesheet">
+  <link href="/css/custom.css" rel="stylesheet">
+
+  <!-- Code highlighter CSS -->
+  <link href="/css/pygments-default.css" rel="stylesheet">
+
+  <script type="text/javascript">
+  <!-- Google Analytics initialization -->
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-32518208-2']);
+  _gaq.push(['_trackPageview']);
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+
+  <!-- Adds slight delay to links to allow async reporting -->
+  function trackOutboundLink(link, category, action) {
+    try {
+      _gaq.push(['_trackEvent', category , action]);
+    } catch(err){}
+
+    setTimeout(function() {
+      document.location.href = link.href;
+    }, 100);
+  }
+  </script>
+
+  <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+  <!--[if lt IE 9]>
+  <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+  <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+  <![endif]-->
+</head>
+
+<body>
+
+<script src="https://code.jquery.com/jquery.js"></script>
+<script src="https://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
+<script src="/js/lang-tabs.js"></script>
+<script src="/js/downloads.js"></script>
+
+<div class="container" style="max-width: 1200px;">
+
+<div class="masthead">
+  
+    <p class="lead">
+      <a href="/">
+      <img src="/images/spark-logo-trademark.png"
+        style="height:100px; width:auto; vertical-align: bottom; margin-top: 20px;"></a><span class="tagline">
+          Lightning-fast cluster computing
+      </span>
+    </p>
+  
+</div>
+
+<nav class="navbar navbar-default" role="navigation">
+  <!-- Brand and toggle get grouped for better mobile display -->
+  <div class="navbar-header">
+    <button type="button" class="navbar-toggle" data-toggle="collapse"
+            data-target="#navbar-collapse-1">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+  </div>
+
+  <!-- Collect the nav links, forms, and other content for toggling -->
+  <div class="collapse navbar-collapse" id="navbar-collapse-1">
+    <ul class="nav navbar-nav">
+      <li><a href="/downloads.html">Download</a></li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Libraries <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/sql/">SQL and DataFrames</a></li>
+          <li><a href="/streaming/">Spark Streaming</a></li>
+          <li><a href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a href="/graphx/">GraphX (graph)</a></li>
+          <li class="divider"></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+        </ul>
+      </li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Documentation <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/docs/latest/">Latest Release (Spark 2.0.2)</a></li>
+          <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
+        </ul>
+      </li>
+      <li><a href="/examples.html">Examples</a></li>
+      <li class="dropdown">
+        <a href="/community.html" class="dropdown-toggle" data-toggle="dropdown">
+          Community <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#events">Events and Meetups</a></li>
+          <li><a href="/community.html#history">Project History</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
+        </ul>
+      </li>
+      <li><a href="/faq.html">FAQ</a></li>
+    </ul>
+    <ul class="nav navbar-nav navbar-right">
+      <li class="dropdown">
+        <a href="http://www.apache.org/" class="dropdown-toggle" data-toggle="dropdown">
+          Apache Software Foundation <b class="caret"></b></a>
+        <ul class="dropdown-menu">
+          <li><a href="http://www.apache.org/">Apache Homepage</a></li>
+          <li><a href="http://www.apache.org/licenses/">License</a></li>
+          <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+          <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
+          <li><a href="http://www.apache.org/security/">Security</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <!-- /.navbar-collapse -->
+</nav>
+
+
+<div class="row">
+  <div class="col-md-3 col-md-push-9">
+    <div class="news" style="margin-bottom: 20px;">
+      <h5>Latest News</h5>
+      <ul class="list-unstyled">
+        
+          <li><a href="/news/spark-wins-cloudsort-100tb-benchmark.html">Spark wins CloudSort Benchmark as the most efficient engine</a>
+          <span class="small">(Nov 15, 2016)</span></li>
+        
+          <li><a href="/news/spark-2-0-2-released.html">Spark 2.0.2 released</a>
+          <span class="small">(Nov 14, 2016)</span></li>
+        
+          <li><a href="/news/spark-1-6-3-released.html">Spark 1.6.3 released</a>
+          <span class="small">(Nov 07, 2016)</span></li>
+        
+          <li><a href="/news/spark-2-0-1-released.html">Spark 2.0.1 released</a>
+          <span class="small">(Oct 03, 2016)</span></li>
+        
+      </ul>
+      <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
+    </div>
+    <div class="hidden-xs hidden-sm">
+      <a href="/downloads.html" class="btn btn-success btn-lg btn-block" style="margin-bottom: 30px;">
+        Download Spark
+      </a>
+      <p style="font-size: 16px; font-weight: 500; color: #555;">
+        Built-in Libraries:
+      </p>
+      <ul class="list-none">
+        <li><a href="/sql/">SQL and DataFrames</a></li>
+        <li><a href="/streaming/">Spark Streaming</a></li>
+        <li><a href="/mllib/">MLlib (machine learning)</a></li>
+        <li><a href="/graphx/">GraphX (graph)</a></li>
+      </ul>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+    </div>
+  </div>
+
+  <div class="col-md-9 col-md-pull-3">
+    <h2>Current Committers</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Organization</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Michael Armbrust</td>
+      <td>Databricks</td>
+    </tr>
+    <tr>
+      <td>Joseph Bradley</td>
+      <td>Databricks</td>
+    </tr>
+    <tr>
+      <td>Felix Cheung</td>
+      <td>Automattic</td>
+    </tr>
+    <tr>
+      <td>Mosharaf Chowdhury</td>
+      <td>University of Michigan, Ann Arbor</td>
+    </tr>
+    <tr>
+      <td>Jason Dai</td>
+      <td>Intel</td>
+    </tr>
+    <tr>
+      <td>Tathagata Das</td>
+      <td>Databricks</td>
+    </tr>
+    <tr>
+      <td>Ankur Dave</td>
+      <td>UC Berkeley</td>
+    </tr>
+    <tr>
+      <td>Aaron Davidson</td>
+      <td>Databricks</td>
+    </tr>
+    <tr>
+      <td>Thomas Dudziak</td>
+      <td>Facebook</td>
+    </tr>
+    <tr>
+      <td>Robert Evans</td>
+      <td>Yahoo!</td>
+    </tr>
+    <tr>
+      <td>Wenchen Fan</td>
+      <td>Databricks</td>
+    </tr>
+    <tr>
+      <td>Joseph Gonzalez</td>
+      <td>UC Berkeley</td>
+    </tr>
+    <tr>
+      <td>Thomas Graves</td>
+      <td>Yahoo!</td>
+    </tr>
+    <tr>
+      <td>Stephen Haberman</td>
+      <td>Bizo</td>
+    </tr>
+    <tr>
+      <td>Mark Hamstra</td>
+      <td>ClearStory Data</td>
+    </tr>
+    <tr>
+      <td>Herman van Hovell</td>
+      <td>QuestTec B.V.</td>
+    </tr>
+    <tr>
+      <td>Yin Huai</td>
+      <td>Databricks</td>
+    </tr>
+    <tr>
+      <td>Shane Huang</td>
+      <td>Intel</td>
+    </tr>
+    <tr>
+      <td>Andy Konwinski</td>
+      <td>Databricks</td>
+    </tr>
+    <tr>
+      <td>Ryan LeCompte</td>
+      <td>Quantifind</td>
+    </tr>
+    <tr>
+      <td>Haoyuan Li</td>
+      <td>Alluxio, UC Berkeley</td>
+    </tr>
+    <tr>
+      <td>Xiao Li</td>
+      <td>IBM</td>
+    </tr>
+    <tr>
+      <td>Davies Liu</td>
+      <td>Databricks</td>
+    </tr>
+    <tr>
+      <td>Cheng Lian</td>
+      <td>Databricks</td>
+    </tr>
+    <tr>
+      <td>Yanbo Liang</td>
+      <td>Hortonworks</td>
+    </tr>
+    <tr>
+      <td>Sean McNamara</td>
+      <td>Webtrends</td>
+    </tr>
+    <tr>
+      <td>Xiangrui Meng</td>
+      <td>Databricks</td>
+    </tr>
+    <tr>
+      <td>Mridul Muralidharam</td>
+      <td>Hortonworks</td>
+    </tr>
+    <tr>
+      <td>Andrew Or</td>
+      <td>Princeton University</td>
+    </tr>
+    <tr>
+      <td>Kay Ousterhout</td>
+      <td>UC Berkeley</td>
+    </tr>
+    <tr>
+      <td>Sean Owen</td>
+      <td>Cloudera</td>
+    </tr>
+    <tr>
+      <td>Nick Pentreath</td>
+      <td>IBM</td>
+    </tr>
+    <tr>
+      <td>Imran Rashid</td>
+      <td>Cloudera</td>
+    </tr>
+    <tr>
+      <td>Charles Reiss</td>
+      <td>UC Berkeley</td>
+    </tr>
+    <tr>
+      <td>Josh Rosen</td>
+      <td>Databricks</td>
+    </tr>
+    <tr>
+      <td>Sandy Ryza</td>
+      <td>Clover Health</td>
+    </tr>
+    <tr>
+      <td>Kousuke Saruta</td>
+      <td>NTT Data</td>
+    </tr>
+    <tr>
+      <td>Prashant Sharma</td>
+      <td>IBM</td>
+    </tr>
+    <tr>
+      <td>Ram Sriharsha</td>
+      <td>Databricks</td>
+    </tr>
+    <tr>
+      <td>DB Tsai</td>
+      <td>Netflix</td>
+    </tr>
+    <tr>
+      <td>Marcelo Vanzin</td>
+      <td>Cloudera</td>
+    </tr>
+    <tr>
+      <td>Shivaram Venkataraman</td>
+      <td>UC Berkeley</td>
+    </tr>
+    <tr>
+      <td>Patrick Wendell</td>
+      <td>Databricks</td>
+    </tr>
+    <tr>
+      <td>Andrew Xia</td>
+      <td>Alibaba</td>
+    </tr>
+    <tr>
+      <td>Reynold Xin</td>
+      <td>Databricks</td>
+    </tr>
+    <tr>
+      <td>Matei Zaharia</td>
+      <td>Databricks, Stanford</td>
+    </tr>
+    <tr>
+      <td>Shixiong Zhu</td>
+      <td>Databricks</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>Becoming a Committer</h3>
+
+<p>To get started contributing to Spark, learn 
+<a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">how to contribute</a> – 
+anyone can submit patches, documentation and examples to the project.</p>
+
+<p>The PMC regularly adds new committers from the active contributors, based on their contributions 
+to Spark. The qualifications for new committers include:</p>
+
+<ol>
+  <li>Sustained contributions to Spark: Committers should have a history of major contributions to 
+Spark. An ideal committer will have contributed broadly throughout the project, and have 
+contributed at least one major component where they have taken an &#8220;ownership&#8221; role. An ownership 
+role means that existing contributors feel that they should run patches for this component by 
+this person.</li>
+  <li>Quality of contributions: Committers more than any other community member should submit simple, 
+well-tested, and well-designed patches. In addition, they should show sufficient expertise to be 
+able to review patches, including making sure they fit within Spark&#8217;s engineering practices 
+(testability, documentation, API stability, code style, etc). The committership is collectively 
+responsible for the software quality and maintainability of Spark.</li>
+  <li>Community involvement: Committers should have a constructive and friendly attitude in all 
+community interactions. They should also be active on the dev and user list and help mentor 
+newer contributors and users. In design discussions, committers should maintain a professional 
+and diplomatic approach, even in the face of disagreement.</li>
+</ol>
+
+<p>The type and level of contributions considered may vary by project area &#8211; for example, we 
+greatly encourage contributors who want to work on mainly the documentation, or mainly on 
+platform support for specific OSes, storage systems, etc.</p>
+
+<h3>Review Process</h3>
+
+<p>All contributions should be reviewed before merging as described in 
+<a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">Contributing to Spark</a>. 
+In particular, if you are working on an area of the codebase you are unfamiliar with, look at the 
+Git history for that code to see who reviewed patches before. You can do this using 
+<code>git log --format=full &lt;filename&gt;</code>, by examining the &#8220;Commit&#8221; field to see who committed each patch.</p>
+
+<h3>How to Merge a Pull Request</h3>
+
+<p>Changes pushed to the master branch on Apache cannot be removed; that is, we can&#8217;t force-push to 
+it. So please don&#8217;t add any test commits or anything like that, only real patches.</p>
+
+<p>All merges should be done using the 
+<a href="https://github.com/apache/spark/blob/master/dev/merge_spark_pr.py">dev/merge_spark_pr.py</a> 
+script, which squashes the pull request&#8217;s changes into one commit. To use this script, you 
+will need to add a git remote called &#8220;apache&#8221; at https://git-wip-us.apache.org/repos/asf/spark.git, 
+as well as one called &#8220;apache-github&#8221; at <code>git://github.com/apache/spark</code>. For the <code>apache</code> repo, 
+you can authenticate using your ASF username and password. Ask Patrick if you have trouble with 
+this or want help doing your first merge.</p>
+
+<p>The script is fairly self explanatory and walks you through steps and options interactively.</p>
+
+<p>If you want to amend a commit before merging – which should be used for trivial touch-ups – 
+then simply let the script wait at the point where it asks you if you want to push to Apache. 
+Then, in a separate window, modify the code and push a commit. Run <code>git rebase -i HEAD~2</code> and 
+&#8220;squash&#8221; your new commit. Edit the commit message just after to remove your commit message. 
+You can verify the result is one change with <code>git log</code>. Then resume the script in the other window.</p>
+
+<p>Also, please remember to set Assignee on JIRAs where applicable when they are resolved. The script 
+can&#8217;t do this automatically.</p>
+
+<!--
+<h3>Minimize use of MINOR, BUILD, and HOTFIX with no JIRA</h3>
+
+From pwendell at https://www.mail-archive.com/dev@spark.apache.org/msg09565.html:
+It would be great if people could create JIRA's for any and all merged pull requests. The reason is 
+that when patches get reverted due to build breaks or other issues, it is very difficult to keep 
+track of what is going on if there is no JIRA. 
+Here is a list of 5 patches we had to revert recently that didn't include a JIRA:
+    Revert "[MINOR] [BUILD] Use custom temp directory during build."
+    Revert "[SQL] [TEST] [MINOR] Uses a temporary log4j.properties in HiveThriftServer2Test to ensure expected logging behavior"
+    Revert "[BUILD] Always run SQL tests in master build."
+    Revert "[MINOR] [CORE] Warn users who try to cache RDDs with dynamic allocation on."
+    Revert "[HOT FIX] [YARN] Check whether `/lib` exists before listing its files"
+
+The cost overhead of creating a JIRA relative to other aspects of development is very small. 
+If it's really a documentation change or something small, that's okay.
+
+But anything affecting the build, packaging, etc. These all need to have a JIRA to ensure that 
+follow-up can be well communicated to all Spark developers.
+-->
+
+<h3>Policy on Backporting Bug Fixes</h3>
+
+<p>From <code>pwendell</code> at https://www.mail-archive.com/dev@spark.apache.org/msg10284.html:</p>
+
+<p>The trade off when backporting is you get to deliver the fix to people running older versions 
+(great!), but you risk introducing new or even worse bugs in maintenance releases (bad!). 
+The decision point is when you have a bug fix and it&#8217;s not clear whether it is worth backporting.</p>
+
+<p>I think the following facets are important to consider:</p>
+<ul>
+  <li>Backports are an extremely valuable service to the community and should be considered for 
+any bug fix.</li>
+  <li>Introducing a new bug in a maintenance release must be avoided at all costs. It over time would 
+erode confidence in our release process.</li>
+  <li>Distributions or advanced users can always backport risky patches on their own, if they see fit.</li>
+</ul>
+
+<p>For me, the consequence of these is that we should backport in the following situations:</p>
+<ul>
+  <li>Both the bug and the fix are well understood and isolated. Code being modified is well tested.</li>
+  <li>The bug being addressed is high priority to the community.</li>
+  <li>The backported fix does not vary widely from the master branch fix.</li>
+</ul>
+
+<p>We tend to avoid backports in the converse situations:</p>
+<ul>
+  <li>The bug or fix are not well understood. For instance, it relates to interactions between complex 
+components or third party libraries (e.g. Hadoop libraries). The code is not well tested outside 
+of the immediate bug being fixed.</li>
+  <li>The bug is not clearly a high priority for the community.</li>
+  <li>The backported fix is widely different from the master branch fix.</li>
+</ul>
+
+  </div>
+</div>
+
+
+
+<footer class="small">
+  <hr>
+  Apache Spark, Spark, Apache, and the Spark logo are <a href="/trademarks.html">trademarks</a> of
+  <a href="http://www.apache.org">The Apache Software Foundation</a>.
+</footer>
+
+</div>
+
+</body>
+</html>

--- a/site/committers.html
+++ b/site/committers.html
@@ -387,7 +387,7 @@
 <h3>Becoming a Committer</h3>
 
 <p>To get started contributing to Spark, learn 
-<a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">how to contribute</a> – 
+<a href="/contributing.html">how to contribute</a> – 
 anyone can submit patches, documentation and examples to the project.</p>
 
 <p>The PMC regularly adds new committers from the active contributors, based on their contributions 
@@ -417,7 +417,7 @@ platform support for specific OSes, storage systems, etc.</p>
 <h3>Review Process</h3>
 
 <p>All contributions should be reviewed before merging as described in 
-<a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">Contributing to Spark</a>. 
+<a href="/contributing.html">Contributing to Spark</a>. 
 In particular, if you are working on an area of the codebase you are unfamiliar with, look at the 
 Git history for that code to see who reviewed patches before. You can do this using 
 <code>git log --format=full &lt;filename&gt;</code>, by examining the &#8220;Commit&#8221; field to see who committed each patch.</p>

--- a/site/committers.html
+++ b/site/committers.html
@@ -470,7 +470,7 @@ follow-up can be well communicated to all Spark developers.
 
 <h3>Policy on Backporting Bug Fixes</h3>
 
-<p>From <code>pwendell</code> at https://www.mail-archive.com/dev@spark.apache.org/msg10284.html:</p>
+<p>From <a href="https://www.mail-archive.com/dev@spark.apache.org/msg10284.html"><code>pwendell</code></a>:</p>
 
 <p>The trade off when backporting is you get to deliver the fix to people running older versions 
 (great!), but you risk introducing new or even worse bugs in maintenance releases (bad!). 

--- a/site/committers.html
+++ b/site/committers.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/committers.html
+++ b/site/committers.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/community.html
+++ b/site/community.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>
@@ -381,7 +381,7 @@ and include only a few lines of the pertinent code / log within the email.</li>
 
 <h3>Powered By</h3>
 
-<p>Our wiki has a list of <a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">projects and organizations powered by Spark</a>.</p>
+<p>Our wiki has a list of <a href="/powered-by.html">projects and organizations powered by Spark</a>.</p>
 
 <p><a name="history"></a></p>
 <h3>Project History</h3>

--- a/site/community.html
+++ b/site/community.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/community.html
+++ b/site/community.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/community.html
+++ b/site/community.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -219,8 +219,9 @@ feedback on any performance or correctness issues found in the newer release.</p
 
 <h2>Contributing by Reviewing Changes</h2>
 
-<p>Changes to Spark source code are proposed, reviewed and committed via Github (described later) at 
-http://github.com/apache/spark/pulls. Anyone can view and comment on active changes here. 
+<p>Changes to Spark source code are proposed, reviewed and committed via 
+<a href="http://github.com/apache/spark/pulls">Github pull requests</a> (described later). 
+Anyone can view and comment on active changes here. 
 Reviewing others&#8217; changes is a good way to learn how the change process works and gain exposure 
 to activity in various parts of the code. You can help by reviewing the changes and asking 
 questions or pointing out issues &#8211; as simple as typos or small issues of style.
@@ -229,15 +230,16 @@ See also https://spark-prs.appspot.com/ for a convenient way to view and filter 
 <h2>Contributing Documentation Changes</h2>
 
 <p>To propose a change to <em>release</em> documentation (that is, docs that appear under 
-https://spark.apache.org/docs/), edit the Markdown source files in Spark&#8217;s 
+<a href="https://spark.apache.org/docs/">https://spark.apache.org/docs/</a>), 
+edit the Markdown source files in Spark&#8217;s 
 <a href="https://github.com/apache/spark/tree/master/docs"><code>docs/</code></a> directory, 
 whose <code>README</code> file shows how to build the documentation locally to test your changes.
 The process to propose a doc change is otherwise the same as the process for proposing code 
 changes below.</p>
 
 <p>To propose a change to the rest of the documentation (that is, docs that do <em>not</em> appear under 
-https://spark.apache.org/docs/), similarly, edit the Markdown in the https://github.com/apache/spark-website
-repository and open a pull request.</p>
+<a href="https://spark.apache.org/docs/">https://spark.apache.org/docs/</a>), similarly, edit the Markdown in the 
+<a href="https://github.com/apache/spark-website">spark-website repository</a> and open a pull request.</p>
 
 <h2>Contributing User Libraries to Spark</h2>
 
@@ -249,7 +251,7 @@ learning algorithms can happily exist outside of MLlib.</p>
 
 <p>To that end, large and independent new functionality is often rejected for inclusion in Spark 
 itself, but, can and should be hosted as a separate project and repository, and included in 
-the http://spark-packages.org/ collection.</p>
+the <a href="http://spark-packages.org/">spark-packages.org</a> collection.</p>
 
 <h2>Contributing Bug Reports</h2>
 
@@ -264,7 +266,8 @@ first. Unreproducible bugs, or simple error reports, may be closed.</p>
 
 <p>It is possible to propose new features as well. These are generally not helpful unless 
 accompanied by detail, such as a design document and/or code change. Large new contributions 
-should consider http://spark-packages.org first (see above), or be discussed on the mailing 
+should consider <a href="http://spark-packages.org/">spark-packages.org</a> first (see above), 
+or be discussed on the mailing 
 list first. Feature requests may be rejected, or closed after a long period of inactivity.</p>
 
 <h2>Contributing to JIRA Maintenance</h2>
@@ -318,7 +321,7 @@ Review can take hours or days of committer time. Everyone benefits if contributo
 changes that are useful, clear, easy to evaluate, and already pass basic checks.</p>
 
 <p>Sometimes, a contributor will already have a particular new change or bug in mind. If seeking 
-ideas, consult the list of starter tasks in JIRA, or ask the user@spark.apache.org mailing list.</p>
+ideas, consult the list of starter tasks in JIRA, or ask the <code>user@spark.apache.org</code> mailing list.</p>
 
 <p>Before proceeding, contributors should evaluate if the proposed change is likely to be relevant, 
 new and actionable:</p>
@@ -330,10 +333,12 @@ lists first, rather than consider filing a JIRA or proposing a change. When in d
 <code>user@spark.apache.org</code> first about the possible change</li>
   <li>Search the <code>user@spark.apache.org</code> and <code>dev@spark.apache.org</code> mailing list 
 <a href="/community.html#mailing-lists">archives</a> for 
-related discussions. Use http://search-hadoop.com/?q=&amp;fc_project=Spark or similar search tools. 
+related discussions. Use <a href="http://search-hadoop.com/?q=&amp;fc_project=Spark">search-hadoop.com</a> 
+or similar search tools. 
 Often, the problem has been discussed before, with a resolution that doesn&#8217;t require a code 
 change, or recording what kinds of changes will not be accepted as a resolution.</li>
-  <li>Search JIRA for existing issues: https://issues.apache.org/jira/browse/SPARK</li>
+  <li>Search JIRA for existing issues: 
+<a href="https://issues.apache.org/jira/browse/SPARK">https://issues.apache.org/jira/browse/SPARK</a></li>
   <li>Type <code>spark [search terms]</code> at the top right search box. If a logically similar issue already 
 exists, then contribute to the discussion on the existing JIRA and pull request first, instead of 
 creating a new one.</li>
@@ -384,7 +389,7 @@ rather than receive iterations of review.</p>
   <li>Introduces complex new functionality, especially an API that needs to be supported</li>
   <li>Adds complexity that only helps a niche use case</li>
   <li>Adds user-space functionality that does not need to be maintained in Spark, but could be hosted 
-externally and indexed by http://spark-packages.org</li>
+externally and indexed by <a href="http://spark-packages.org/">spark-packages.org</a></li>
   <li>Changes a public API or semantics (rarely allowed)</li>
   <li>Adds large dependencies</li>
   <li>Changes versions of existing dependencies</li>
@@ -469,19 +474,19 @@ Example: <code>Fix typos in Foo scaladoc</code></li>
 
 <ol>
   <li><a href="https://help.github.com/articles/fork-a-repo/">Fork</a> the Github repository at 
-http://github.com/apache/spark if you haven&#8217;t already</li>
+<a href="http://github.com/apache/spark">http://github.com/apache/spark</a> if you haven&#8217;t already</li>
   <li>Clone your fork, create a new branch, push commits to the branch.</li>
   <li>Consider whether documentation or tests need to be added or updated as part of the change, 
 and add them as needed.</li>
-  <li>Run all tests with ./dev/run-tests to verify that the code still compiles, passes tests, and 
+  <li>Run all tests with <code>./dev/run-tests</code> to verify that the code still compiles, passes tests, and 
 passes style checks. If style checks fail, review the Code Style Guide below.</li>
   <li><a href="https://help.github.com/articles/using-pull-requests/">Open a pull request</a> against 
-the master branch of apache/spark. (Only in special cases would the PR be opened against other branches.)
+the <code>master</code> branch of <code>apache/spark</code>. (Only in special cases would the PR be opened against other branches.)
     <ol>
       <li>The PR title should be of the form <code>[SPARK-xxxx][COMPONENT] Title</code>, where <code>SPARK-xxxx</code> is 
   the relevant JIRA number, <code>COMPONENT </code>is one of the PR categories shown at 
-  https://spark-prs.appspot.com/ and Title may be the JIRA&#8217;s title or a more specific title 
-  describing the PR itself.</li>
+  <a href="https://spark-prs.appspot.com/">spark-prs.appspot.com</a> and 
+  Title may be the JIRA&#8217;s title or a more specific title describing the PR itself.</li>
       <li>If the pull request is still a work in progress, and so is not ready to be merged, 
   but needs to be pushed to Github to facilitate review, then add <code>[WIP]</code> after the component.</li>
       <li>Consider identifying committers or other contributors who have worked on the code being 

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -1,0 +1,760 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>
+     Contributing to Spark | Apache Spark
+    
+  </title>
+
+  
+
+  
+
+  <!-- Bootstrap core CSS -->
+  <link href="/css/cerulean.min.css" rel="stylesheet">
+  <link href="/css/custom.css" rel="stylesheet">
+
+  <!-- Code highlighter CSS -->
+  <link href="/css/pygments-default.css" rel="stylesheet">
+
+  <script type="text/javascript">
+  <!-- Google Analytics initialization -->
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-32518208-2']);
+  _gaq.push(['_trackPageview']);
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+
+  <!-- Adds slight delay to links to allow async reporting -->
+  function trackOutboundLink(link, category, action) {
+    try {
+      _gaq.push(['_trackEvent', category , action]);
+    } catch(err){}
+
+    setTimeout(function() {
+      document.location.href = link.href;
+    }, 100);
+  }
+  </script>
+
+  <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+  <!--[if lt IE 9]>
+  <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+  <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+  <![endif]-->
+</head>
+
+<body>
+
+<script src="https://code.jquery.com/jquery.js"></script>
+<script src="https://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
+<script src="/js/lang-tabs.js"></script>
+<script src="/js/downloads.js"></script>
+
+<div class="container" style="max-width: 1200px;">
+
+<div class="masthead">
+  
+    <p class="lead">
+      <a href="/">
+      <img src="/images/spark-logo-trademark.png"
+        style="height:100px; width:auto; vertical-align: bottom; margin-top: 20px;"></a><span class="tagline">
+          Lightning-fast cluster computing
+      </span>
+    </p>
+  
+</div>
+
+<nav class="navbar navbar-default" role="navigation">
+  <!-- Brand and toggle get grouped for better mobile display -->
+  <div class="navbar-header">
+    <button type="button" class="navbar-toggle" data-toggle="collapse"
+            data-target="#navbar-collapse-1">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+  </div>
+
+  <!-- Collect the nav links, forms, and other content for toggling -->
+  <div class="collapse navbar-collapse" id="navbar-collapse-1">
+    <ul class="nav navbar-nav">
+      <li><a href="/downloads.html">Download</a></li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Libraries <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/sql/">SQL and DataFrames</a></li>
+          <li><a href="/streaming/">Spark Streaming</a></li>
+          <li><a href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a href="/graphx/">GraphX (graph)</a></li>
+          <li class="divider"></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+        </ul>
+      </li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Documentation <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/docs/latest/">Latest Release (Spark 2.0.2)</a></li>
+          <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
+        </ul>
+      </li>
+      <li><a href="/examples.html">Examples</a></li>
+      <li class="dropdown">
+        <a href="/community.html" class="dropdown-toggle" data-toggle="dropdown">
+          Community <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#events">Events and Meetups</a></li>
+          <li><a href="/community.html#history">Project History</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
+        </ul>
+      </li>
+      <li><a href="/faq.html">FAQ</a></li>
+    </ul>
+    <ul class="nav navbar-nav navbar-right">
+      <li class="dropdown">
+        <a href="http://www.apache.org/" class="dropdown-toggle" data-toggle="dropdown">
+          Apache Software Foundation <b class="caret"></b></a>
+        <ul class="dropdown-menu">
+          <li><a href="http://www.apache.org/">Apache Homepage</a></li>
+          <li><a href="http://www.apache.org/licenses/">License</a></li>
+          <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+          <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
+          <li><a href="http://www.apache.org/security/">Security</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <!-- /.navbar-collapse -->
+</nav>
+
+
+<div class="row">
+  <div class="col-md-3 col-md-push-9">
+    <div class="news" style="margin-bottom: 20px;">
+      <h5>Latest News</h5>
+      <ul class="list-unstyled">
+        
+          <li><a href="/news/spark-wins-cloudsort-100tb-benchmark.html">Spark wins CloudSort Benchmark as the most efficient engine</a>
+          <span class="small">(Nov 15, 2016)</span></li>
+        
+          <li><a href="/news/spark-2-0-2-released.html">Spark 2.0.2 released</a>
+          <span class="small">(Nov 14, 2016)</span></li>
+        
+          <li><a href="/news/spark-1-6-3-released.html">Spark 1.6.3 released</a>
+          <span class="small">(Nov 07, 2016)</span></li>
+        
+          <li><a href="/news/spark-2-0-1-released.html">Spark 2.0.1 released</a>
+          <span class="small">(Oct 03, 2016)</span></li>
+        
+      </ul>
+      <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
+    </div>
+    <div class="hidden-xs hidden-sm">
+      <a href="/downloads.html" class="btn btn-success btn-lg btn-block" style="margin-bottom: 30px;">
+        Download Spark
+      </a>
+      <p style="font-size: 16px; font-weight: 500; color: #555;">
+        Built-in Libraries:
+      </p>
+      <ul class="list-none">
+        <li><a href="/sql/">SQL and DataFrames</a></li>
+        <li><a href="/streaming/">Spark Streaming</a></li>
+        <li><a href="/mllib/">MLlib (machine learning)</a></li>
+        <li><a href="/graphx/">GraphX (graph)</a></li>
+      </ul>
+      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+    </div>
+  </div>
+
+  <div class="col-md-9 col-md-pull-3">
+    <p>This guide documents the best way to make various types of contribution to Apache Spark, 
+including what is required before submitting a code change.</p>
+
+<p>Contributing to Spark doesn&#8217;t just mean writing code. Helping new users on the mailing list, 
+testing releases, and improving documentation are also welcome. In fact, proposing significant 
+code changes usually requires first gaining experience and credibility within the community by h
+elping in other ways. This is also a guide to becoming an effective contributor.</p>
+
+<p>So, this guide organizes contributions in order that they should probably be considered by new 
+contributors who intend to get involved long-term. Build some track record of helping others, 
+rather than just open pull requests.</p>
+
+<h2>Contributing by Helping Other Users</h2>
+
+<p>A great way to contribute to Spark is to help answer user questions on the <code>user@spark.apache.org</code> 
+mailing list or on StackOverflow. There are always many new Spark users; taking a few minutes to 
+help answer a question is a very valuable community service.</p>
+
+<p>Contributors should subscribe to this list and follow it in order to keep up to date on what&#8217;s 
+happening in Spark. Answering questions is an excellent and visible way to help the community, 
+which also demonstrates your expertise.</p>
+
+<p>See the <a href="/mailing-lists.html">Mailing Lists guide</a> for guidelines 
+about how to effectively participate in discussions on the mailing list, as well as forums 
+like StackOverflow.</p>
+
+<h2>Contributing by Testing Releases</h2>
+
+<p>Spark&#8217;s release process is community-oriented, and members of the community can vote on new 
+releases on the <code>dev@spark.apache.org</code> mailing list. Spark users are invited to subscribe to 
+this list to receive announcements, and test their workloads on newer release and provide 
+feedback on any performance or correctness issues found in the newer release.</p>
+
+<h2>Contributing by Reviewing Changes</h2>
+
+<p>Changes to Spark source code are proposed, reviewed and committed via Github (described later) at 
+http://github.com/apache/spark/pulls. Anyone can view and comment on active changes here. 
+Reviewing others&#8217; changes is a good way to learn how the change process works and gain exposure 
+to activity in various parts of the code. You can help by reviewing the changes and asking 
+questions or pointing out issues &#8211; as simple as typos or small issues of style.
+See also https://spark-prs.appspot.com/ for a convenient way to view and filter open PRs.</p>
+
+<h2>Contributing Documentation Changes</h2>
+
+<p>To propose a change to <em>release</em> documentation (that is, docs that appear under 
+https://spark.apache.org/docs/), edit the Markdown source files in Spark&#8217;s 
+<a href="https://github.com/apache/spark/tree/master/docs"><code>docs/</code></a> directory, 
+whose <code>README</code> file shows how to build the documentation locally to test your changes.
+The process to propose a doc change is otherwise the same as the process for proposing code 
+changes below.</p>
+
+<p>To propose a change to the rest of the documentation (that is, docs that do <em>not</em> appear under 
+https://spark.apache.org/docs/), similarly, edit the Markdown in the https://github.com/apache/spark-website
+repository and open a pull request.</p>
+
+<h2>Contributing User Libraries to Spark</h2>
+
+<p>Just as Java and Scala applications can access a huge selection of libraries and utilities, 
+none of which are part of Java or Scala themselves, Spark aims to support a rich ecosystem of 
+libraries. Many new useful utilities or features belong outside of Spark rather than in the core. 
+For example: language support probably has to be a part of core Spark, but, useful machine 
+learning algorithms can happily exist outside of MLlib.</p>
+
+<p>To that end, large and independent new functionality is often rejected for inclusion in Spark 
+itself, but, can and should be hosted as a separate project and repository, and included in 
+the http://spark-packages.org/ collection.</p>
+
+<h2>Contributing Bug Reports</h2>
+
+<p>Ideally, bug reports are accompanied by a proposed code change to fix the bug. This isn&#8217;t 
+always possible, as those who discover a bug may not have the experience to fix it. A bug 
+may be reported by creating a JIRA but without creating a pull request (see below).</p>
+
+<p>Bug reports are only useful however if they include enough information to understand, isolate 
+and ideally reproduce the bug. Simply encountering an error does not mean a bug should be 
+reported; as below, search JIRA and search and inquire on the Spark user / dev mailing lists 
+first. Unreproducible bugs, or simple error reports, may be closed.</p>
+
+<p>It is possible to propose new features as well. These are generally not helpful unless 
+accompanied by detail, such as a design document and/or code change. Large new contributions 
+should consider http://spark-packages.org first (see above), or be discussed on the mailing 
+list first. Feature requests may be rejected, or closed after a long period of inactivity.</p>
+
+<h2>Contributing to JIRA Maintenance</h2>
+
+<p>Given the sheer volume of issues raised in the Apache Spark JIRA, inevitably some issues are 
+duplicates, or become obsolete and eventually fixed otherwise, or can&#8217;t be reproduced, or could 
+benefit from more detail, and so on. It&#8217;s useful to help identify these issues and resolve them, 
+either by advancing the discussion or even resolving the JIRA. Most contributors are able to 
+directly resolve JIRAs. Use judgment in determining whether you are quite confident the issue 
+should be resolved, although changes can be easily undone. If in doubt, just leave a comment 
+on the JIRA.</p>
+
+<p>When resolving JIRAs, observe a few useful conventions:</p>
+
+<ul>
+  <li>Resolve as <strong>Fixed</strong> if there&#8217;s a change you can point to that resolved the issue
+    <ul>
+      <li>Set Fix Version(s), if and only if the resolution is Fixed</li>
+      <li>Set Assignee to the person who most contributed to the resolution, which is usually the person 
+who opened the PR that resolved the issue.</li>
+      <li>In case several people contributed, prefer to assign to the more &#8216;junior&#8217;, non-committer contributor</li>
+    </ul>
+  </li>
+  <li>For issues that can&#8217;t be reproduced against master as reported, resolve as <strong>Cannot Reproduce</strong>
+    <ul>
+      <li>Fixed is reasonable too, if it&#8217;s clear what other previous pull request resolved it. Link to it.</li>
+    </ul>
+  </li>
+  <li>If the issue is the same as or a subset of another issue, resolved as <strong>Duplicate</strong>
+    <ul>
+      <li>Make sure to link to the JIRA it duplicates</li>
+      <li>Prefer to resolve the issue that has less activity or discussion as the duplicate</li>
+    </ul>
+  </li>
+  <li>If the issue seems clearly obsolete and applies to issues or components that have changed 
+radically since it was opened, resolve as <strong>Not a Problem</strong></li>
+  <li>If the issue doesn&#8217;t make sense – not actionable, for example, a non-Spark issue, resolve 
+as <strong>Invalid</strong></li>
+  <li>If it&#8217;s a coherent issue, but there is a clear indication that there is not support or interest 
+in acting on it, then resolve as <strong>Won&#8217;t Fix</strong></li>
+  <li>Umbrellas are frequently marked <strong>Done</strong> if they are just container issues that don&#8217;t correspond 
+to an actionable change of their own</li>
+</ul>
+
+<h2>Preparing to Contribute Code Changes</h2>
+
+<h3>Choosing What to Contribute</h3>
+
+<p>Spark is an exceptionally busy project, with a new JIRA or pull request every few hours on average. 
+Review can take hours or days of committer time. Everyone benefits if contributors focus on 
+changes that are useful, clear, easy to evaluate, and already pass basic checks.</p>
+
+<p>Sometimes, a contributor will already have a particular new change or bug in mind. If seeking 
+ideas, consult the list of starter tasks in JIRA, or ask the user@spark.apache.org mailing list.</p>
+
+<p>Before proceeding, contributors should evaluate if the proposed change is likely to be relevant, 
+new and actionable:</p>
+
+<ul>
+  <li>Is it clear that code must change? Proposing a JIRA and pull request is appropriate only when a 
+clear problem or change has been identified. If simply having trouble using Spark, use the mailing 
+lists first, rather than consider filing a JIRA or proposing a change. When in doubt, email 
+<code>user@spark.apache.org</code> first about the possible change</li>
+  <li>Search the <code>user@spark.apache.org</code> and <code>dev@spark.apache.org</code> mailing list 
+<a href="/community.html#mailing-lists">archives</a> for 
+related discussions. Use http://search-hadoop.com/?q=&amp;fc_project=Spark or similar search tools. 
+Often, the problem has been discussed before, with a resolution that doesn&#8217;t require a code 
+change, or recording what kinds of changes will not be accepted as a resolution.</li>
+  <li>Search JIRA for existing issues: https://issues.apache.org/jira/browse/SPARK</li>
+  <li>Type <code>spark [search terms]</code> at the top right search box. If a logically similar issue already 
+exists, then contribute to the discussion on the existing JIRA and pull request first, instead of 
+creating a new one.</li>
+  <li>Is the scope of the change matched to the contributor&#8217;s level of experience? Anyone is qualified 
+to suggest a typo fix, but refactoring core scheduling logic requires much more understanding of 
+Spark. Some changes require building up experience first (see above).</li>
+</ul>
+
+<h3>MLlib-specific Contribution Guidelines</h3>
+
+<p>While a rich set of algorithms is an important goal for MLLib, scaling the project requires 
+that maintainability, consistency, and code quality come first. New algorithms should:</p>
+
+<ul>
+  <li>Be widely known</li>
+  <li>Be used and accepted (academic citations and concrete use cases can help justify this)</li>
+  <li>Be highly scalable</li>
+  <li>Be well documented</li>
+  <li>Have APIs consistent with other algorithms in MLLib that accomplish the same thing</li>
+  <li>Come with a reasonable expectation of developer support.</li>
+  <li>Have <code>@Since</code> annotation on public classes, methods, and variables.</li>
+</ul>
+
+<h3>Code Review Criteria</h3>
+
+<p>Before considering how to contribute code, it&#8217;s useful to understand how code is reviewed, 
+and why changes may be rejected. Simply put, changes that have many or large positives, and 
+few negative effects or risks, are much more likely to be merged, and merged quickly. 
+Risky and less valuable changes are very unlikely to be merged, and may be rejected outright 
+rather than receive iterations of review.</p>
+
+<h4>Positives</h4>
+
+<ul>
+  <li>Fixes the root cause of a bug in existing functionality</li>
+  <li>Adds functionality or fixes a problem needed by a large number of users</li>
+  <li>Simple, targeted</li>
+  <li>Maintains or improves consistency across Python, Java, Scala</li>
+  <li>Easily tested; has tests</li>
+  <li>Reduces complexity and lines of code</li>
+  <li>Change has already been discussed and is known to committers</li>
+</ul>
+
+<h4>Negatives, Risks</h4>
+
+<ul>
+  <li>Band-aids a symptom of a bug only</li>
+  <li>Introduces complex new functionality, especially an API that needs to be supported</li>
+  <li>Adds complexity that only helps a niche use case</li>
+  <li>Adds user-space functionality that does not need to be maintained in Spark, but could be hosted 
+externally and indexed by http://spark-packages.org</li>
+  <li>Changes a public API or semantics (rarely allowed)</li>
+  <li>Adds large dependencies</li>
+  <li>Changes versions of existing dependencies</li>
+  <li>Adds a large amount of code</li>
+  <li>Makes lots of modifications in one &#8220;big bang&#8221; change</li>
+</ul>
+
+<h2>Contributing Code Changes</h2>
+
+<p>Please review the preceding section before proposing a code change. This section documents how to do so.</p>
+
+<p><strong>When you contribute code, you affirm that the contribution is your original work and that you 
+license the work to the project under the project&#8217;s open source license. Whether or not you state 
+this explicitly, by submitting any copyrighted material via pull request, email, or other means 
+you agree to license the material under the project&#8217;s open source license and warrant that you 
+have the legal authority to do so.</strong></p>
+
+<h3>JIRA</h3>
+
+<p>Generally, Spark uses JIRA to track logical issues, including bugs and improvements, and uses 
+Github pull requests to manage the review and merge of specific code changes. That is, JIRAs are 
+used to describe <em>what</em> should be fixed or changed, and high-level approaches, and pull requests 
+describe <em>how</em> to implement that change in the project&#8217;s source code. For example, major design 
+decisions are discussed in JIRA.</p>
+
+<ol>
+  <li>Find the existing Spark JIRA that the change pertains to.
+    <ol>
+      <li>Do not create a new JIRA if creating a change to address an existing issue in JIRA; add to 
+ the existing discussion and work instead</li>
+      <li>Look for existing pull requests that are linked from the JIRA, to understand if someone is 
+ already working on the JIRA</li>
+    </ol>
+  </li>
+  <li>If the change is new, then it usually needs a new JIRA. However, trivial changes, where the
+what should change is virtually the same as the how it should change do not require a JIRA. 
+Example: <code>Fix typos in Foo scaladoc</code></li>
+  <li>If required, create a new JIRA:
+    <ol>
+      <li>Provide a descriptive Title. &#8220;Update web UI&#8221; or &#8220;Problem in scheduler&#8221; is not sufficient.
+ &#8220;Kafka Streaming support fails to handle empty queue in YARN cluster mode&#8221; is good.</li>
+      <li>Write a detailed Description. For bug reports, this should ideally include a short 
+ reproduction of the problem. For new features, it may include a design document.</li>
+      <li>Set required fields:
+        <ol>
+          <li><strong>Issue Type</strong>. Generally, Bug, Improvement and New Feature are the only types used in Spark.</li>
+          <li><strong>Priority</strong>. Set to Major or below; higher priorities are generally reserved for 
+ committers to set. JIRA tends to unfortunately conflate &#8220;size&#8221; and &#8220;importance&#8221; in its 
+ Priority field values. Their meaning is roughly:
+            <ol>
+              <li>Blocker: pointless to release without this change as the release would be unusable 
+  to a large minority of users</li>
+              <li>Critical: a large minority of users are missing important functionality without 
+  this, and/or a workaround is difficult</li>
+              <li>Major: a small minority of users are missing important functionality without this, 
+  and there is a workaround</li>
+              <li>Minor: a niche use case is missing some support, but it does not affect usage or 
+  is easily worked around</li>
+              <li>Trivial: a nice-to-have change but unlikely to be any problem in practice otherwise</li>
+            </ol>
+          </li>
+          <li><strong>Component</strong></li>
+          <li><strong>Affects Version</strong>. For Bugs, assign at least one version that is known to exhibit the 
+ problem or need the change</li>
+        </ol>
+      </li>
+      <li>Do not set the following fields:
+        <ol>
+          <li><strong>Fix Version</strong>. This is assigned by committers only when resolved.</li>
+          <li><strong>Target Version</strong>. This is assigned by committers to indicate a PR has been accepted for 
+ possible fix by the target version.</li>
+        </ol>
+      </li>
+      <li>Do not include a patch file; pull requests are used to propose the actual change.</li>
+    </ol>
+  </li>
+  <li>If the change is a large change, consider inviting discussion on the issue at 
+<code>dev@spark.apache.org</code> first before proceeding to implement the change.</li>
+</ol>
+
+<h3>Pull Request</h3>
+
+<ol>
+  <li><a href="https://help.github.com/articles/fork-a-repo/">Fork</a> the Github repository at 
+http://github.com/apache/spark if you haven&#8217;t already</li>
+  <li>Clone your fork, create a new branch, push commits to the branch.</li>
+  <li>Consider whether documentation or tests need to be added or updated as part of the change, 
+and add them as needed.</li>
+  <li>Run all tests with ./dev/run-tests to verify that the code still compiles, passes tests, and 
+passes style checks. If style checks fail, review the Code Style Guide below.</li>
+  <li><a href="https://help.github.com/articles/using-pull-requests/">Open a pull request</a> against 
+the master branch of apache/spark. (Only in special cases would the PR be opened against other branches.)
+    <ol>
+      <li>The PR title should be of the form <code>[SPARK-xxxx][COMPONENT] Title</code>, where <code>SPARK-xxxx</code> is 
+  the relevant JIRA number, <code>COMPONENT </code>is one of the PR categories shown at 
+  https://spark-prs.appspot.com/ and Title may be the JIRA&#8217;s title or a more specific title 
+  describing the PR itself.</li>
+      <li>If the pull request is still a work in progress, and so is not ready to be merged, 
+  but needs to be pushed to Github to facilitate review, then add <code>[WIP]</code> after the component.</li>
+      <li>Consider identifying committers or other contributors who have worked on the code being 
+  changed. Find the file(s) in Github and click &#8220;Blame&#8221; to see a line-by-line annotation of 
+  who changed the code last. You can add <code>@username</code> in the PR description to ping them 
+  immediately.</li>
+      <li>Please state that the contribution is your original work and that you license the work 
+  to the project under the project&#8217;s open source license.</li>
+    </ol>
+  </li>
+  <li>The related JIRA, if any, will be marked as &#8220;In Progress&#8221; and your pull request will 
+automatically be linked to it. There is no need to be the Assignee of the JIRA to work on it, 
+though you are welcome to comment that you have begun work.</li>
+  <li>The Jenkins automatic pull request builder will test your changes
+    <ol>
+      <li>If it is your first contribution, Jenkins will wait for confirmation before building 
+  your code and post &#8220;Can one of the admins verify this patch?&#8221;</li>
+      <li>A committer can authorize testing with a comment like &#8220;ok to test&#8221;</li>
+      <li>A committer can automatically allow future pull requests from a contributor to be 
+  tested with a comment like &#8220;Jenkins, add to whitelist&#8221;</li>
+    </ol>
+  </li>
+  <li>After about 2 hours, Jenkins will post the results of the test to the pull request, along 
+with a link to the full results on Jenkins.</li>
+  <li>Watch for the results, and investigate and fix failures promptly
+    <ol>
+      <li>Fixes can simply be pushed to the same branch from which you opened your pull request</li>
+      <li>Jenkins will automatically re-test when new commits are pushed</li>
+      <li>If the tests failed for reasons unrelated to the change (e.g. Jenkins outage), then a 
+  committer can request a re-test with &#8220;Jenkins, retest this please&#8221;. 
+  Ask if you need a test restarted.</li>
+    </ol>
+  </li>
+</ol>
+
+<h3>The Review Process</h3>
+
+<ul>
+  <li>Other reviewers, including committers, may comment on the changes and suggest modifications. 
+Changes can be added by simply pushing more commits to the same branch.</li>
+  <li>Lively, polite, rapid technical debate is encouraged from everyone in the community. The outcome 
+may be a rejection of the entire change.</li>
+  <li>Reviewers can indicate that a change looks suitable for merging with a comment such as: &#8220;I think 
+this patch looks good&#8221;. Spark uses the LGTM convention for indicating the strongest level of 
+technical sign-off on a patch: simply comment with the word &#8220;LGTM&#8221;. It specifically means: &#8220;I&#8217;ve 
+looked at this thoroughly and take as much ownership as if I wrote the patch myself&#8221;. If you 
+comment LGTM you will be expected to help with bugs or follow-up issues on the patch. Consistent, 
+judicious use of LGTMs is a great way to gain credibility as a reviewer with the broader community.</li>
+  <li>Sometimes, other changes will be merged which conflict with your pull request&#8217;s changes. The 
+PR can&#8217;t be merged until the conflict is resolved. This can be resolved with <code>git fetch origin</code> 
+followed by <code>git merge origin/master</code> and resolving the conflicts by hand, then pushing the result 
+to your branch.</li>
+  <li>Try to be responsive to the discussion rather than let days pass between replies</li>
+</ul>
+
+<h3>Closing Your Pull Request / JIRA</h3>
+
+<ul>
+  <li>If a change is accepted, it will be merged and the pull request will automatically be closed, 
+along with the associated JIRA if any
+    <ul>
+      <li>Note that in the rare case you are asked to open a pull request against a branch besides 
+<code>master</code>, that you will actually have to close the pull request manually</li>
+      <li>The JIRA will be Assigned to the primary contributor to the change as a way of giving credit. 
+If the JIRA isn&#8217;t closed and/or Assigned promptly, comment on the JIRA.</li>
+    </ul>
+  </li>
+  <li>If your pull request is ultimately rejected, please close it promptly
+    <ul>
+      <li>&#8230; because committers can&#8217;t close PRs directly</li>
+      <li>Pull requests will be automatically closed by an automated process at Apache after about a 
+week if a committer has made a comment like &#8220;mind closing this PR?&#8221; This means that the 
+committer is specifically requesting that it be closed.</li>
+    </ul>
+  </li>
+  <li>If a pull request has gotten little or no attention, consider improving the description or 
+the change itself and ping likely reviewers again after a few days. Consider proposing a 
+change that&#8217;s easier to include, like a smaller and/or less invasive change.</li>
+  <li>If it has been reviewed but not taken up after weeks, after soliciting review from the 
+most relevant reviewers, or, has met with neutral reactions, the outcome may be considered a 
+&#8220;soft no&#8221;. It is helpful to withdraw and close the PR in this case.</li>
+  <li>If a pull request is closed because it is deemed not the right approach to resolve a JIRA, 
+then leave the JIRA open. However if the review makes it clear that the issue identified in 
+the JIRA is not going to be resolved by any pull request (not a problem, won&#8217;t fix) then also 
+resolve the JIRA.</li>
+</ul>
+
+<p><a name="code-style-guide"></a></p>
+<h2>Code Style Guide</h2>
+
+<p>Please follow the style of the existing codebase.</p>
+
+<ul>
+  <li>For Python code, Apache Spark follows 
+<a href="http://legacy.python.org/dev/peps/pep-0008/">PEP 8</a> with one exception: 
+lines can be up to 100 characters in length, not 79.</li>
+  <li>For Java code, Apache Spark follows 
+<a href="http://www.oracle.com/technetwork/java/codeconvtoc-136057.html">Oracle&#8217;s Java code conventions</a>. 
+Many Scala guidelines below also apply to Java.</li>
+  <li>For Scala code, Apache Spark follows the official 
+<a href="http://docs.scala-lang.org/style/">Scala style guide</a>, but with the following changes, below.</li>
+</ul>
+
+<h3>Line Length</h3>
+
+<p>Limit lines to 100 characters. The only exceptions are import statements (although even for 
+those, try to keep them under 100 chars).</p>
+
+<h3>Indentation</h3>
+
+<p>Use 2-space indentation in general. For function declarations, use 4 space indentation for its 
+parameters when they don&#8217;t fit in a single line. For example:</p>
+
+<pre><code class="language-scala">// Correct:
+if (true) {
+  println("Wow!")
+}
+ 
+// Wrong:
+if (true) {
+    println("Wow!")
+}
+ 
+// Correct:
+def newAPIHadoopFile[K, V, F &lt;: NewInputFormat[K, V]](
+    path: String,
+    fClass: Class[F],
+    kClass: Class[K],
+    vClass: Class[V],
+    conf: Configuration = hadoopConfiguration): RDD[(K, V)] = {
+  // function body
+}
+ 
+// Wrong
+def newAPIHadoopFile[K, V, F &lt;: NewInputFormat[K, V]](
+  path: String,
+  fClass: Class[F],
+  kClass: Class[K],
+  vClass: Class[V],
+  conf: Configuration = hadoopConfiguration): RDD[(K, V)] = {
+  // function body
+}
+</code></pre>
+
+<h3>Code documentation style</h3>
+
+<p>For Scala doc / Java doc comment before classes, objects and methods, use Java docs style 
+instead of Scala docs style.</p>
+
+<pre><code class="language-scala">/** This is a correct one-liner, short description. */
+ 
+/**
+ * This is correct multi-line JavaDoc comment. And
+ * this is my second line, and if I keep typing, this would be
+ * my third line.
+ */
+ 
+/** In Spark, we don't use the ScalaDoc style so this
+  * is not correct.
+  */
+</code></pre>
+
+<p>For inline comment with the code, use <code>//</code> and not <code>/*  .. */</code>.</p>
+
+<pre><code class="language-scala">// This is a short, single line comment
+ 
+// This is a multi line comment.
+// Bla bla bla
+ 
+/*
+ * Do not use this style for multi line comments. This
+ * style of comment interferes with commenting out
+ * blocks of code, and also makes code comments harder
+ * to distinguish from Scala doc / Java doc comments.
+ */
+ 
+/**
+ * Do not use scala doc style for inline comments.
+ */
+</code></pre>
+
+<h3>Imports</h3>
+
+<p>Always import packages using absolute paths (e.g. <code>scala.util.Random</code>) instead of relative ones 
+(e.g. <code>util.Random</code>). In addition, sort imports in the following order 
+(use alphabetical order within each group):</p>
+<ul>
+  <li><code>java.*</code> and <code>javax.*</code></li>
+  <li><code>scala.*</code></li>
+  <li>Third-party libraries (<code>org.*</code>, <code>com.*</code>, etc)</li>
+  <li>Project classes (<code>org.apache.spark.*</code>)</li>
+</ul>
+
+<p>The <a href="https://plugins.jetbrains.com/plugin/7350">IntelliJ import organizer plugin</a> 
+can organize imports for you. Use this configuration for the plugin (configured under 
+Preferences / Editor / Code Style / Scala Imports Organizer):</p>
+
+<pre><code class="language-scala">import java.*
+import javax.*
+ 
+import scala.*
+ 
+import *
+ 
+import org.apache.spark.*
+</code></pre>
+
+<h3>Infix Methods</h3>
+
+<p>Don&#8217;t use infix notation for methods that aren&#8217;t operators. For example, instead of 
+<code>list map func</code>, use <code>list.map(func)</code>, or instead of <code>string contains "foo"</code>, use 
+<code>string.contains("foo")</code>. This is to improve familiarity to developers coming from other languages.</p>
+
+<h3>Curly Braces</h3>
+
+<p>Put curly braces even around one-line <code>if</code>, <code>else</code> or loop statements. The only exception is if 
+you are using <code>if/else</code> as an one-line ternary operator.</p>
+
+<p>```scala
+// Correct:
+if (true) {
+  println(&#8220;Wow!&#8221;)
+}</p>
+
+<p>// Correct:
+if (true) statement1 else statement2</p>
+
+<p>// Wrong:
+if (true)
+  println(&#8220;Wow!&#8221;)
+Return Types
+Always specify the return types of methods where possible. If a method has no return type, specify Unit instead in accordance with the Scala style guide. Return types for variables are not required unless the definition involves huge code blocks with potentially ambiguous return values.
+// Correct:
+def getSize(partitionId: String): Long = { &#8230; }
+def compute(partitionId: String): Unit = { &#8230; }</p>
+
+<p>// Wrong:
+def getSize(partitionId: String) = { &#8230; }
+def compute(partitionId: String) = { &#8230; }
+def compute(partitionId: String) { &#8230; }</p>
+
+<p>// Correct:
+val name = &#8220;black-sheep&#8221;
+val path: Option[String] =
+  try {
+    Option(names)
+      .map { ns =&gt; ns.split(&#8220;,&#8221;) }
+      .flatMap { ns =&gt; ns.filter(_.nonEmpty).headOption }
+      .map { n =&gt; &#8220;prefix&#8221; + n + &#8220;suffix&#8221; }
+      .flatMap { n =&gt; if (n.hashCode % 3 == 0) Some(n + n) else None }
+  } catch {
+    case e: SomeSpecialException =&gt;
+      computePath(names)
+  }
+ ```</p>
+
+<h3>If in Doubt</h3>
+
+<p>If you&#8217;re not sure about the right style for something, try to follow the style of the existing 
+codebase. Look at whether there are other examples in the code that use your feature. Feel free 
+to ask on the <code>dev@spark.apache.org</code> list as well.</p>
+
+  </div>
+</div>
+
+
+
+<footer class="small">
+  <hr>
+  Apache Spark, Spark, Apache, and the Spark logo are <a href="/trademarks.html">trademarks</a> of
+  <a href="http://www.apache.org">The Apache Software Foundation</a>.
+</footer>
+
+</div>
+
+</body>
+</html>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>
@@ -699,43 +700,48 @@ import org.apache.spark.*
 <p>Put curly braces even around one-line <code>if</code>, <code>else</code> or loop statements. The only exception is if 
 you are using <code>if/else</code> as an one-line ternary operator.</p>
 
-<p>```scala
-// Correct:
+<pre><code class="language-scala">// Correct:
 if (true) {
-  println(&#8220;Wow!&#8221;)
-}</p>
-
-<p>// Correct:
-if (true) statement1 else statement2</p>
-
-<p>// Wrong:
-if (true)
-  println(&#8220;Wow!&#8221;)
-Return Types
-Always specify the return types of methods where possible. If a method has no return type, specify Unit instead in accordance with the Scala style guide. Return types for variables are not required unless the definition involves huge code blocks with potentially ambiguous return values.
+  println("Wow!")
+}
+ 
 // Correct:
-def getSize(partitionId: String): Long = { &#8230; }
-def compute(partitionId: String): Unit = { &#8230; }</p>
+if (true) statement1 else statement2
+ 
+// Wrong:
+if (true)
+  println("Wow!")
+</code></pre>
 
-<p>// Wrong:
-def getSize(partitionId: String) = { &#8230; }
-def compute(partitionId: String) = { &#8230; }
-def compute(partitionId: String) { &#8230; }</p>
+<h3>Return Types</h3>
 
-<p>// Correct:
-val name = &#8220;black-sheep&#8221;
+<p>Always specify the return types of methods where possible. If a method has no return type, specify 
+<code>Unit</code> instead in accordance with the Scala style guide. Return types for variables are not 
+required unless the definition involves huge code blocks with potentially ambiguous return values.</p>
+
+<pre><code class="language-scala">// Correct:
+def getSize(partitionId: String): Long = { ... }
+def compute(partitionId: String): Unit = { ... }
+ 
+// Wrong:
+def getSize(partitionId: String) = { ... }
+def compute(partitionId: String) = { ... }
+def compute(partitionId: String) { ... }
+ 
+// Correct:
+val name = "black-sheep"
 val path: Option[String] =
   try {
     Option(names)
-      .map { ns =&gt; ns.split(&#8220;,&#8221;) }
+      .map { ns =&gt; ns.split(",") }
       .flatMap { ns =&gt; ns.filter(_.nonEmpty).headOption }
-      .map { n =&gt; &#8220;prefix&#8221; + n + &#8220;suffix&#8221; }
+      .map { n =&gt; "prefix" + n + "suffix" }
       .flatMap { n =&gt; if (n.hashCode % 3 == 0) Some(n + n) else None }
   } catch {
     case e: SomeSpecialException =&gt;
       computePath(names)
   }
- ```</p>
+</code></pre>
 
 <h3>If in Doubt</h3>
 

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -353,7 +353,7 @@ Slides, videos and EC2-based exercises from each of these are available online:
 
 <ul><li>
 The <a href="https://cwiki.apache.org/confluence/display/SPARK/Wiki+Homepage">Spark wiki</a> contains
-information for developers, such as architecture documents and how to <a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">contribute</a> to Spark.
+information for developers, such as architecture documents and how to <a href="/contributing.html">"&gt;contribute</a> to Spark.
 </li></ul>
 
 <h3>Research Papers</h3>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/examples.html
+++ b/site/examples.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/examples.html
+++ b/site/examples.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/examples.html
+++ b/site/examples.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/examples.html
+++ b/site/examples.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/faq.html
+++ b/site/faq.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/faq.html
+++ b/site/faq.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/faq.html
+++ b/site/faq.html
@@ -243,7 +243,7 @@ Please also refer to our
 
 <p class="question">How can I contribute to Spark?</p>
 
-<p class="answer">See the <a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">Contributing to Spark wiki</a> for more information.</p>
+<p class="answer">See the <a href="/contributing.html">Contributing to Spark wiki</a> for more information.</p>
 
 <p class="question">Where can I get more help?</p>
 

--- a/site/faq.html
+++ b/site/faq.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>
@@ -193,7 +193,7 @@ Spark is a fast and general processing engine compatible with Hadoop data. It ca
 
 <p class="question">Who is using Spark in production?</p>
 
-<p class="answer">As of 2016, surveys show that more than 1000 organizations are using Spark in production. Some of them are listed on the <a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By page</a> and at the <a href="http://spark-summit.org">Spark Summit</a>.</p>
+<p class="answer">As of 2016, surveys show that more than 1000 organizations are using Spark in production. Some of them are listed on the <a href="/powered-by.html">Powered By page</a> and at the <a href="http://spark-summit.org">Spark Summit</a>.</p>
 
 <p class="question">How large a cluster can Spark scale to?</p>
 <p class="answer">Many organizations run Spark on clusters of thousands of nodes. The largest cluster we are know has 8000. In terms of data size, Spark has been shown to work well up to petabytes. It has been used to sort 100 TB of data 3X faster than Hadoop MapReduce on 1/10th of the machines, <a href="http://databricks.com/blog/2014/11/05/spark-officially-sets-a-new-record-in-large-scale-sorting.html">winning the 2014 Daytona GraySort Benchmark</a>, as well as to <a href="https://databricks.com/blog/2014/10/10/spark-petabyte-sort.html">sort 1 PB</a>. Several production workloads <a href="http://databricks.com/blog/2014/08/14/mining-graph-data-with-spark-at-alibaba-taobao.html">use Spark to do ETL and data analysis on PBs of data</a>.</p>

--- a/site/faq.html
+++ b/site/faq.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -119,12 +119,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -266,7 +266,7 @@
     </p>
     <p>
       GraphX is in the alpha stage and welcomes contributions. If you'd like to submit a change to GraphX,
-      read <a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">how to
+      read <a href="/contributing.html">how to
       contribute to Spark</a> and send us a patch!
     </p>
   </div>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -123,7 +123,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -101,7 +101,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -182,7 +182,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -124,7 +124,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/index.html
+++ b/site/index.html
@@ -100,7 +100,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -181,7 +181,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/index.html
+++ b/site/index.html
@@ -332,8 +332,7 @@
 
     <p>
       If you'd like to participate in Spark, or contribute to the libraries on top of it, learn
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">how to
-        contribute</a>.
+      <a href="/contributing.html">how to contribute</a>.
     </p>
   </div>
 

--- a/site/index.html
+++ b/site/index.html
@@ -122,7 +122,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
@@ -326,7 +326,7 @@
 
     <p>
       The project's
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">committers</a>
+      <a href="/committers.html">committers</a>
       come from 19 organizations.
     </p>
 

--- a/site/index.html
+++ b/site/index.html
@@ -123,7 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>
@@ -301,9 +301,7 @@
     <p>
       Spark is used at a wide range of organizations to process large datasets.
       You can find example use cases at the <a href="http://spark-summit.org/summit-2013/">Spark Summit</a>
-      conference, or on the
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a>
-      page.
+      conference, or on the <a href="/powered-by.html">Powered By</a> page.
     </p>
 
     <p>

--- a/site/index.html
+++ b/site/index.html
@@ -118,12 +118,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -119,12 +119,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -123,7 +123,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -101,7 +101,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -182,7 +182,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -124,7 +124,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -119,12 +119,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -123,7 +123,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -294,7 +294,7 @@
     </p>
     <p>
       MLlib is still a rapidly growing project and welcomes contributions. If you'd like to submit an algorithm to MLlib,
-      read <a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">how to
+      read <a href="/contributing.html">how to
       contribute to Spark</a> and send us a patch!
     </p>
   </div>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -101,7 +101,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -182,7 +182,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -124,7 +124,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-summit-east-agenda-posted.html
+++ b/site/news/spark-summit-east-agenda-posted.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-east-agenda-posted.html
+++ b/site/news/spark-summit-east-agenda-posted.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-east-agenda-posted.html
+++ b/site/news/spark-summit-east-agenda-posted.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-east-agenda-posted.html
+++ b/site/news/spark-summit-east-agenda-posted.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>
@@ -189,7 +189,7 @@
 
 <p>As we continue developing Spark, we would love to get feedback from users and hear what you&#8217;d like us to work on next. We&#8217;ve decided that a good way to do that is a survey &#8211; we hope to run this at regular intervals. If you have a few minutes to participate, <a href="https://docs.google.com/forms/d/1eMXp4GjcIXglxJe5vYYBzXKVm-6AiYt1KThJwhCjJiY/viewform">fill in the survey here</a>. Your time is greatly appreciated.</p>
 
-<p>In parallel, we are starting a <a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">&#8220;powered by&#8221; page</a> on the Apache Spark wiki for organizations that are using, or contributing to, Spark. Sign up if you&#8217;d like to support the project! This is a great way to let the world know you&#8217;re using Spark, and can also be helpful to generate leads for recruiting. You can also add yourself when you fill the survey.</p>
+<p>In parallel, we are starting a <a href="/powered-by.html">&#8220;powered by&#8221; page</a> on the Apache Spark wiki for organizations that are using, or contributing to, Spark. Sign up if you&#8217;d like to support the project! This is a great way to let the world know you&#8217;re using Spark, and can also be helpful to generate leads for recruiting. You can also add yourself when you fill the survey.</p>
 
 <p>Thanks for taking the time to give feedback.</p>
 

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -188,9 +188,9 @@
 
 <p>Organizations creating products and projects for use with Apache Spark, along with associated 
 marketing materials, should take care to respect the trademark in &#8220;Apache Spark&#8221; and its logo. 
-Please refer to http://www.apache.org/foundation/marks/ and 
-http://www.apache.org/foundation/marks/faq/ for comprehensive and authoritative guidance on 
-proper usage of ASF trademarks.</p>
+Please refer to <a href="http://www.apache.org/foundation/marks/">ASF Trademarks Guidance</a> and 
+associated <a href="http://www.apache.org/foundation/marks/faq/">FAQ</a> 
+for comprehensive and authoritative guidance on proper usage of ASF trademarks.</p>
 
 <p>Names that do not include &#8220;Spark&#8221; at all have no potential trademark issue with the Spark project. 
 This is recommended.</p>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -1,0 +1,563 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>
+     Powered By Spark | Apache Spark
+    
+  </title>
+
+  
+
+  
+
+  <!-- Bootstrap core CSS -->
+  <link href="/css/cerulean.min.css" rel="stylesheet">
+  <link href="/css/custom.css" rel="stylesheet">
+
+  <!-- Code highlighter CSS -->
+  <link href="/css/pygments-default.css" rel="stylesheet">
+
+  <script type="text/javascript">
+  <!-- Google Analytics initialization -->
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-32518208-2']);
+  _gaq.push(['_trackPageview']);
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+
+  <!-- Adds slight delay to links to allow async reporting -->
+  function trackOutboundLink(link, category, action) {
+    try {
+      _gaq.push(['_trackEvent', category , action]);
+    } catch(err){}
+
+    setTimeout(function() {
+      document.location.href = link.href;
+    }, 100);
+  }
+  </script>
+
+  <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+  <!--[if lt IE 9]>
+  <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+  <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+  <![endif]-->
+</head>
+
+<body>
+
+<script src="https://code.jquery.com/jquery.js"></script>
+<script src="https://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
+<script src="/js/lang-tabs.js"></script>
+<script src="/js/downloads.js"></script>
+
+<div class="container" style="max-width: 1200px;">
+
+<div class="masthead">
+  
+    <p class="lead">
+      <a href="/">
+      <img src="/images/spark-logo-trademark.png"
+        style="height:100px; width:auto; vertical-align: bottom; margin-top: 20px;"></a><span class="tagline">
+          Lightning-fast cluster computing
+      </span>
+    </p>
+  
+</div>
+
+<nav class="navbar navbar-default" role="navigation">
+  <!-- Brand and toggle get grouped for better mobile display -->
+  <div class="navbar-header">
+    <button type="button" class="navbar-toggle" data-toggle="collapse"
+            data-target="#navbar-collapse-1">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+  </div>
+
+  <!-- Collect the nav links, forms, and other content for toggling -->
+  <div class="collapse navbar-collapse" id="navbar-collapse-1">
+    <ul class="nav navbar-nav">
+      <li><a href="/downloads.html">Download</a></li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Libraries <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/sql/">SQL and DataFrames</a></li>
+          <li><a href="/streaming/">Spark Streaming</a></li>
+          <li><a href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a href="/graphx/">GraphX (graph)</a></li>
+          <li class="divider"></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
+        </ul>
+      </li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Documentation <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/docs/latest/">Latest Release (Spark 2.0.2)</a></li>
+          <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
+        </ul>
+      </li>
+      <li><a href="/examples.html">Examples</a></li>
+      <li class="dropdown">
+        <a href="/community.html" class="dropdown-toggle" data-toggle="dropdown">
+          Community <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
+          <li><a href="/community.html#events">Events and Meetups</a></li>
+          <li><a href="/community.html#history">Project History</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
+        </ul>
+      </li>
+      <li><a href="/faq.html">FAQ</a></li>
+    </ul>
+    <ul class="nav navbar-nav navbar-right">
+      <li class="dropdown">
+        <a href="http://www.apache.org/" class="dropdown-toggle" data-toggle="dropdown">
+          Apache Software Foundation <b class="caret"></b></a>
+        <ul class="dropdown-menu">
+          <li><a href="http://www.apache.org/">Apache Homepage</a></li>
+          <li><a href="http://www.apache.org/licenses/">License</a></li>
+          <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+          <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
+          <li><a href="http://www.apache.org/security/">Security</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <!-- /.navbar-collapse -->
+</nav>
+
+
+<div class="row">
+  <div class="col-md-3 col-md-push-9">
+    <div class="news" style="margin-bottom: 20px;">
+      <h5>Latest News</h5>
+      <ul class="list-unstyled">
+        
+          <li><a href="/news/spark-wins-cloudsort-100tb-benchmark.html">Spark wins CloudSort Benchmark as the most efficient engine</a>
+          <span class="small">(Nov 15, 2016)</span></li>
+        
+          <li><a href="/news/spark-2-0-2-released.html">Spark 2.0.2 released</a>
+          <span class="small">(Nov 14, 2016)</span></li>
+        
+          <li><a href="/news/spark-1-6-3-released.html">Spark 1.6.3 released</a>
+          <span class="small">(Nov 07, 2016)</span></li>
+        
+          <li><a href="/news/spark-2-0-1-released.html">Spark 2.0.1 released</a>
+          <span class="small">(Oct 03, 2016)</span></li>
+        
+      </ul>
+      <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
+    </div>
+    <div class="hidden-xs hidden-sm">
+      <a href="/downloads.html" class="btn btn-success btn-lg btn-block" style="margin-bottom: 30px;">
+        Download Spark
+      </a>
+      <p style="font-size: 16px; font-weight: 500; color: #555;">
+        Built-in Libraries:
+      </p>
+      <ul class="list-none">
+        <li><a href="/sql/">SQL and DataFrames</a></li>
+        <li><a href="/streaming/">Spark Streaming</a></li>
+        <li><a href="/mllib/">MLlib (machine learning)</a></li>
+        <li><a href="/graphx/">GraphX (graph)</a></li>
+      </ul>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
+    </div>
+  </div>
+
+  <div class="col-md-9 col-md-pull-3">
+    <h2>Project and Product names using "Spark"</h2>
+
+<p>Organizations creating products and projects for use with Apache Spark, along with associated 
+marketing materials, should take care to respect the trademark in &#8220;Apache Spark&#8221; and its logo. 
+Please refer to http://www.apache.org/foundation/marks/ and 
+http://www.apache.org/foundation/marks/faq/ for comprehensive and authoritative guidance on 
+proper usage of ASF trademarks.</p>
+
+<p>Names that do not include &#8220;Spark&#8221; at all have no potential trademark issue with the Spark project. 
+This is recommended.</p>
+
+<p>Names like &#8220;Spark BigCoProduct&#8221; are not OK, as are names including &#8220;Spark&#8221; in general. 
+The above links, however, describe some exceptions, like for names such as &#8220;BigCoProduct, 
+powered by Apache Spark&#8221; or &#8220;BigCoProduct for Apache Spark&#8221;.</p>
+
+<p>It is common practice to create software identifiers (Maven coordinates, module names, etc.) 
+like &#8220;spark-foo&#8221;. These are permitted. Nominative use of trademarks in descriptions is also 
+always allowed, as in &#8220;BigCoProduct is a widget for Apache Spark&#8221;.</p>
+
+<h2>Companies and Organizations</h2>
+
+<p>To add yourself to the list, please email <code>dev@spark.apache.org</code> with your organization name, URL, 
+a list of which Spark components you are using, and a short description of your use case.</p>
+
+<ul>
+  <li><a href="http://amplab.cs.berkeley.edu">UC Berkeley AMPLab</a> - Big data research lab that 
+initially launched Spark
+    <ul>
+      <li>We&#8217;re building a variety of open source projects on Spark</li>
+      <li>We have both graduate students and a team of professional software engineers working on the stack</li>
+    </ul>
+  </li>
+  <li><a href="http://4quant.com">4Quant</a></li>
+  <li><a href="http://www.actnowib.com">Act Now</a>
+    <ul>
+      <li>Spark powers NOW APPS, a big data, real-time, predictive analytics platform. We use Spark SQL, 
+MLlib and GraphX components for both batch ETL and analytics applied to telecommunication data, 
+providing faster and more meaningful insights and actionable data to the operators.</li>
+    </ul>
+  </li>
+  <li><a href="http://adatao.com">Adatao, Inc.</a> - Data Intelligence for All
+    <ul>
+      <li>Visual, Real-Time, Predictive Analytics on Spark+Hadoop, with built-in support for R, Python, 
+SQL, and Natural Language.</li>
+      <li>Team of ex-Googlers and Yahoos with large-scale infrastructure experience 
+(including both flavors of MapReduce at Google and Yahoo) and PhD&#8217;s in ML/Data Mining</li>
+      <li>Determined that Spark, among the many alternatives, answered the right problem statements with 
+the right design</li>
+    </ul>
+  </li>
+  <li><a href="http://www.agilelab.it">Agile Lab</a>
+    <ul>
+      <li>enhancing big data. 360 customer view, log analysis, BI</li>
+    </ul>
+  </li>
+  <li><a href="http://www.taobao.com/">Alibaba Taobao</a>
+    <ul>
+      <li>We built one of the world&#8217;s first Spark on YARN production clusters.</li>
+      <li>See our blog posts (in Chinese) about Spark at Taobao: 
+<a href="http://rdc.taobao.org/?tag=spark">http://rdc.taobao.org/?tag=spark</a></li>
+    </ul>
+  </li>
+  <li><a href="http://alpinenow.com/">Alpine Data Labs</a></li>
+  <li><a href="http://amazon.com">Amazon</a></li>
+  <li><a href="http://www.amrita.edu/cyber/">Amrita Center for Cyber Security Systems and Networks</a></li>
+  <li><a href="http://www.art.com/">Art.com</a>
+    <ul>
+      <li>Trending analytics and personalization</li>
+    </ul>
+  </li>
+  <li><a href="http://www.asiainfo.com">AsiaInfo</a>
+    <ul>
+      <li>We are using Spark Core, Streaming, MLlib and Graphx. We leverage Spark and Hadoop ecosystem 
+to build cost effective data center solution for our customer in telco industry as well as 
+other industrial sectors.</li>
+    </ul>
+  </li>
+  <li><a href="http://www.atigeo.com">Atigeo</a> – integrated Spark in xPatterns, our big data 
+analytics platform, as a replacement for Hadoop MR</li>
+  <li><a href="https://atp.io">atp</a>
+    <ul>
+      <li>Predictive models and learning algorithms to improve the relevance of programmatic marketing.</li>
+      <li>Components used: Spark SQL, MLLib.</li>
+    </ul>
+  </li>
+  <li><a href="http://www.autodesk.com">Autodesk</a></li>
+  <li><a href="http://www.baidu.com">Baidu</a></li>
+  <li><a href="http://www.bakdata.com/">Bakdata</a> – using Spark (and Shark) to perform interactive 
+exploration of large datasets</li>
+  <li><a href="http://http//www.bigindustries.be/">Big Industries</a> - using Spark Streaming: The 
+Big Content Platform is a business-to-business content asset management service providing a 
+searchable, aggregated source of live news feeds, public domain media and archives of content.</li>
+  <li><a href="http://www.bizo.com">Bizo</a>
+    <ul>
+      <li>Check out our talk on <a href="http://www.meetup.com/spark-users/events/139804022/">Spark at Bizo</a> 
+at Spark user meetup</li>
+    </ul>
+  </li>
+  <li><a href="http://www.celtra.com">Celtra</a></li>
+  <li><a href="http://www.clearstorydata.com">ClearStory Data</a> – ClearStory&#8217;s platform and 
+integrated Data Intelligence application leverages Spark to speed analysis across internal 
+and external data sources, driving holistic and actionable insights.</li>
+  <li><a href="https://www.concur.com">Concur</a>
+    <ul>
+      <li>Spark SQL, MLlib</li>
+      <li>Using Spark for travel and expenses analytics and personalization&lt;</li>
+    </ul>
+  </li>
+  <li><a href="http://www.contentsquare.com">Content Square</a>
+    <ul>
+      <li>We use Spark to regularly read raw data, convert them into Parquet, and process them to 
+create advanced analytics dashboards: aggregation, sampling, statistics computations, 
+anomaly detection, machine learning.</li>
+    </ul>
+  </li>
+  <li><a href="http://www.conviva.com">Conviva</a> – Experience Live
+    <ul>
+      <li>See our talk at <a href="http://ampcamp.berkeley.edu/3/">AmpCamp</a> on how we are 
+<a href="http://www.youtube.com/watch?feature=player_detailpage&amp;v=YaayAatdRNs">using Spark to 
+provide real time video optimization</a></li>
+    </ul>
+  </li>
+  <li><a href="https://www.creditkarma.com/">Credit Karma</a>
+    <ul>
+      <li>We create personalized experiences using Spark.</li>
+    </ul>
+  </li>
+  <li><a href="http://databricks.com">Databricks</a>
+    <ul>
+      <li>Formed by the creators of Apache Spark and Shark, Databricks is working to greatly expand these 
+open source projects and transform big data analysis in the process. We&#8217;re deeply committed to 
+keeping all work on these systems open source.</li>
+      <li>We provided a hosted service to run Spark, 
+<a href="http://www.databricks.com/cloud">Databricks Cloud</a>, and partner to 
+<a href="http://databricks.com/support/">support Apache Spark</a> with other Hadoop and big 
+data companies.</li>
+    </ul>
+  </li>
+  <li><a href="http://dianping.com">Dianping.com</a></li>
+  <li><a href="http://www.digby.com">Digby</a></li>
+  <li><a href="http://www.drawbrid.ge/">Drawbridge</a></li>
+  <li><a href="http://www.ebay.com/">eBay Inc.</a>
+    <ul>
+      <li>Using Spark core for log transaction aggregation and analytics</li>
+    </ul>
+  </li>
+  <li><a href="http://labs.elsevier.com">Elsevier Labs</a>
+    <ul>
+      <li>Use Case: Building Machine Reading Pipeline, Knowledge Graphs, Content as a Service, Content 
+and Event Analytics, Content/Event based Predictive Models and Big Data Processing.</li>
+      <li>We use Scala and Python over Databricks Notebooks for most of our work.</li>
+    </ul>
+  </li>
+  <li><a href="http://www.eurecom.fr/en">EURECOM</a></li>
+  <li><a href="http://www.exabeam.com">Exabeam</a></li>
+  <li><a href="http://www.faimdata.com/">Faimdata</a>
+    <ul>
+      <li>Build eCommerce and data intelligence solutions to the retail industry on top of 
+Spark/Shark/Spark Streaming</li>
+    </ul>
+  </li>
+  <li><a href="http://falkonry.com">Falkonry</a></li>
+  <li><a href="http://www.flytxt.com">Flytxt</a>
+    <ul>
+      <li>Big Data analytics for subscriber profiling and personalization in telecommunications domain. 
+We are using Spark Core and MLlib.</li>
+    </ul>
+  </li>
+  <li><a href="http://www.jeremyfreeman.net">Freeman Lab at HHMI</a>
+    <ul>
+      <li>We are using Spark for analyzing and visualizing patterns in large-scale recordings of brain 
+activity in real time</li>
+    </ul>
+  </li>
+  <li><a href="http://www.fundacionctic.org">Fundacion CTIC</a></li>
+  <li><a href="http://graphflow.com">GraphFlow, Inc.</a></li>
+  <li><a href="http://www.groupon.com/app/subscriptions/new_zip?division_p=san-francisco">Groupon</a></li>
+  <li><a href="http://www.guavus.com/">Guavus</a>
+    <ul>
+      <li>Stream processing of network machine data</li>
+    </ul>
+  </li>
+  <li><a href="http://www.hitachi-solutions.com/">Hitachi Solutions</a></li>
+  <li><a href="http://hivedata.com/">The Hive</a></li>
+  <li><a href="http://www.research.ibm.com/labs/almaden/index.shtml">IBM Almaden</a></li>
+  <li><a href="http://www.infoobjects.com">InfoObjects</a>
+    <ul>
+      <li>Award winning Big Data consulting company with focus on Spark and Hadoop</li>
+    </ul>
+  </li>
+  <li><a href="http://en.inspur.com">Inspur</a></li>
+  <li><a href="http://www.sehir.edu.tr/en/">Istanbul Sehir University</a></li>
+  <li><a href="http://www.kenshoo.com/">Kenshoo</a>
+    <ul>
+      <li>Digital marketing solutions and predictive media optimization</li>
+    </ul>
+  </li>
+  <li><a href="http://www.kelkoo.co.uk">Kelkoo</a>
+    <ul>
+      <li>Using Spark Core, SQL, and Streaming. Product recommendations, BI and analytics, 
+real-time malicious activity filtering, and data mining.</li>
+    </ul>
+  </li>
+  <li><a href="http://www.knoldus.com">Knoldus Software LLC</a></li>
+  <li><a href="http://eng.localytics.com">Localytics</a>
+    <ul>
+      <li>Batch, real-time, and predictive analytics driving our mobile app analytics and marketing 
+automation product.</li>
+      <li>Components used: Spark, Spark Streaming, MLLib.</li>
+    </ul>
+  </li>
+  <li><a href="http://magine.com">Magine TV</a></li>
+  <li><a href="http://mediacrossing.com">MediaCrossing</a> – Digital Media Trading Experts in the 
+New York and Boston areas
+    <ul>
+      <li>We are using Spark as a drop-in replacement for Hadoop Map/Reduce to get the right answer 
+to our queries in a much shorter amount of time.</li>
+    </ul>
+  </li>
+  <li><a href="http://www.myfitnesspal.com/">MyFitnessPal</a>
+    <ul>
+      <li>Using Spark to clean-up user entered food data using both explicit and implicit user signals 
+with the final goal of identifying high-quality food items.</li>
+      <li>Using Spark to build different recommendation systems for recipes and foods.</li>
+    </ul>
+  </li>
+  <li><a href="http://deepspace.jpl.nasa.gov/">NASA JPL - Deep Space Network</a></li>
+  <li><a href="http://www.163.com/">Netease</a></li>
+  <li><a href="http://www.nflabs.com">NFLabs</a></li>
+  <li><a href="http://nsn.com">Nokia Solutions and Networks</a></li>
+  <li><a href="http://www.nttdata.com/global/en/">NTT DATA</a></li>
+  <li><a href="http://www.nubetech.co">Nube Technologies</a>
+    <ul>
+      <li>Nube provides solutions for data curation at scale helping customer targeting, accurate 
+inventory and efficient analysis.</li>
+    </ul>
+  </li>
+  <li><a href="http://ooyala.com">Ooyala, Inc.</a> – Powering personalized video experiences 
+across all screens
+    <ul>
+      <li>See our blog post on how we use 
+<a href="http://engineering.ooyala.com/blog/fast-spark-queries-memory-datasets">Spark for 
+Fast Queries</a></li>
+      <li>See our presentation on 
+<a href="http://www.slideshare.net/EvanChan2/cassandra2013-spark-talk-final">Cassandra, Spark, 
+and Shark</a></li>
+    </ul>
+  </li>
+  <li><a href="http://www.opentable.com/">Opentable</a>
+    <ul>
+      <li>Using Apache Spark for log processing and ETL. The data obtained feeds the recommender 
+system powered by Spark MLLIB Matrix Factorization. We are evaluating the use of Spark 
+Streaming for real-time analytics.</li>
+    </ul>
+  </li>
+  <li><a href="http://pantera.io">PanTera</a>
+    <ul>
+      <li>PanTera is a tool for exploring large datasets. It uses Spark to create XY and geographic 
+scatterplots from millions to billions of datapoints.</li>
+      <li>Components we are using: Spark Core (Scala API), Spark SQL, and GraphX</li>
+    </ul>
+  </li>
+  <li><a href="http://www.peerialism.com">Peerialism</a></li>
+  <li><a href="http://www.planbmedia.com">PlanBMedia</a></li>
+  <li><a href="http://prediction.io/">PredicitionIo</a> - PredictionIO currently offers two engine 
+templates for Apache Spark MLlib for recommendation (MLlib ALS) and classification (MLlib Naive 
+Bayes). With these templates, you can create a custom predictive engine for production deployment 
+efficiently.</li>
+  <li><a href="http://premise.com">Premise</a></li>
+  <li><a href="http://www.quantifind.com">Quantifind</a></li>
+  <li><a href="http://radius.com">Radius Intelligence</a>
+    <ul>
+      <li>Using Scala, Spark and MLLib for Radius Marketing and Sales intelligence platform including 
+data aggregation, data processing, data clustering, data analysis and predictive modeling of all 
+US businesses.</li>
+    </ul>
+  </li>
+  <li><a href="http://www.realimpactanalytics.com/">Real Impact Analytics</a>
+    <ul>
+      <li>Building large scale analytics platforms for telecoms operators</li>
+    </ul>
+  </li>
+  <li><a href="http://rocketfuel.com/">RocketFuel</a></li>
+  <li><a href="http://www.rondhuit.com/">RONDHUIT</a>
+    <ul>
+      <li>Machine Learning with Apache Mahout and Spark 
+<a href="http://www.rondhuit.com/services/training/mahout-ML.html">http://www.rondhuit.com/services/training/mahout-ML.html</a></li>
+    </ul>
+  </li>
+  <li><a href="http://www.sailthru.com/">Sailthru</a>
+    <ul>
+      <li>Uses Spark to build predictive models and recommendation systems for marketing automation 
+and personalization.</li>
+    </ul>
+  </li>
+  <li><a href="http://www.sisa.samsung.com/">Samsung Research America</a></li>
+  <li><a href="http://www.shopify.com/">Shopify</a></li>
+  <li><a href="http://www.simba.com/">Simba Technologies</a>
+    <ul>
+      <li>BI/reporting/ETL for Spark and beyond</li>
+    </ul>
+  </li>
+  <li><a href="http://www.sinnia.com">Sinnia</a></li>
+  <li><a href="http://www.sktelecom.com/en/main/index.do">SK Telecom</a>
+    <ul>
+      <li>SK Telecom analyses mobile usage patterns of customer with Spark and Shark.</li>
+    </ul>
+  </li>
+  <li><a href="http://socialmetrix.com/">Socialmetrix</a></li>
+  <li><a href="http://www.sohu.com">Sohu</a></li>
+  <li><a href="http://www.stratio.com/">Stratio</a>
+    <ul>
+      <li>Offers an open-source Big Data platform centered around Apache Spark.</li>
+    </ul>
+  </li>
+  <li><a href="https://www.taboola.com/">Taboola</a> – Powering &#8216;Content You May Like&#8217; around the web</li>
+  <li><a href="http://www.techbase.com.tr">Techbase</a></li>
+  <li><a href="http://tencent.com/">Tencent</a></li>
+  <li><a href="http://www.tetraconcepts.com/">Tetra Concepts</a></li>
+  <li><a href="http://www.trendmicro.com/us/index.html">TrendMicro</a></li>
+  <li><a href="http://engineering.tripadvisor.com/using-apache-spark-for-massively-parallel-nlp/">TripAdvisor</a></li>
+  <li><a href="http://truedash.io">truedash</a>
+    <ul>
+      <li>Automatic pulling of all your data in to Spark for enterprise visualisation, predictive 
+analytics and data exploration at a low cost.</li>
+    </ul>
+  </li>
+  <li><a href="http://www.trueffect.com">TruEffect Inc</a></li>
+  <li><a href="http://www.tuplejump.com">Tuplejump</a>
+    <ul>
+      <li>Software development partners for Apache Spark and Cassandra projects</li>
+    </ul>
+  </li>
+  <li><a href="http://www.ucsc.edu">UC Santa Cruz</a></li>
+  <li><a href="http://missouri.edu/">University of Missouri Data Analytics and Discover Lab</a></li>
+  <li><a href="http://videoamp.com/">VideoAmp</a>
+    <ul>
+      <li>Intelligent video ads for online and television viewing audiences.</li>
+    </ul>
+  </li>
+  <li><a href="http://www.vistarmedia.com">Vistar Media</a>
+    <ul>
+      <li>Location technology company enabling brands to reach on-the-go consumers</li>
+    </ul>
+  </li>
+  <li><a href="http://www.yahoo.com">Yahoo!</a></li>
+  <li><a href="http://www.yandex.com">Yandex</a>
+    <ul>
+      <li>Using Spark in 
+<a href="http://www.searchenginejournal.com/yandex-islands-markup-issues-implementation/71891/">Yandex Islands</a>, 
+to process islands identified from a search robor</li>
+    </ul>
+  </li>
+  <li><a href="http://www.zaloni.com/products/">Zaloni</a>
+    <ul>
+      <li>Zaloni&#8217;s data lake management platform (Bedrock) and self-service data preparation solution 
+(Mica) leverage Spark for fast execution of transformations and data exploration.</li>
+    </ul>
+  </li>
+</ul>
+
+
+  </div>
+</div>
+
+
+
+<footer class="small">
+  <hr>
+  Apache Spark, Spark, Apache, and the Spark logo are <a href="/trademarks.html">trademarks</a> of
+  <a href="http://www.apache.org">The Apache Software Foundation</a>.
+</footer>
+
+</div>
+
+</body>
+</html>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/research.html
+++ b/site/research.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/research.html
+++ b/site/research.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/research.html
+++ b/site/research.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/research.html
+++ b/site/research.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -584,7 +584,15 @@
 </url>
 
 <url>
+  <loc>http://spark.apache.org/committers.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>http://spark.apache.org/community.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>http://spark.apache.org/contributing.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
@@ -601,14 +609,6 @@
 </url>
 <url>
   <loc>http://spark.apache.org/faq.html</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>http://spark.apache.org/streaming/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>http://spark.apache.org/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
@@ -632,7 +632,19 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
+  <loc>http://spark.apache.org/streaming/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>http://spark.apache.org/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>http://spark.apache.org/mailing-lists.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>http://spark.apache.org/powered-by.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
@@ -640,6 +652,10 @@
   <changefreq>weekly</changefreq>
 </url>
 
+<url>
+  <loc>http://spark.apache.org/third-party-projects.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
 <url>
   <loc>http://spark.apache.org/trademarks.html</loc>
   <changefreq>weekly</changefreq>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -119,12 +119,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -317,7 +317,7 @@
     </p>
     <p>
       The Spark SQL developers welcome contributions. If you'd like to help out,
-      read <a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">how to
+      read <a href="/contributing.html">how to
       contribute to Spark</a>, and send us a patch!
     </p>
   </div>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -123,7 +123,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -101,7 +101,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -182,7 +182,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -124,7 +124,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -119,12 +119,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -123,7 +123,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -101,7 +101,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -182,7 +182,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -124,7 +124,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -294,7 +294,7 @@
     </p>
     <p>
       The Spark Streaming developers welcome contributions. If you'd like to help out,
-      read <a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">how to
+      read <a href="/contributing.html">how to
       contribute to Spark</a>, and send us a patch!
     </p>
   </div>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>
+     Third-Party Projects | Apache Spark
+    
+  </title>
+
+  
+
+  
+
+  <!-- Bootstrap core CSS -->
+  <link href="/css/cerulean.min.css" rel="stylesheet">
+  <link href="/css/custom.css" rel="stylesheet">
+
+  <!-- Code highlighter CSS -->
+  <link href="/css/pygments-default.css" rel="stylesheet">
+
+  <script type="text/javascript">
+  <!-- Google Analytics initialization -->
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-32518208-2']);
+  _gaq.push(['_trackPageview']);
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+
+  <!-- Adds slight delay to links to allow async reporting -->
+  function trackOutboundLink(link, category, action) {
+    try {
+      _gaq.push(['_trackEvent', category , action]);
+    } catch(err){}
+
+    setTimeout(function() {
+      document.location.href = link.href;
+    }, 100);
+  }
+  </script>
+
+  <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+  <!--[if lt IE 9]>
+  <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+  <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+  <![endif]-->
+</head>
+
+<body>
+
+<script src="https://code.jquery.com/jquery.js"></script>
+<script src="https://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
+<script src="/js/lang-tabs.js"></script>
+<script src="/js/downloads.js"></script>
+
+<div class="container" style="max-width: 1200px;">
+
+<div class="masthead">
+  
+    <p class="lead">
+      <a href="/">
+      <img src="/images/spark-logo-trademark.png"
+        style="height:100px; width:auto; vertical-align: bottom; margin-top: 20px;"></a><span class="tagline">
+          Lightning-fast cluster computing
+      </span>
+    </p>
+  
+</div>
+
+<nav class="navbar navbar-default" role="navigation">
+  <!-- Brand and toggle get grouped for better mobile display -->
+  <div class="navbar-header">
+    <button type="button" class="navbar-toggle" data-toggle="collapse"
+            data-target="#navbar-collapse-1">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+  </div>
+
+  <!-- Collect the nav links, forms, and other content for toggling -->
+  <div class="collapse navbar-collapse" id="navbar-collapse-1">
+    <ul class="nav navbar-nav">
+      <li><a href="/downloads.html">Download</a></li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Libraries <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/sql/">SQL and DataFrames</a></li>
+          <li><a href="/streaming/">Spark Streaming</a></li>
+          <li><a href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a href="/graphx/">GraphX (graph)</a></li>
+          <li class="divider"></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
+        </ul>
+      </li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Documentation <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/docs/latest/">Latest Release (Spark 2.0.2)</a></li>
+          <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
+        </ul>
+      </li>
+      <li><a href="/examples.html">Examples</a></li>
+      <li class="dropdown">
+        <a href="/community.html" class="dropdown-toggle" data-toggle="dropdown">
+          Community <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
+          <li><a href="/community.html#events">Events and Meetups</a></li>
+          <li><a href="/community.html#history">Project History</a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
+        </ul>
+      </li>
+      <li><a href="/faq.html">FAQ</a></li>
+    </ul>
+    <ul class="nav navbar-nav navbar-right">
+      <li class="dropdown">
+        <a href="http://www.apache.org/" class="dropdown-toggle" data-toggle="dropdown">
+          Apache Software Foundation <b class="caret"></b></a>
+        <ul class="dropdown-menu">
+          <li><a href="http://www.apache.org/">Apache Homepage</a></li>
+          <li><a href="http://www.apache.org/licenses/">License</a></li>
+          <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+          <li><a href="http://www.apache.org/foundation/thanks.html">Thanks</a></li>
+          <li><a href="http://www.apache.org/security/">Security</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <!-- /.navbar-collapse -->
+</nav>
+
+
+<div class="row">
+  <div class="col-md-3 col-md-push-9">
+    <div class="news" style="margin-bottom: 20px;">
+      <h5>Latest News</h5>
+      <ul class="list-unstyled">
+        
+          <li><a href="/news/spark-wins-cloudsort-100tb-benchmark.html">Spark wins CloudSort Benchmark as the most efficient engine</a>
+          <span class="small">(Nov 15, 2016)</span></li>
+        
+          <li><a href="/news/spark-2-0-2-released.html">Spark 2.0.2 released</a>
+          <span class="small">(Nov 14, 2016)</span></li>
+        
+          <li><a href="/news/spark-1-6-3-released.html">Spark 1.6.3 released</a>
+          <span class="small">(Nov 07, 2016)</span></li>
+        
+          <li><a href="/news/spark-2-0-1-released.html">Spark 2.0.1 released</a>
+          <span class="small">(Oct 03, 2016)</span></li>
+        
+      </ul>
+      <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
+    </div>
+    <div class="hidden-xs hidden-sm">
+      <a href="/downloads.html" class="btn btn-success btn-lg btn-block" style="margin-bottom: 30px;">
+        Download Spark
+      </a>
+      <p style="font-size: 16px; font-weight: 500; color: #555;">
+        Built-in Libraries:
+      </p>
+      <ul class="list-none">
+        <li><a href="/sql/">SQL and DataFrames</a></li>
+        <li><a href="/streaming/">Spark Streaming</a></li>
+        <li><a href="/mllib/">MLlib (machine learning)</a></li>
+        <li><a href="/graphx/">GraphX (graph)</a></li>
+      </ul>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
+    </div>
+  </div>
+
+  <div class="col-md-9 col-md-pull-3">
+    <p>This page tracks external software projects that supplement Apache Spark and add to its ecosystem.</p>
+
+<h2>spark-packages.org</h2>
+
+<p><a href="https://spark-packages.org/">spark-packages.org</a>&lt;/strong&gt; is an external, 
+community-managed list of third-party libraries, add-ons, and applications that work with 
+Apache Spark. You can add a package as long as you have a GitHub repository.</p>
+
+<h2>Infrastructure Projects</h2>
+
+<ul>
+  <li><a href="https://github.com/spark-jobserver/spark-jobserver">Spark Job Server</a> - 
+REST interface for managing and submitting Spark jobs on the same cluster 
+(see <a href="http://engineering.ooyala.com/blog/open-sourcing-our-spark-job-server">blog post</a> 
+for details)</li>
+  <li><a href="https://github.com/amplab-extras/SparkR-pkg">SparkR</a> - R frontend for Spark</li>
+  <li><a href="http://mlbase.org/">MLbase</a> - Machine Learning research project on top of Spark</li>
+  <li><a href="http://mesos.apache.org/">Apache Mesos</a> - Cluster management system that supports 
+running Spark</li>
+  <li><a href="http://alluxio.org/">Alluxio</a> (née Tachyon) - Memory speed virtual distributed 
+storage system that supports running Spark</li>
+  <li><a href="https://github.com/datastax/spark-cassandra-connector">Spark Cassandra Connector</a> - 
+Easily load your Cassandra data into Spark and Spark SQL; from Datastax</li>
+  <li><a href="http://github.com/tuplejump/FiloDB">FiloDB</a> - a Spark integrated analytical/columnar 
+database, with in-memory option capable of sub-second concurrent queries</li>
+  <li><a href="http://www.elasticsearch.org/guide/en/elasticsearch/hadoop/master/spark.html#spark-sql">ElasticSearch - 
+Spark SQL</a> Integration</li>
+  <li><a href="https://github.com/tresata/spark-scalding">Spark-Scalding</a> - Easily transition 
+Cascading/Scalding code to Spark</li>
+  <li><a href="http://zeppelin-project.org/">Zeppelin</a> - an IPython-like notebook for Spark. There 
+is also <a href="https://github.com/tribbloid/ISpark">ISpark</a>, and the 
+<a href="https://github.com/andypetrella/spark-notebook/">Spark Notebook</a>.</li>
+  <li><a href="http://www.ibm.com/developerworks/servicemanagement/tc/pcs/index.html">IBM Spectrum Conductor with Spark</a> - 
+cluster management software that integrates with Spark</li>
+  <li><a href="https://github.com/EclairJS/eclairjs-node">EclairJS</a> - enables Node.js developers to code
+against Spark, and data scientists to use Javascript in Jupyter notebooks.</li>
+  <li><a href="https://github.com/SnappyDataInc/snappydata">SnappyData</a> - an open source 
+OLTP + OLAP database integrated with Spark on the same JVMs.</li>
+  <li><a href="https://github.com/DataSystemsLab/GeoSpark">GeoSpark</a> - Geospatial RDDs and joins</li>
+  <li><a href="https://github.com/ispras/spark-openstack">Spark Cluster Deploy Tools for OpenStack</a></li>
+</ul>
+
+<h2>Applications Using Spark</h2>
+
+<ul>
+  <li><a href="http://mahout.apache.org/">Apache Mahout</a> - Previously on Hadoop MapReduce, 
+Mahout has switched to using Spark as the backend</li>
+  <li><a href="https://wiki.apache.org/mrql/">Apache MRQL</a> - A query processing and optimization 
+system for large-scale, distributed data analysis, built on top of Apache Hadoop, Hama, and Spark</li>
+  <li><a href="http://blinkdb.org/">BlinkDB</a> - a massively parallel, approximate query engine built 
+on top of Shark and Spark</li>
+  <li><a href="https://github.com/adobe-research/spindle">Spindle</a> - Spark/Parquet-based web 
+analytics query engine</li>
+  <li><a href="http://simin.me/projects/spatialspark/">Spark Spatial</a> - Spatial joins and 
+processing for Spark</li>
+  <li><a href="https://github.com/thunderain-project/thunderain">Thunderain</a> - a framework 
+for combining stream processing with historical data, think Lambda architecture</li>
+  <li><a href="https://github.com/AyasdiOpenSource/df">DF</a> from Ayasdi - a Pandas-like data frame 
+implementation for Spark</li>
+  <li><a href="https://github.com/OryxProject/oryx">Oryx</a> -  Lambda architecture on Apache Spark, 
+Apache Kafka for real-time large scale machine learning</li>
+  <li><a href="https://github.com/bigdatagenomics/adam">ADAM</a> - A framework and CLI for loading, 
+transforming, and analyzing genomic data using Apache Spark</li>
+</ul>
+
+<h2>Additional Language Bindings</h2>
+
+<h3>C# / .NET</h3>
+
+<ul>
+  <li><a href="https://github.com/Microsoft/SparkCLR">CLR for Spark</a></li>
+</ul>
+
+<h3>Clojure</h3>
+
+<ul>
+  <li><a href="https://github.com/TheClimateCorporation/clj-spark">clj-spark</a></li>
+  <li><a href="http://spark-packages.org/package/21">Sparkling</a></li>
+</ul>
+
+<h3>Groovy</h3>
+
+<ul>
+  <li><a href="https://github.com/bunions1/groovy-spark-example">groovy-spark-example</a></li>
+</ul>
+
+  </div>
+</div>
+
+
+
+<footer class="small">
+  <hr>
+  Apache Spark, Spark, Apache, and the Spark logo are <a href="/trademarks.html">trademarks</a> of
+  <a href="http://www.apache.org">The Apache Software Foundation</a>.
+</footer>
+
+</div>
+
+</body>
+</html>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -188,7 +188,7 @@
 
 <h2>spark-packages.org</h2>
 
-<p><a href="https://spark-packages.org/">spark-packages.org</a>&lt;/strong&gt; is an external, 
+<p><a href="https://spark-packages.org/">spark-packages.org</a> is an external, 
 community-managed list of third-party libraries, add-ons, and applications that work with 
 Apache Spark. You can add a package as long as you have a GitHub repository.</p>
 

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -121,7 +121,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
         </ul>
       </li>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -98,7 +98,7 @@
           <li><a href="/mllib/">MLlib (machine learning)</a></li>
           <li><a href="/graphx/">GraphX (graph)</a></li>
           <li class="divider"></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -179,7 +179,7 @@
         <li><a href="/mllib/">MLlib (machine learning)</a></li>
         <li><a href="/graphx/">GraphX (graph)</a></li>
       </ul>
-      <a href="https://cwiki.apache.org/confluence/display/SPARK/Third+Party+Projects">Third-Party Packages</a>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
     </div>
   </div>
 

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -120,7 +120,7 @@
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
-          <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Committers">Project Committers</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -116,12 +116,13 @@
           Community <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/community.html">Mailing Lists</a></li>
+          <li><a href="/community.html#mailing-lists">Mailing Lists</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/community.html#events">Events and Meetups</a></li>
           <li><a href="/community.html#history">Project History</a></li>
           <li><a href="https://cwiki.apache.org/confluence/display/SPARK/Powered+By+Spark">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
-          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
         </ul>
       </li>
       <li><a href="/faq.html">FAQ</a></li>

--- a/sql/index.md
+++ b/sql/index.md
@@ -139,7 +139,7 @@ subproject: SQL
     </p>
     <p>
       The Spark SQL developers welcome contributions. If you'd like to help out,
-      read <a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">how to
+      read <a href="{{site.baseurl}}/contributing.html">how to
       contribute to Spark</a>, and send us a patch!
     </p>
   </div>

--- a/streaming/index.md
+++ b/streaming/index.md
@@ -117,7 +117,7 @@ subproject: Streaming
     </p>
     <p>
       The Spark Streaming developers welcome contributions. If you'd like to help out,
-      read <a href="https://cwiki.apache.org/confluence/display/SPARK/Contributing+to+Spark">how to
+      read <a href="{{site.baseurl}}/contributing.html">how to
       contribute to Spark</a>, and send us a patch!
     </p>
   </div>

--- a/third-party-projects.md
+++ b/third-party-projects.md
@@ -11,7 +11,7 @@ This page tracks external software projects that supplement Apache Spark and add
 
 <h2>spark-packages.org</h2>
 
-<a href="https://spark-packages.org/">spark-packages.org</a></strong> is an external, 
+<a href="https://spark-packages.org/">spark-packages.org</a> is an external, 
 community-managed list of third-party libraries, add-ons, and applications that work with 
 Apache Spark. You can add a package as long as you have a GitHub repository.
 

--- a/third-party-projects.md
+++ b/third-party-projects.md
@@ -1,0 +1,84 @@
+---
+layout: global
+title: Third-Party Projects
+type: "page singular"
+navigation:
+  weight: 5
+  show: true
+---
+
+This page tracks external software projects that supplement Apache Spark and add to its ecosystem.
+
+<h2>spark-packages.org</h2>
+
+<a href="https://spark-packages.org/">spark-packages.org</a></strong> is an external, 
+community-managed list of third-party libraries, add-ons, and applications that work with 
+Apache Spark. You can add a package as long as you have a GitHub repository.
+
+<h2>Infrastructure Projects</h2>
+
+- <a href="https://github.com/spark-jobserver/spark-jobserver">Spark Job Server</a> - 
+REST interface for managing and submitting Spark jobs on the same cluster 
+(see <a href="http://engineering.ooyala.com/blog/open-sourcing-our-spark-job-server">blog post</a> 
+for details)
+- <a href="https://github.com/amplab-extras/SparkR-pkg">SparkR</a> - R frontend for Spark
+- <a href="http://mlbase.org/">MLbase</a> - Machine Learning research project on top of Spark
+- <a href="http://mesos.apache.org/">Apache Mesos</a> - Cluster management system that supports 
+running Spark
+- <a href="http://alluxio.org/">Alluxio</a> (née Tachyon) - Memory speed virtual distributed 
+storage system that supports running Spark    
+- <a href="https://github.com/datastax/spark-cassandra-connector">Spark Cassandra Connector</a> - 
+Easily load your Cassandra data into Spark and Spark SQL; from Datastax
+- <a href="http://github.com/tuplejump/FiloDB">FiloDB</a> - a Spark integrated analytical/columnar 
+database, with in-memory option capable of sub-second concurrent queries
+- <a href="http://www.elasticsearch.org/guide/en/elasticsearch/hadoop/master/spark.html#spark-sql">ElasticSearch - 
+Spark SQL</a> Integration
+- <a href="https://github.com/tresata/spark-scalding">Spark-Scalding</a> - Easily transition 
+Cascading/Scalding code to Spark
+- <a href="http://zeppelin-project.org/">Zeppelin</a> - an IPython-like notebook for Spark. There 
+is also <a href="https://github.com/tribbloid/ISpark">ISpark</a>, and the 
+<a href="https://github.com/andypetrella/spark-notebook/">Spark Notebook</a>.
+- <a href="http://www.ibm.com/developerworks/servicemanagement/tc/pcs/index.html">IBM Spectrum Conductor with Spark</a> - 
+cluster management software that integrates with Spark
+- <a href="https://github.com/EclairJS/eclairjs-node">EclairJS</a> - enables Node.js developers to code
+against Spark, and data scientists to use Javascript in Jupyter notebooks.
+- <a href="https://github.com/SnappyDataInc/snappydata">SnappyData</a> - an open source 
+OLTP + OLAP database integrated with Spark on the same JVMs.
+- <a href="https://github.com/DataSystemsLab/GeoSpark">GeoSpark</a> - Geospatial RDDs and joins
+- <a href="https://github.com/ispras/spark-openstack">Spark Cluster Deploy Tools for OpenStack</a>
+
+<h2>Applications Using Spark</h2>
+
+- <a href="http://mahout.apache.org/">Apache Mahout</a> - Previously on Hadoop MapReduce, 
+Mahout has switched to using Spark as the backend
+- <a href="https://wiki.apache.org/mrql/">Apache MRQL</a> - A query processing and optimization 
+system for large-scale, distributed data analysis, built on top of Apache Hadoop, Hama, and Spark
+- <a href="http://blinkdb.org/">BlinkDB</a> - a massively parallel, approximate query engine built 
+on top of Shark and Spark
+- <a href="https://github.com/adobe-research/spindle">Spindle</a> - Spark/Parquet-based web 
+analytics query engine
+- <a href="http://simin.me/projects/spatialspark/">Spark Spatial</a> - Spatial joins and 
+processing for Spark
+- <a href="https://github.com/thunderain-project/thunderain">Thunderain</a> - a framework 
+for combining stream processing with historical data, think Lambda architecture
+- <a href="https://github.com/AyasdiOpenSource/df">DF</a> from Ayasdi - a Pandas-like data frame 
+implementation for Spark
+- <a href="https://github.com/OryxProject/oryx">Oryx</a> -  Lambda architecture on Apache Spark, 
+Apache Kafka for real-time large scale machine learning
+- <a href="https://github.com/bigdatagenomics/adam">ADAM</a> - A framework and CLI for loading, 
+transforming, and analyzing genomic data using Apache Spark
+
+<h2>Additional Language Bindings</h2>
+
+<h3>C# / .NET</h3>
+
+- <a href="https://github.com/Microsoft/SparkCLR">CLR for Spark</a>
+
+<h3>Clojure</h3>
+
+- <a href="https://github.com/TheClimateCorporation/clj-spark">clj-spark</a>
+- <a href="http://spark-packages.org/package/21">Sparkling</a>
+
+<h3>Groovy</h3>
+
+- <a href="https://github.com/bunions1/groovy-spark-example">groovy-spark-example</a>


### PR DESCRIPTION
I will likely break this up into several stages to keep this from potentially losing changes when the wiki is updated. 

Pay attention to the `.md` changes; the HTML changes are just changes in the resulting rendering. I have tried to break up the ports of pages into the markdown change, and resulting HTML change, for convenience.