### PR TITLE
Fixes git command and description for resolving conflicts in the contributing guide

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -311,9 +311,10 @@ looked at this thoroughly and take as much ownership as if I wrote the patch mys
 comment LGTM you will be expected to help with bugs or follow-up issues on the patch. Consistent, 
 judicious use of LGTMs is a great way to gain credibility as a reviewer with the broader community.
 - Sometimes, other changes will be merged which conflict with your pull request's changes. The 
-PR can't be merged until the conflict is resolved. This can be resolved with `git fetch origin` 
-followed by `git merge origin/master` and resolving the conflicts by hand, then pushing the result 
-to your branch.
+PR can't be merged until the conflict is resolved. This can be resolved by, for example, adding a remote
+to keep up with upstream changes by `git remote add upstream https://github.com/apache/spark.git`,
+running `git fetch upstream` followed by `git rebase upstream/master` and resolving the conflicts by hand,
+then pushing the result to your branch.
 - Try to be responsive to the discussion rather than let days pass between replies
 
 <h3>Closing Your Pull Request / JIRA</h3>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -546,9 +546,10 @@ looked at this thoroughly and take as much ownership as if I wrote the patch mys
 comment LGTM you will be expected to help with bugs or follow-up issues on the patch. Consistent, 
 judicious use of LGTMs is a great way to gain credibility as a reviewer with the broader community.</li>
   <li>Sometimes, other changes will be merged which conflict with your pull request&#8217;s changes. The 
-PR can&#8217;t be merged until the conflict is resolved. This can be resolved with <code>git fetch origin</code> 
-followed by <code>git merge origin/master</code> and resolving the conflicts by hand, then pushing the result 
-to your branch.</li>
+PR can&#8217;t be merged until the conflict is resolved. This can be resolved by, for example, adding a remote
+to keep up with upstream changes by <code>git remote add upstream https://github.com/apache/spark.git</code>,
+running <code>git fetch upstream</code> followed by <code>git rebase upstream/master</code> and resolving the conflicts by hand,
+then pushing the result to your branch.</li>
   <li>Try to be responsive to the discussion rather than let days pass between replies</li>
 </ul>
 


### PR DESCRIPTION
This PR proposes to fix git command and description for resolving conflicts.

I tried to follow the guide but I ended up with the below:

![2017-07-25 12 41 19](https://user-images.githubusercontent.com/6477701/28557500-c335033a-7147-11e7-9a1d-11715b51c870.png)

Also, this PR rather promotes rebasing, not merging which might trigger SparkR build on AppVeyor as the merged one possibly includes changes in R.

