### PR TITLE
Correct typo: cyclic -> acyclic

### DIFF
--- a/index.md
+++ b/index.md
@@ -24,7 +24,7 @@ navigation:
     </p>
 
     <p>
-      Apache Spark has an advanced DAG execution engine that supports cyclic data flow and
+      Apache Spark has an advanced DAG execution engine that supports acyclic data flow and
       in-memory computing.
     </p>
   </div>

--- a/site/index.html
+++ b/site/index.html
@@ -208,7 +208,7 @@
     </p>
 
     <p>
-      Apache Spark has an advanced DAG execution engine that supports cyclic data flow and
+      Apache Spark has an advanced DAG execution engine that supports acyclic data flow and
       in-memory computing.
     </p>
   </div>


### PR DESCRIPTION
`jekyll build` changed a huge number of files unrelated to my change, so I opted to just directly edit the Markdown and corresponding HTML.

I couldn't find any other instances of this typo. (Lots of stuff under `site/` did mention "cyclic" though, but it was unrelated.)

cc @srowen 