### PR TITLE
Add a note for searching PySpark and SparkR version changes in release-process.md

### DIFF
--- a/release-process.md
+++ b/release-process.md
@@ -46,6 +46,8 @@ Maven when cutting the release. Note that there are a few exceptions that should
 - **Spark REPLs**. Look for the Spark ASCII art in `SparkILoopInit.scala` for the Scala shell 
 and in `shell.py` for the Python REPL.
 - **Docs**. Search for VERSION in `docs/_config.yml`
+- **PySpark**. Search for `__version__` in `python/pyspark/version.py`
+- **SparkR**. Search for `Version` in `R/pkg/DESCRIPTION`
 
 Finally, update `CHANGES.txt` with this script in the Spark repository. `CHANGES.txt` captures 
 all the patches that have made it into this release candidate since the last release.

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -245,6 +245,8 @@ Maven when cutting the release. Note that there are a few exceptions that should
   <li><strong>Spark REPLs</strong>. Look for the Spark ASCII art in <code>SparkILoopInit.scala</code> for the Scala shell 
 and in <code>shell.py</code> for the Python REPL.</li>
   <li><strong>Docs</strong>. Search for VERSION in <code>docs/_config.yml</code></li>
+  <li><strong>PySpark</strong>. Search for <code>__version__</code> in <code>python/pyspark/version.py</code></li>
+  <li><strong>SparkR</strong>. Search for <code>Version</code> in <code>R/pkg/DESCRIPTION</code></li>
 </ul>
 
 <p>Finally, update <code>CHANGES.txt</code> with this script in the Spark repository. <code>CHANGES.txt</code> captures 


### PR DESCRIPTION
This PR adds a note for searching PySpark and SparkR version changes in release-process.md. Please refer the related PR - https://github.com/apache/spark/pull/18341.