### PR TITLE
Add .DS_Store in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+.DS_Store


### PR DESCRIPTION
This PR proposes to add `.DS_Store` into `.gitignore`. I usually open via Finder in my Mac and check HTMLs and it sometimes creates this file.