### PR TITLE
Add chat rooms to community links

### DIFF
--- a/community.md
+++ b/community.md
@@ -72,6 +72,16 @@ Some quick tips when using email:
 and include only a few lines of the pertinent code / log within the email.
 - No jobs, sales, or solicitation is permitted on the Apache Spark mailing lists.
 
+<a name="chat"></a>
+<h4>Chat Rooms</h4>
+
+Chat rooms are great for quick questions or discussions on specialized topics. The following chat rooms are not officially part of Apache Spark; they are provided for reference only.
+<ul>
+  <li>
+    <a href="https://gitter.im/spark-scala/Lobby">Spark with Scala</a> is for questions and discussions related to using Spark with the Scala programming language.
+  </li>
+</ul>
+
 <a name="events"></a>
 <h3>Events and Meetups</h3>
 

--- a/site/community.html
+++ b/site/community.html
@@ -262,6 +262,16 @@ and include only a few lines of the pertinent code / log within the email.</li>
   <li>No jobs, sales, or solicitation is permitted on the Apache Spark mailing lists.</li>
 </ul>
 
+<p><a name="chat"></a></p>
+<h4>Chat Rooms</h4>
+
+<p>Chat rooms are great for quick questions or discussions on specialized topics. The following chat rooms are not officially part of Apache Spark; they are provided for reference only.</p>
+<ul>
+  <li>
+    <a href="https://gitter.im/spark-scala/Lobby">Spark with Scala</a> is for questions and discussions related to using Spark with the Scala programming language.
+  </li>
+</ul>
+
 <p><a name="events"></a></p>
 <h3>Events and Meetups</h3>
 


### PR DESCRIPTION
We've had quite some activity on the spark-with-scala Gitter channel, although it was only advertised once in an email thread. Adding it to the community page would help in making it more visible.

I went ahead and put together a template for links to chat rooms, let me know if there are any others and I'll add them to the list.