### PR TITLE
Add a reference to the Julia binding to the Spark website

### DIFF
--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -280,6 +280,12 @@ transforming, and analyzing genomic data using Apache Spark</li>
   <li><a href="https://github.com/bunions1/groovy-spark-example">groovy-spark-example</a></li>
 </ul>
 
+<h3>Julia</h3>
+
+<ul>
+  <li><a href="https://github.com/dfdx/Spark.jl">Spark.jl</a></li>
+</ul>
+
   </div>
 </div>
 

--- a/third-party-projects.md
+++ b/third-party-projects.md
@@ -82,3 +82,7 @@ transforming, and analyzing genomic data using Apache Spark
 <h3>Groovy</h3>
 
 - <a href="https://github.com/bunions1/groovy-spark-example">groovy-spark-example</a>
+
+<h3>Julia</h3>
+
+- <a href="https://github.com/dfdx/Spark.jl">Spark.jl</a>


### PR DESCRIPTION
There is now a Julia interface to Spark that is reasonably mature. It'd be great to get that listed here. 

cc: @dfdx
