### PR TITLE
Fix latest master build url

### DIFF
--- a/developer-tools.md
+++ b/developer-tools.md
@@ -301,7 +301,7 @@ incorporated into a maintenance release. These should only be used by Spark deve
 may have bugs and have not undergone the same level of testing as releases. Spark nightly packages 
 are available at:
 
-- Latest master build: <a href="http://people.apache.org/~pwendell/spark-nightly/spark-master-bin/latest">http://people.apache.org/~pwendell/spark-nightly/spark-master-bin/latest</a>
+- Latest master build: <a href="http://people.apache.org/~pwendell/spark-nightly/spark-master-bin/">http://people.apache.org/~pwendell/spark-nightly/spark-master-bin/</a>
 - All nightly builds: <a href="http://people.apache.org/~pwendell/spark-nightly/">http://people.apache.org/~pwendell/spark-nightly/</a>
 
 Spark also publishes SNAPSHOT releases of its Maven artifacts for both master and maintenance 

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -482,7 +482,7 @@ may have bugs and have not undergone the same level of testing as releases. Spar
 are available at:</p>
 
 <ul>
-  <li>Latest master build: <a href="http://people.apache.org/~pwendell/spark-nightly/spark-master-bin/latest">http://people.apache.org/~pwendell/spark-nightly/spark-master-bin/latest</a></li>
+  <li>Latest master build: <a href="http://people.apache.org/~pwendell/spark-nightly/spark-master-bin/">http://people.apache.org/~pwendell/spark-nightly/spark-master-bin/</a></li>
   <li>All nightly builds: <a href="http://people.apache.org/~pwendell/spark-nightly/">http://people.apache.org/~pwendell/spark-nightly/</a></li>
 </ul>
 


### PR DESCRIPTION
The PR removes `latest` at the end of the latest SNAPSHOT URL.
This is tested by manually with `jekyll serve`.