### PR TITLE
Remove SparkR from 3rd party project list

### DIFF
--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -209,7 +209,6 @@ Apache Spark. You can add a package as long as you have a GitHub repository.</p>
 REST interface for managing and submitting Spark jobs on the same cluster 
 (see <a href="http://engineering.ooyala.com/blog/open-sourcing-our-spark-job-server">blog post</a> 
 for details)</li>
-  <li><a href="https://github.com/amplab-extras/SparkR-pkg">SparkR</a> - R frontend for Spark</li>
   <li><a href="http://mlbase.org/">MLbase</a> - Machine Learning research project on top of Spark</li>
   <li><a href="https://mesos.apache.org/">Apache Mesos</a> - Cluster management system that supports 
 running Spark</li>

--- a/third-party-projects.md
+++ b/third-party-projects.md
@@ -21,7 +21,6 @@ Apache Spark. You can add a package as long as you have a GitHub repository.
 REST interface for managing and submitting Spark jobs on the same cluster 
 (see <a href="http://engineering.ooyala.com/blog/open-sourcing-our-spark-job-server">blog post</a> 
 for details)
-- <a href="https://github.com/amplab-extras/SparkR-pkg">SparkR</a> - R frontend for Spark
 - <a href="http://mlbase.org/">MLbase</a> - Machine Learning research project on top of Spark
 - <a href="https://mesos.apache.org/">Apache Mesos</a> - Cluster management system that supports 
 running Spark


### PR DESCRIPTION
Since SparkR is a part of Apache Spark, this PR removes the old link from 3rd party project list.