### PR TITLE
Change company to Oath from Yahoo

### DIFF
--- a/committers.md
+++ b/committers.md
@@ -20,10 +20,10 @@ navigation:
 |Ankur Dave|UC Berkeley|
 |Aaron Davidson|Databricks|
 |Thomas Dudziak|Facebook|
-|Robert Evans|Yahoo!|
+|Robert Evans|Oath|
 |Wenchen Fan|Databricks|
 |Joseph Gonzalez|UC Berkeley|
-|Thomas Graves|Yahoo!|
+|Thomas Graves|Oath|
 |Stephen Haberman|Bizo|
 |Mark Hamstra|ClearStory Data|
 |Herman van Hovell|QuestTec B.V.|

--- a/site/committers.html
+++ b/site/committers.html
@@ -246,7 +246,7 @@
     </tr>
     <tr>
       <td>Robert Evans</td>
-      <td>Yahoo!</td>
+      <td>Oath</td>
     </tr>
     <tr>
       <td>Wenchen Fan</td>
@@ -258,7 +258,7 @@
     </tr>
     <tr>
       <td>Thomas Graves</td>
-      <td>Yahoo!</td>
+      <td>Oath</td>
     </tr>
     <tr>
       <td>Stephen Haberman</td>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -672,15 +672,11 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
+  <loc>https://spark.apache.org/graphx/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/mllib/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>https://spark.apache.org/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>https://spark.apache.org/sql/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
@@ -692,11 +688,15 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/graphx/</loc>
+  <loc>https://spark.apache.org/screencasts/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/screencasts/</loc>
+  <loc>https://spark.apache.org/sql/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>


### PR DESCRIPTION
I ran jekyll build and it looks like it reordered the sitemap.  Let me know if that is an issue.

otherwise update the company from Yahoo to Oath.