### PR TITLE
Adds AppVeyor and additional information for Jenkins in "Pull Request" at the contributing guide

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -295,8 +295,12 @@ with a link to the full results on Jenkins.
      1. Fixes can simply be pushed to the same branch from which you opened your pull request
      1. Jenkins will automatically re-test when new commits are pushed
      1. If the tests failed for reasons unrelated to the change (e.g. Jenkins outage), then a 
-     committer can request a re-test with "Jenkins, retest this please". 
-     Ask if you need a test restarted.
+     committer can request a re-test with "Jenkins, retest this please".
+     Ask if you need a test restarted. If you were added by "Jenkins, add to whitelist" from a
+     committer before, you can also request the re-test.
+1. If there is a change related to SparkR in your pull request, AppVeyor will be triggered
+automatically to test SparkR on Windows, which takes roughly an hour. Similarly to the steps
+above, fix failures and push new commits which will request the re-test in AppVeyor.
 
 <h3>The Review Process</h3>
 

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -526,10 +526,14 @@ with a link to the full results on Jenkins.</li>
       <li>Fixes can simply be pushed to the same branch from which you opened your pull request</li>
       <li>Jenkins will automatically re-test when new commits are pushed</li>
       <li>If the tests failed for reasons unrelated to the change (e.g. Jenkins outage), then a 
-  committer can request a re-test with &#8220;Jenkins, retest this please&#8221;. 
-  Ask if you need a test restarted.</li>
+  committer can request a re-test with &#8220;Jenkins, retest this please&#8221;.
+  Ask if you need a test restarted. If you were added by &#8220;Jenkins, add to whitelist&#8221; from a
+  committer before, you can also request the re-test.</li>
     </ol>
   </li>
+  <li>If there is a change related to SparkR in your pull request, AppVeyor will be triggered
+automatically to test SparkR on Windows, which takes roughly an hour. Similarly to the steps
+above, fix failures and push new commits which will request the re-test in AppVeyor.</li>
 </ol>
 
 <h3>The Review Process</h3>


### PR DESCRIPTION
This PR proposes to describe AppVeyor with SparkR and some more information related with Jenkins about triggering the test.

I have seen few guys confused about this before:

As a reference for the former - `https://github.com/apache/spark/pull/18164#issuecomment-305734419`
As a reference for the latter - `https://github.com/apache/spark/pull/18444#issuecomment-312468983`

I was also confused when I started to contribute on Spark few years ago. 
