### PR TITLE
[SPARK-22525] Fix web download javascript

### DIFF
--- a/js/downloads.js
+++ b/js/downloads.js
@@ -99,6 +99,14 @@ function initReleaseNotes() {
   }
 }
 
+function onPackageSelect() {
+  var packageSelect = document.getElementById("sparkPackageSelect");
+
+  var pkg = getSelectedValue(packageSelect);
+
+  updateDownloadLink();
+}
+
 function onVersionSelect() {
   var versionSelect = document.getElementById("sparkVersionSelect");
   var packageSelect = document.getElementById("sparkPackageSelect");

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -99,6 +99,14 @@ function initReleaseNotes() {
   }
 }
 
+function onPackageSelect() {
+  var packageSelect = document.getElementById("sparkPackageSelect");
+
+  var pkg = getSelectedValue(packageSelect);
+
+  updateDownloadLink();
+}
+
 function onVersionSelect() {
   var versionSelect = document.getElementById("sparkVersionSelect");
   var packageSelect = document.getElementById("sparkPackageSelect");


### PR DESCRIPTION
Right now we don't process the package selection (e.g. which version of hadoop the user wants to download for). Restore the `onPackageSelect` function.