### PR TITLE
Reduce generated HTML differences

### DIFF
--- a/committers.md
+++ b/committers.md
@@ -156,6 +156,7 @@ The trade off when backporting is you get to deliver the fix to people running o
 The decision point is when you have a bug fix and it's not clear whether it is worth backporting.
 
 I think the following facets are important to consider:
+
 - Backports are an extremely valuable service to the community and should be considered for 
 any bug fix.
 - Introducing a new bug in a maintenance release must be avoided at all costs. It over time would 
@@ -163,11 +164,13 @@ erode confidence in our release process.
 - Distributions or advanced users can always backport risky patches on their own, if they see fit.
 
 For me, the consequence of these is that we should backport in the following situations:
+
 - Both the bug and the fix are well understood and isolated. Code being modified is well tested.
 - The bug being addressed is high priority to the community.
 - The backported fix does not vary widely from the master branch fix.
 
 We tend to avoid backports in the converse situations:
+
 - The bug or fix are not well understood. For instance, it relates to interactions between complex 
 components or third party libraries (e.g. Hadoop libraries). The code is not well tested outside 
 of the immediate bug being fixed.

--- a/contributing.md
+++ b/contributing.md
@@ -449,6 +449,7 @@ For inline comment with the code, use `//` and not `/*  .. */`.
 Always import packages using absolute paths (e.g. `scala.util.Random`) instead of relative ones 
 (e.g. `util.Random`). In addition, sort imports in the following order 
 (use alphabetical order within each group):
+
 - `java.*` and `javax.*`
 - `scala.*`
 - Third-party libraries (`org.*`, `com.*`, etc)

--- a/security.md
+++ b/security.md
@@ -42,6 +42,7 @@ Mitigation:
 Update to Apache Spark 2.1.2, 2.2.0 or later.
 
 Credit:
+
 - Aditya Sharad, Semmle
 
 <h3 id="CVE-2017-7678">CVE-2017-7678 Apache Spark XSS web UI MHTML vulnerability</h3>
@@ -63,6 +64,7 @@ Update to Apache Spark 2.1.2, 2.2.0 or later.
 
 Example:
 Request:
+
 ```
 GET /app/?appId=Content-Type:%20multipart/related;%20boundary=_AppScan%0d%0a--
 _AppScan%0d%0aContent-Location:foo%0d%0aContent-Transfer-
@@ -71,6 +73,7 @@ HTTP/1.1
 ```
 
 Excerpt from response:
+
 ```
 <div class="row-fluid">No running application with ID Content-Type: multipart/related;
 boundary=_AppScan
@@ -80,11 +83,14 @@ Content-Transfer-Encoding:base64
 PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
 </div>
 ```
+
 Result: In the above payload the BASE64 data decodes as:
+
 ```
 <html><script>alert("XSS")</script></html>
 ```
 
 Credit:
+
 - Mike Kasper, Nicholas Marion
 - IBM z Systems Center for Secure Engineering

--- a/site/committers.html
+++ b/site/committers.html
@@ -516,6 +516,7 @@ follow-up can be well communicated to all Spark developers.
 The decision point is when you have a bug fix and it&#8217;s not clear whether it is worth backporting.</p>
 
 <p>I think the following facets are important to consider:</p>
+
 <ul>
   <li>Backports are an extremely valuable service to the community and should be considered for 
 any bug fix.</li>
@@ -525,6 +526,7 @@ erode confidence in our release process.</li>
 </ul>
 
 <p>For me, the consequence of these is that we should backport in the following situations:</p>
+
 <ul>
   <li>Both the bug and the fix are well understood and isolated. Code being modified is well tested.</li>
   <li>The bug being addressed is high priority to the community.</li>
@@ -532,6 +534,7 @@ erode confidence in our release process.</li>
 </ul>
 
 <p>We tend to avoid backports in the converse situations:</p>
+
 <ul>
   <li>The bug or fix are not well understood. For instance, it relates to interactions between complex 
 components or third party libraries (e.g. Hadoop libraries). The code is not well tested outside 

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -692,6 +692,7 @@ instead of Scala docs style.</p>
 <p>Always import packages using absolute paths (e.g. <code>scala.util.Random</code>) instead of relative ones 
 (e.g. <code>util.Random</code>). In addition, sort imports in the following order 
 (use alphabetical order within each group):</p>
+
 <ul>
   <li><code>java.*</code> and <code>javax.*</code></li>
   <li><code>scala.*</code></li>

--- a/site/security.html
+++ b/site/security.html
@@ -229,6 +229,7 @@ later.</p>
 Update to Apache Spark 2.1.2, 2.2.0 or later.</p>
 
 <p>Credit:</p>
+
 <ul>
   <li>Aditya Sharad, Semmle</li>
 </ul>
@@ -252,6 +253,7 @@ Update to Apache Spark 2.1.2, 2.2.0 or later.</p>
 
 <p>Example:
 Request:</p>
+
 <pre><code>GET /app/?appId=Content-Type:%20multipart/related;%20boundary=_AppScan%0d%0a--
 _AppScan%0d%0aContent-Location:foo%0d%0aContent-Transfer-
 Encoding:base64%0d%0a%0d%0aPGh0bWw%2bPHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw%2b%0d%0a
@@ -259,6 +261,7 @@ HTTP/1.1
 </code></pre>
 
 <p>Excerpt from response:</p>
+
 <pre><code>&lt;div class="row-fluid"&gt;No running application with ID Content-Type: multipart/related;
 boundary=_AppScan
 --_AppScan
@@ -267,11 +270,14 @@ Content-Transfer-Encoding:base64
 PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
 &lt;/div&gt;
 </code></pre>
+
 <p>Result: In the above payload the BASE64 data decodes as:</p>
+
 <pre><code>&lt;html&gt;&lt;script&gt;alert("XSS")&lt;/script&gt;&lt;/html&gt;
 </code></pre>
 
 <p>Credit:</p>
+
 <ul>
   <li>Mike Kasper, Nicholas Marion</li>
   <li>IBM z Systems Center for Secure Engineering</li>


### PR DESCRIPTION
This PR proposes to reduce diff of generated HTMLs. I use Jekyll 3.3.1 but It always produces different generated HTML with `site/...`.

The diff breaks rendering, for example:

**Expected:**

<img width="576" alt="2017-10-28 7 38 24" src="https://user-images.githubusercontent.com/6477701/32133650-ac57a99a-bc17-11e7-81d3-4bf88d83e6c1.png">


**Actual:**

<img width="879" alt="2017-10-28 7 37 34" src="https://user-images.githubusercontent.com/6477701/32133651-ae2d2d58-bc17-11e7-91c6-81b27eb61e4d.png">


There are still some diff but I could at least identify other instances I am sure of - newline related issue.

Up to my knowledge, newline between text and item list, and between text and code block is more correct. 
(^, sorry, I can't find the reference but I somehow know this. Please correct me if I was wrong.)
I am aware of this issue for few other md -> html tools.

So, this change adds each newline for those md texts generating broken HTMLs.

I manually double checked the HTML output is the same by `jekyll serve --watch`.

