### PR TITLE
Apache Spark 2.3.0 Release: Announcements & Release Notes

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -12,6 +12,7 @@ navigation:
 <p>Setup instructions, programming guides, and other documentation are available for each stable version of Spark below:</p>
 
 <ul>
+  <li><a href="{{site.baseurl}}/docs/2.3.0/">Spark 2.3.0</a></li>
   <li><a href="{{site.baseurl}}/docs/2.2.1/">Spark 2.2.1</a></li>
   <li><a href="{{site.baseurl}}/docs/2.2.0/">Spark 2.2.0</a></li>
   <li><a href="{{site.baseurl}}/docs/2.1.2/">Spark 2.1.2</a></li>

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -24,6 +24,7 @@ var packagesV7 = [hadoop2p7, hadoop2p6, hadoop2p4, hadoop2p3, hadoopFree, source
 // 2.2.0+
 var packagesV8 = [hadoop2p7, hadoop2p6, hadoopFree, sources];
 
+addRelease("2.3.0", new Date("02/28/2018"), packagesV8, true);
 addRelease("2.2.1", new Date("12/01/2017"), packagesV8, true);
 addRelease("2.2.0", new Date("07/11/2017"), packagesV8, true);
 addRelease("2.1.2", new Date("10/09/2017"), packagesV7, true);

--- a/news/_posts/2018-02-28-spark-2-3-0-released.md
+++ b/news/_posts/2018-02-28-spark-2-3-0-released.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: Spark 2.3.0 released
+categories:
+- News
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+We are happy to announce the availability of <a href="{{site.baseurl}}/releases/spark-release-2-3-0.html" title="Spark Release 2.3.0">Spark 2.3.0</a>! Visit the <a href="{{site.baseurl}}/releases/spark-release-2-3-0.html" title="Spark Release 2.3.0">release notes</a> to read about the new features, or <a href="{{site.baseurl}}/downloads.html">download</a> the release today.

--- a/releases/_posts/2018-02-28-spark-release-2-3-0.md
+++ b/releases/_posts/2018-02-28-spark-release-2-3-0.md
@@ -1,0 +1,169 @@
+---
+layout: post
+title: Spark Release 2.3.0
+categories: []
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+
+
+Apache Spark 2.3.0 is the fourth release on the 2.x line. This release adds support for Continuous Processing in Structured Streaming along with a brand new Kubernetes Scheduler backend. Other major updates include the new DataSource and Structured Streaming v2 APIs, and a number of PySpark performance and enhancements. In addition, this release continues to focus on usability, stability, and polish while resolving around 1400 tickets.
+
+To download Apache Spark 2.3.0, visit the <a href="{{site.baseurl}}/downloads.html">downloads</a> page. You can consult JIRA for the [detailed changes](https://s.apache.org/spark-2.3.0). We have curated a list of high level changes here, grouped by major modules.
+
+* This will become a table of contents (this text will be scraped).
+{:toc}
+
+
+### Core, PySpark and Spark SQL
+
+ - **Major features**
+   - **Spark on Kubernetes**: [[SPARK-18278](https://issues.apache.org/jira/browse/SPARK-18278)] A new kubernetes scheduler backend that supports native submission of spark jobs to a cluster managed by kubernetes. Note that this support is currently experimental and behavioral changes around configurations, container images and entrypoints should be expected.
+   - **Vectorized ORC Reader**: [[SPARK-16060](https://issues.apache.org/jira/browse/SPARK-16060)] Adds support for new ORC reader that substantially improves the ORC scan throughput through vectorization (2-5x). To enable the reader, users can set `spark.sql.orc.impl` to `native`.
+   - **Spark History Server V2**: [[SPARK-18085](https://issues.apache.org/jira/browse/SPARK-18085)] A new spark history server (SHS) backend that provides better scalability for large scale applications with a more efficient event storage mechanism.
+   - **Data source API V2**: [[SPARK-15689](https://issues.apache.org/jira/browse/SPARK-15689)][[SPARK-22386](https://issues.apache.org/jira/browse/SPARK-22386)] An experimental API for plugging in new data sources in Spark. The new API attempts to address several limitations of the V1 API and aims to facilitate development of high performant, easy-to-maintain, and extensible external data sources. Note that this API is still undergoing active development and breaking changes should be expected.
+   - **PySpark Performance Enhancements**: [[SPARK-22216](https://issues.apache.org/jira/browse/SPARK-22216)][[SPARK-21187](https://issues.apache.org/jira/browse/SPARK-21187)] Significant improvements in python performance and interoperability by fast data serialization and vectorized execution.
+
+ - **Performance and stability**
+    - [[SPARK-21975](https://issues.apache.org/jira/browse/SPARK-21975)] Histogram support in cost-based optimizer
+    - [[SPARK-20331](https://issues.apache.org/jira/browse/SPARK-20331)] Better support for predicate pushdown for Hive partition pruning 
+    - [[SPARK-19112](https://issues.apache.org/jira/browse/SPARK-19112)] Support for ZStandard compression codec
+    - [[SPARK-21113](https://issues.apache.org/jira/browse/SPARK-21113)] Support for read ahead input stream to amortize disk I/O cost in the spill reader
+    - [[SPARK-22510](https://issues.apache.org/jira/browse/SPARK-22510)][[SPARK-22692](https://issues.apache.org/jira/browse/SPARK-22692)][[SPARK-21871](https://issues.apache.org/jira/browse/SPARK-21871)] Further stabilize the codegen framework to avoid hitting the `64KB` JVM bytecode limit on the Java method and Java compiler constant pool limit
+    - [[SPARK-23207](https://issues.apache.org/jira/browse/SPARK-23207)] Fixed a long standing bug in Spark where consecutive shuffle+repartition on a DataFrame could lead to incorrect answers in certain surgical cases
+    - [[SPARK-22062](https://issues.apache.org/jira/browse/SPARK-22062)][[SPARK-17788](https://issues.apache.org/jira/browse/SPARK-17788)][[SPARK-21907](https://issues.apache.org/jira/browse/SPARK-21907)] Fix various causes of OOMs 
+    - [[SPARK-22489](https://issues.apache.org/jira/browse/SPARK-22489)][[SPARK-22916](https://issues.apache.org/jira/browse/SPARK-22916)][[SPARK-22895](https://issues.apache.org/jira/browse/SPARK-22895)][[SPARK-20758](https://issues.apache.org/jira/browse/SPARK-20758)][[SPARK-22266](https://issues.apache.org/jira/browse/SPARK-22266)][[SPARK-19122](https://issues.apache.org/jira/browse/SPARK-19122)][[SPARK-22662](https://issues.apache.org/jira/browse/SPARK-22662)][[SPARK-21652](https://issues.apache.org/jira/browse/SPARK-21652)] Enhancements in rule-based optimizer and planner
+
+ - **Other notable changes**
+    - [[SPARK-20236](https://issues.apache.org/jira/browse/SPARK-20236)] Support Hive style dynamic partition overwrite semantics.
+    - [[SPARK-4131](https://issues.apache.org/jira/browse/SPARK-4131)] Support `INSERT OVERWRITE DIRECTORY` to directly write data into the filesystem from a query
+    - [[SPARK-19285](https://issues.apache.org/jira/browse/SPARK-19285)][[SPARK-22945](https://issues.apache.org/jira/browse/SPARK-22945)][[SPARK-21499](https://issues.apache.org/jira/browse/SPARK-21499)][[SPARK-20586](https://issues.apache.org/jira/browse/SPARK-20586)][[SPARK-20416](https://issues.apache.org/jira/browse/SPARK-20416)][[SPARK-20668](https://issues.apache.org/jira/browse/SPARK-20668)] UDF enhancements
+    - [[SPARK-20463](https://issues.apache.org/jira/browse/SPARK-20463)][[SPARK-19951](https://issues.apache.org/jira/browse/SPARK-19951)][[SPARK-22934](https://issues.apache.org/jira/browse/SPARK-22934)][[SPARK-21055](https://issues.apache.org/jira/browse/SPARK-21055)][[SPARK-17729](https://issues.apache.org/jira/browse/SPARK-17729)][[SPARK-20962](https://issues.apache.org/jira/browse/SPARK-20962)][[SPARK-20963](https://issues.apache.org/jira/browse/SPARK-20963)][[SPARK-20841](https://issues.apache.org/jira/browse/SPARK-20841)][[SPARK-17642](https://issues.apache.org/jira/browse/SPARK-17642)][[SPARK-22475](https://issues.apache.org/jira/browse/SPARK-22475)][[SPARK-22934](https://issues.apache.org/jira/browse/SPARK-22934)] Improved ANSI SQL compliance and Hive compatibility
+    - [[SPARK-20746](https://issues.apache.org/jira/browse/SPARK-20746)] More comprehensive SQL built-in functions
+    - [[SPARK-21485](https://issues.apache.org/jira/browse/SPARK-21485)] Spark SQL documentation generation for built-in functions
+    - [[SPARK-19810](https://issues.apache.org/jira/browse/SPARK-19810)] Remove support for Scala `2.10`
+    - [[SPARK-22324](https://issues.apache.org/jira/browse/SPARK-22324)] Upgrade Arrow to `0.8.0` and Netty to `4.1.17`
+
+*Programming guides: <a href="{{site.baseurl}}/docs/2.3.0/rdd-programming-guide.html">Spark RDD Programming Guide</a> and <a href="{{site.baseurl}}/docs/2.3.0/sql-programming-guide.html">Spark SQL, DataFrames and Datasets Guide</a>.*
+
+
+### Structured Streaming
+
+ - **Continuous Processing**
+   - A new execution engine that can execute streaming queries with sub-millisecond end-to-end latency by changing only a single line of user code. To learn more see the programming guide.
+ - **Stream-Stream Joins**
+   - Ability to join two streams of data, buffering rows until matching tuples arrive in the other stream. Predicates can be used against event time columns to bound the amount of state that needs to be retained.
+ - **Streaming API V2**
+   - An experimental API for plugging in new source and sinks that works for batch, micro-batch, and continuous execution. Note this API is still undergoing active development and breaking changes should be expected.
+
+*Programming guide: <a href="{{site.baseurl}}/docs/2.3.0/structured-streaming-programming-guide.html">Structured Streaming Programming Guide</a>.*
+
+### MLlib
+
+ - **Highlights**
+   - ML Prediction now works with Structured Streaming, using updated APIs. Details below.
+
+ - **New/Improved APIs**
+   - [[SPARK-21866](https://issues.apache.org/jira/browse/SPARK-21866)]: Built-in support for reading images into a DataFrame (Scala/Java/Python)
+   - [[SPARK-19634](https://issues.apache.org/jira/browse/SPARK-19634)]: DataFrame functions for descriptive summary statistics over vector columns (Scala/Java)
+   - [[SPARK-14516](https://issues.apache.org/jira/browse/SPARK-14516)]: `ClusteringEvaluator` for tuning clustering algorithms, supporting Cosine silhouette and squared Euclidean silhouette metrics (Scala/Java/Python)
+   - [[SPARK-3181](https://issues.apache.org/jira/browse/SPARK-3181)]: Robust linear regression with Huber loss (Scala/Java/Python)
+   - [[SPARK-13969](https://issues.apache.org/jira/browse/SPARK-13969)]: `FeatureHasher` transformer (Scala/Java/Python)
+   - Multiple column support for several feature transformers:
+     + [[SPARK-13030](https://issues.apache.org/jira/browse/SPARK-13030)]: `OneHotEncoderEstimator` (Scala/Java/Python)
+     + [[SPARK-22397](https://issues.apache.org/jira/browse/SPARK-22397)]: `QuantileDiscretizer` (Scala/Java)
+     + [[SPARK-20542](https://issues.apache.org/jira/browse/SPARK-20542)]: `Bucketizer` (Scala/Java/Python)
+   - [[SPARK-21633](https://issues.apache.org/jira/browse/SPARK-21633)] and [SPARK-21542](https://issues.apache.org/jira/browse/SPARK-21542)]: Improved support for custom pipeline components in Python.
+
+ - **New Features**
+   - [[SPARK-21087](https://issues.apache.org/jira/browse/SPARK-21087)]: `CrossValidator` and `TrainValidationSplit` can collect all models when fitting (Scala/Java).  This allows you to inspect or save all fitted models.
+   - [[SPARK-19357](https://issues.apache.org/jira/browse/SPARK-19357)]: Meta-algorithms `CrossValidator`, `TrainValidationSplit, `OneVsRest` support a parallelism Param for fitting multiple sub-models in parallel Spark jobs
+   - [[SPARK-17139](https://issues.apache.org/jira/browse/SPARK-17139)]: Model summary for multinomial logistic regression (Scala/Java/Python)
+   - [[SPARK-18710](https://issues.apache.org/jira/browse/SPARK-18710)]: Add offset in GLM
+   - [[SPARK-20199](https://issues.apache.org/jira/browse/SPARK-20199)]: Added `featureSubsetStrategy` Param to `GBTClassifier` and `GBTRegressor`.  Using this to subsample features can significantly improve training speed; this option has been a key strength of `xgboost`.
+
+ - **Other Notable Changes**
+   - [[SPARK-22156](https://issues.apache.org/jira/browse/SPARK-22156)] Fixed `Word2Vec` learning rate scaling with `num` iterations.  The new learning rate is set to match the original `Word2Vec` C code and should give better results from training.
+   - [[SPARK-22289](https://issues.apache.org/jira/browse/SPARK-22289)] Add `JSON` support for Matrix parameters (This fixed a bug for ML persistence with `LogisticRegressionModel` when using bounds on coefficients.)
+   - [[SPARK-22700](https://issues.apache.org/jira/browse/SPARK-22700)] `Bucketizer.transform` incorrectly drops row containing `NaN`.  When Param `handleInvalid` was set to “skip,” `Bucketizer` would drop a row with a valid value in the input column if another (irrelevant) column had a `NaN` value.
+   - [[SPARK-22446](https://issues.apache.org/jira/browse/SPARK-22446)] Catalyst optimizer sometimes caused `StringIndexerModel` to throw an incorrect “Unseen label” exception when `handleInvalid` was set to “error.”  This could happen for filtered data, due to predicate push-down, causing errors even after invalid rows had already been filtered from the input dataset.
+   - [[SPARK-21681](https://issues.apache.org/jira/browse/SPARK-21681)] Fixed an edge case bug in multinomial logistic regression that resulted in incorrect coefficients when some features had zero variance.
+   - Major optimizations:
+     + [[SPARK-22707](https://issues.apache.org/jira/browse/SPARK-22707)] Reduced memory consumption for `CrossValidator`
+     + [[SPARK-22949](https://issues.apache.org/jira/browse/SPARK-22949)] Reduced memory consumption for `TrainValidationSplit`
+     + [[SPARK-21690](https://issues.apache.org/jira/browse/SPARK-21690)] `Imputer` should train using a single pass over the data
+     + [[SPARK-14371](https://issues.apache.org/jira/browse/SPARK-14371)] `OnlineLDAOptimizer` avoids collecting statistics to the driver for each mini-batch.
+
+*Programming guide: <a href="{{site.baseurl}}/docs/2.3.0/ml-guide.html">Machine Learning Library (MLlib) Guide</a>.*
+
+### SparkR
+
+The main focus of SparkR in the 2.3.0 release was towards improving the stability of UDFs and adding several new SparkR wrappers around existing APIs:
+
+ - **Major features**
+   -  Improved function parity between SQL and R
+   - [[SPARK-22933](https://issues.apache.org/jira/browse/SPARK-22933)]: Structured Streaming APIs for `withWatermark`, `trigger`, `partitionBy` and stream-stream joins
+   - [[SPARK-21266](https://issues.apache.org/jira/browse/SPARK-21266)]: SparkR UDF with DDL-formatted schema support
+   - [[SPARK-20726](https://issues.apache.org/jira/browse/SPARK-20726)][[SPARK-22924](https://issues.apache.org/jira/browse/SPARK-22924)][[SPARK-22843](https://issues.apache.org/jira/browse/SPARK-22843)] Several new Dataframe API Wrappers
+   - [[SPARK-15767](https://issues.apache.org/jira/browse/SPARK-15767)][[SPARK-21622](https://issues.apache.org/jira/browse/SPARK-21622)][[SPARK-20917](https://issues.apache.org/jira/browse/SPARK-20917)][[SPARK-20307](https://issues.apache.org/jira/browse/SPARK-20307)][[SPARK-20906](https://issues.apache.org/jira/browse/SPARK-20906)] Several new SparkML API Wrappers
+
+*Programming guide: <a href="{{site.baseurl}}/docs/2.3.0/sparkr.html">SparkR (R on Spark)</a>.*
+
+### GraphX
+
+ - **Optimizations**
+   - [[SPARK-5484](https://issues.apache.org/jira/browse/SPARK-5484)] Pregel now checkpoints periodically to avoid `StackOverflowErrors`
+   - [[SPARK-21491](https://issues.apache.org/jira/browse/SPARK-21491)] Small performance improvement in several places
+
+*Programming guide: <a href="{{site.baseurl}}/docs/2.3.0/graphx-programming-guide.html">GraphX Programming Guide</a>.*
+
+### Deprecations
+
+ - **Python**
+   - [[SPARK-23122](https://issues.apache.org/jira/browse/SPARK-23122)] Deprecate `register*` for UDFs in `SQLContext` and `Catalog` in PySpark
+ - **MLlib**
+   - [[SPARK-13030](https://issues.apache.org/jira/browse/SPARK-13030)] `OneHotEncoder` has been deprecated and will be removed in 3.0. It has been replaced by the new `OneHotEncoderEstimator`. Note that `OneHotEncoderEstimator` will be renamed to `OneHotEncoder` in 3.0 (but `OneHotEncoderEstimator` will be kept as an alias).
+
+### Changes of behavior
+
+ - **SparkSQL**
+   - [[SPARK-22036](https://issues.apache.org/jira/browse/SPARK-22036)]: By default arithmetic operations between decimals return a rounded value if an exact representation is not possible (instead of returning `NULL` in the prior versions)
+   - [[SPARK-22937](https://issues.apache.org/jira/browse/SPARK-22937)]: When all inputs are binary, SQL `elt()` returns an output as binary. Otherwise, it returns as a string. In the prior versions, it always returns as a string despite of input types.
+   - [[SPARK-22895](https://issues.apache.org/jira/browse/SPARK-22895)]: The Join/Filter's deterministic predicates that are after the first non-deterministic predicates are also pushed down/through the child operators, if possible. In the prior versions, these filters were not eligible for predicate pushdown.
+   - [[SPARK-22771](https://issues.apache.org/jira/browse/SPARK-22771)]: When all inputs are binary, `functions.concat()` returns an output as binary. Otherwise, it returns as a string. In the prior versions, it always returns as a string despite of input types.
+   - [[SPARK-22489](https://issues.apache.org/jira/browse/SPARK-22489)]: When either of the join sides is broadcastable, we prefer to broadcasting the table that is explicitly specified in a broadcast hint.
+   - [[SPARK-22165](https://issues.apache.org/jira/browse/SPARK-22165)]: Partition column inference previously found incorrect common type for different inferred types, for example, previously it ended up with `double` type as the common type for `double` type and `date` type. Now it finds the correct common type for such conflicts. For details, see the <a href="{{site.baseurl}}/docs/2.3.0/sql-programming-guide.html#migration-guide">migration guide</a>.
+   - [[SPARK-22100](https://issues.apache.org/jira/browse/SPARK-22100)]: The `percentile_approx` function previously accepted `numeric` type input and outputted `double` type results. Now it supports `date` type, `timestamp` type and `numeric` types as input types. The result type is also changed to be the same as the input type, which is more reasonable for percentiles.
+   - [[SPARK-21610](https://issues.apache.org/jira/browse/SPARK-21610)]: the queries from raw JSON/CSV files are disallowed when the referenced columns only include the internal corrupt record column (named `_corrupt_record` by default). Instead, you can cache or save the parsed results and then send the same query. 
+   - [[SPARK-23421](https://issues.apache.org/jira/browse/SPARK-23421)]: Since Spark 2.2.1 and 2.3.0, the schema is always inferred at runtime when the data source tables have the columns that exist in both partition schema and data schema. The inferred schema does not have the partitioned columns. When reading the table, Spark respects the partition values of these overlapping columns instead of the values stored in the data source files. In 2.2.0 and 2.1.x release, the inferred schema is partitioned but the data of the table is invisible to users (i.e., the result set is empty).
+
+ - **PySpark**
+   - [[SPARK-19732](https://issues.apache.org/jira/browse/SPARK-19732)]: `na.fill()` or `fillna` also accepts boolean and replaces nulls with booleans. In prior Spark versions, PySpark just ignores it and returns the original Dataset/DataFrame.  
+   - [[SPARK-22395](https://issues.apache.org/jira/browse/SPARK-22395)]: Pandas `0.19.2` or upper is required for using Pandas related functionalities, such as `toPandas`, `createDataFrame` from Pandas DataFrame, etc.
+   - [[SPARK-22395](https://issues.apache.org/jira/browse/SPARK-22395)]: The behavior of timestamp values for Pandas related functionalities was changed to respect session timezone, which is ignored in the prior versions.
+   - [[SPARK-23328](https://issues.apache.org/jira/browse/SPARK-23328)]: `df.replace` does not allow to omit `value` when `to_replace` is not a dictionary. Previously, `value` could be omitted in the other cases and had `None` by default, which is counter-intuitive and error prone.
+
+ - **MLlib**
+   - **Breaking API Changes**: The class and trait hierarchy for logistic regression model summaries was changed to be cleaner and better accommodate the addition of the multi-class summary. This is a breaking change for user code that casts a `LogisticRegressionTrainingSummary` to a `BinaryLogisticRegressionTrainingSummary`. Users should instead use the `model.binarySummary` method. See [[SPARK-17139](https://issues.apache.org/jira/browse/SPARK-17139)] for more detail (note this is an `@Experimental` API). This does not affect the Python summary method, which will still work correctly for both multinomial and binary cases.
+   - [[SPARK-21806](https://issues.apache.org/jira/browse/SPARK-21806)]: `BinaryClassificationMetrics.pr()`: first point (0.0, 1.0) is misleading and has been replaced by (0.0, p) where precision p matches the lowest recall point.
+   - [[SPARK-16957](https://issues.apache.org/jira/browse/SPARK-16957)]: Decision trees now use weighted midpoints when choosing split values.  This may change results from model training.
+   - [[SPARK-14657](https://issues.apache.org/jira/browse/SPARK-14657)]: `RFormula` without an intercept now outputs the reference category when encoding string terms, in order to match native R behavior.  This may change results from model training.
+   - [[SPARK-21027](https://issues.apache.org/jira/browse/SPARK-21027)]: The default parallelism used in `OneVsRest` is now set to 1 (i.e. serial). In 2.2 and earlier versions, the level of parallelism was set to the default threadpool size in Scala.  This may change performance.
+   - [[SPARK-21523](https://issues.apache.org/jira/browse/SPARK-21523)]: Upgraded Breeze to `0.13.2`.  This included an important bug fix in strong Wolfe line search for L-BFGS.
+   - [[SPARK-15526](https://issues.apache.org/jira/browse/SPARK-15526)]: The JPMML dependency is now shaded.
+   - Also see the “Bug fixes” section for behavior changes resulting from fixing bugs.
+
+
+### Known Issues
+
+   - [[SPARK-23523](https://issues.apache.org/jira/browse/SPARK-23523)][SQL] Incorrect result caused by the rule `OptimizeMetadataOnlyQuery`
+   - [[SPARK-23406](https://issues.apache.org/jira/browse/SPARK-23406)] Bugs in stream-stream self-joins
+
+### Credits
+Last but not least, this release would not have been possible without the following contributors:
+ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Alberto Rodriguez De Lema, Alex Mikhailau, Alexander Istomin, Anderson Osagie, Andrea Zito, Andrew Ash, Andrew Korzhuev, Andrew Ray, Anirudh Ramanathan, Anton Okolnychyi, Arman Yazdani, Armin Braun, Arseniy Tashoyan, Arthur Rand, Atallah Hezbor, Attila Zsolt Piros, Ayush Singh, Bago Amirbekian, Ben Barnard, Bo Meng, Bo Xu, Bogdan Raducanu, Brad Kaiser, Bravo Zhang, Bruce Robbins, Bruce Xu, Bryan Cutler, Burak Yavuz, Carson Wang, Chang Chen, Charles Chen, Cheng Wang, Chenjun Zou, Chenzhao Guo, Chetan Khatri, Chie Hayashida, Chin Han Yu, Chunsheng Ji, Corey Woodfield, Daniel Li, Daniel Van Der Ende, Devaraj K, Dhruve Ashar, Dilip Biswal, Dmitry Parfenchik, Donghui Xu, Dongjoon Hyun, Eren Avsarogullari, Eric Vandenberg, Erik LaBianca, Eyal Farago, Favio Vazquez, Felix Cheung, Feng Liu, Feng Zhu, Fernando Pereira, Fokko Driesprong, Gabor Somogyi, Gene Pang, Gera Shegalov, German Schiavon, Glen Takahashi, Greg Owen, Grzegorz Slowikowski, Guilherme Berger, Guillaume Dardelet, Guo Xiao Long, He Qiao, Henry Robinson, Herman Van Hovell, Hideaki Tanaka, Holden Karau, Huang Tengfei, Huaxin Gao, Hyukjin Kwon, Ilya Matiach, Imran Rashid, Iurii Antykhovych, Ivan Sadikov, Jacek Laskowski, JackYangzg, Jakub Dubovsky, Jakub Nowacki, James Thompson, Jan Vrsovsky, Jane Wang, Jannik Arndt, Jason Taaffe, Jeff Zhang, Jen-Ming Chung, Jia Li, Jia-Xuan Liu, Jin Xing, Jinhua Fu, Jirka Kremser, Joachim Hereth, John Compitello, John Lee, John O'Leary, Jorge Machado, Jose Torres, Joseph K. Bradley, Josh Rosen, Juliusz Sompolski, Kalvin Chau, Kazuaki Ishizaki, Kent Yao, Kento NOZAWA, Kevin Yu, Kirby Linvill, Kohki Nishio, Kousuke Saruta, Kris Mok, Krishna Pandey, Kyle Kelley, Li Jin, Li Yichao, Li Yuanjian, Liang-Chi Hsieh, Lijia Liu, Liu Shaohui, Liu Xian, Liyun Zhang, Louis Lyu, Lubo Zhang, Luca Canali, Maciej Brynski, Maciej Szymkiewicz, Madhukara Phatak, Mahmut CAVDAR, Marcelo Vanzin, Marco Gaido, Marcos P, Marcos P. Sanchez, Mark Petruska, Maryann Xue, Masha Basmanova, Miao Wang, Michael Allman, Michael Armbrust, Michael Gummelt, Michael Mior, Michael Patterson, Michael Styles, Michal Senkyr, Mikhail Sveshnikov, Min Shen, Ming Jiang, Mingjie Tang, Mridul Muralidharan, Nan Zhu, Nathan Kronenfeld, Neil Alexander McQuarrie, Ngone51, Nicholas Chammas, Nick Pentreath, Ohad Raviv, Oleg Danilov, Onur Satici, PJ Fanning, Parth Gandhi, Patrick Woody, Paul Mackles, Peng Meng, Peng Xiao, Pengcheng Liu, Peter Szalai, Pralabh Kumar, Prashant Sharma, Rekha Joshi, Remis Haroon, Reynold Xin, Reza Safi, Riccardo Corbella, Rishabh Bhardwaj, Robert Kruszewski, Ron Hu, Ruben Berenguel Montoro, Ruben Janssen, Rui Zha, Rui Zhan, Ruifeng Zheng, Russell Spitzer, Ryan Blue, Sahil Takiar, Saisai Shao, Sameer Agarwal, Sandor Murakozi, Sanket Chintapalli, Santiago Saavedra, Sathiya Kumar, Sean Owen, Sergei Lebedev, Sergey Serebryakov, Sergey Zhemzhitsky, Seth Hendrickson, Shane Jarvie, Shashwat Anand, Shintaro Murakami, Shivaram Venkataraman, Shixiong Zhu, Shuangshuang Wang, Sid Murching, Sital Kedia, Soonmok Kwon, Srinivasa Reddy Vundela, Stavros Kontopoulos, Steve Loughran, Steven Rand, Sujith, Sujith Jay Nair, Sumedh Wale, Sunitha Kambhampati, Suresh Thalamati, Susan X. Huynh, Takeshi Yamamuro, Takuya UESHIN, Tathagata Das, Tejas Patil, Teng Peng, Thomas Graves, Tim Van Wassenhove, Travis Hegner, Tristan Stevens, Tucker Beck, Valeriy Avanesov, Vinitha Gankidi, Vinod KC, Wang Gengliang, Wayne Zhang, Weichen Xu, Wenchen Fan, Wieland Hoffmann, Wil Selwood, Wing Yew Poon, Xiang Gao, Xianjin YE, Xianyang Liu, Xiao Li, Xiaochen Ouyang, Xiaofeng Lin, Xiaokai Zhao, Xiayun Sun, Xin Lu, Xin Ren, Xingbo Jiang, Yan Facai (Yan Fa Cai), Yan Kit Li, Yanbo Liang, Yash Sharma, Yinan Li, Yong Tang, Youngbin Kim, Yuanjian Li, Yucai Yu, Yuhai Cen, Yuhao Yang, Yuming Wang, Yuval Itzchakov, Zhan Zhang, Zhang A Peng, Zhaokun Liu, Zheng RuiFeng, Zhenhua Wang, Zuo Tingbing, brandonJY, caneGuy, cxzl25, djvulee, eatoncys, heary-cao, ho3rexqj, lizhaoch, maclockard, neoremind, peay, shaofei007, wangjiaochun, zenglinxi0615

--- a/site/committers.html
+++ b/site/committers.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/community.html
+++ b/site/community.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
@@ -199,6 +199,7 @@
 <p>Setup instructions, programming guides, and other documentation are available for each stable version of Spark below:</p>
 
 <ul>
+  <li><a href="/docs/2.3.0/">Spark 2.3.0</a></li>
   <li><a href="/docs/2.2.1/">Spark 2.2.1</a></li>
   <li><a href="/docs/2.2.0/">Spark 2.2.0</a></li>
   <li><a href="/docs/2.1.2/">Spark 2.1.2</a></li>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/examples.html
+++ b/site/examples.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/faq.html
+++ b/site/faq.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -164,6 +164,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -172,9 +175,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/index.html
+++ b/site/index.html
@@ -163,6 +163,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -171,9 +174,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -24,6 +24,7 @@ var packagesV7 = [hadoop2p7, hadoop2p6, hadoop2p4, hadoop2p3, hadoopFree, source
 // 2.2.0+
 var packagesV8 = [hadoop2p7, hadoop2p6, hadoopFree, sources];
 
+addRelease("2.3.0", new Date("02/28/2018"), packagesV8, true);
 addRelease("2.2.1", new Date("12/01/2017"), packagesV8, true);
 addRelease("2.2.0", new Date("07/11/2017"), packagesV8, true);
 addRelease("2.1.2", new Date("10/09/2017"), packagesV7, true);

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -164,6 +164,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -172,9 +175,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -164,6 +164,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -172,9 +175,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
@@ -195,6 +195,15 @@
 
   <div class="col-md-9 col-md-pull-3">
     <h2 id="spark-news">Spark News</h2>
+
+<article class="hentry">
+    <header class="entry-header">
+      <h3 class="entry-title"><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a></h3>
+      <div class="entry-date">February 28, 2018</div>
+    </header>
+    <div class="entry-content"><p>We are happy to announce the availability of <a href="/releases/spark-release-2-3-0.html" title="Spark Release 2.3.0">Spark 2.3.0</a>! Visit the <a href="/releases/spark-release-2-3-0.html" title="Spark Release 2.3.0">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+</div>
+  </article>
 
 <article class="hentry">
     <header class="entry-header">

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark Summit (June 5-7th, 2017, San Francisco) agenda posted | Apache Spark
+     Spark 2.3.0 released | Apache Spark
     
   </title>
 
@@ -194,10 +194,10 @@
   </div>
 
   <div class="col-md-9 col-md-pull-3">
-    <h2>Spark Summit (June 5-7th, 2017, San Francisco) agenda posted</h2>
+    <h2>Spark 2.3.0 released</h2>
 
 
-<p>The agenda for <a href="https://spark-summit.org/2017/">Spark Summit</a> is now available! The summit kicks off on June 5th with a full day of Spark training followed by over 110+ talks featuring speakers from Databricks, Facebook, Airbnb, Yelp, Salesforce and UC Berkeley. Check out the <a href="https://spark-summit.org/2017/schedule/">full schedule</a> and <a href="https://prevalentdesignevents.com/sparksummit/ss17/?_ga=1.211902866.780052874.1433437196">register</a> to attend!</p>
+<p>We are happy to announce the availability of <a href="/releases/spark-release-2-3-0.html" title="Spark Release 2.3.0">Spark 2.3.0</a>! Visit the <a href="/releases/spark-release-2-3-0.html" title="Spark Release 2.3.0">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
 
 
 <p>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted.html
+++ b/site/news/spark-summit-east-agenda-posted.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -1,0 +1,450 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>
+     Spark Release 2.3.0 | Apache Spark
+    
+  </title>
+
+  
+
+  
+
+  <!-- Bootstrap core CSS -->
+  <link href="/css/cerulean.min.css" rel="stylesheet">
+  <link href="/css/custom.css" rel="stylesheet">
+
+  <!-- Code highlighter CSS -->
+  <link href="/css/pygments-default.css" rel="stylesheet">
+
+  <script type="text/javascript">
+  <!-- Google Analytics initialization -->
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-32518208-2']);
+  _gaq.push(['_trackPageview']);
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+
+  <!-- Adds slight delay to links to allow async reporting -->
+  function trackOutboundLink(link, category, action) {
+    try {
+      _gaq.push(['_trackEvent', category , action]);
+    } catch(err){}
+
+    setTimeout(function() {
+      document.location.href = link.href;
+    }, 100);
+  }
+  </script>
+
+  <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+  <!--[if lt IE 9]>
+  <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+  <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+  <![endif]-->
+</head>
+
+<body>
+
+<script src="https://code.jquery.com/jquery.js"></script>
+<script src="https://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
+<script src="/js/lang-tabs.js"></script>
+<script src="/js/downloads.js"></script>
+
+<div class="container" style="max-width: 1200px;">
+
+<div class="masthead">
+  
+    <p class="lead">
+      <a href="/">
+      <img src="/images/spark-logo-trademark.png"
+        style="height:100px; width:auto; vertical-align: bottom; margin-top: 20px;"></a><span class="tagline">
+          Lightning-fast cluster computing
+      </span>
+    </p>
+  
+</div>
+
+<nav class="navbar navbar-default" role="navigation">
+  <!-- Brand and toggle get grouped for better mobile display -->
+  <div class="navbar-header">
+    <button type="button" class="navbar-toggle" data-toggle="collapse"
+            data-target="#navbar-collapse-1">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+  </div>
+
+  <!-- Collect the nav links, forms, and other content for toggling -->
+  <div class="collapse navbar-collapse" id="navbar-collapse-1">
+    <ul class="nav navbar-nav">
+      <li><a href="/downloads.html">Download</a></li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Libraries <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/sql/">SQL and DataFrames</a></li>
+          <li><a href="/streaming/">Spark Streaming</a></li>
+          <li><a href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a href="/graphx/">GraphX (graph)</a></li>
+          <li class="divider"></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
+        </ul>
+      </li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Documentation <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/docs/latest/">Latest Release (Spark 2.2.1)</a></li>
+          <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
+          <li><a href="/faq.html">Frequently Asked Questions</a></li>
+        </ul>
+      </li>
+      <li><a href="/examples.html">Examples</a></li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Community <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/community.html">Mailing Lists &amp; Resources</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="/improvement-proposals.html">Improvement Proposals (SPIP)</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
+        </ul>
+      </li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+           Developers <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/developer-tools.html">Useful Developer Tools</a></li>
+          <li><a href="/versioning-policy.html">Versioning Policy</a></li>
+          <li><a href="/release-process.html">Release Process</a></li>
+          <li><a href="/security.html">Security</a></li>
+        </ul>
+      </li>
+    </ul>
+    <ul class="nav navbar-nav navbar-right">
+      <li class="dropdown">
+        <a href="https://www.apache.org/" class="dropdown-toggle" data-toggle="dropdown">
+          Apache Software Foundation <b class="caret"></b></a>
+        <ul class="dropdown-menu">
+          <li><a href="https://www.apache.org/">Apache Homepage</a></li>
+          <li><a href="https://www.apache.org/licenses/">License</a></li>
+          <li><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+          <li><a href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
+          <li><a href="https://www.apache.org/security/">Security</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <!-- /.navbar-collapse -->
+</nav>
+
+
+<div class="row">
+  <div class="col-md-3 col-md-push-9">
+    <div class="news" style="margin-bottom: 20px;">
+      <h5>Latest News</h5>
+      <ul class="list-unstyled">
+        
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
+          <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
+          <span class="small">(Dec 01, 2017)</span></li>
+        
+          <li><a href="/news/spark-2-1-2-released.html">Spark 2.1.2 released</a>
+          <span class="small">(Oct 09, 2017)</span></li>
+        
+          <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
+          <span class="small">(Aug 28, 2017)</span></li>
+        
+      </ul>
+      <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
+    </div>
+    <div class="hidden-xs hidden-sm">
+      <a href="/downloads.html" class="btn btn-success btn-lg btn-block" style="margin-bottom: 30px;">
+        Download Spark
+      </a>
+      <p style="font-size: 16px; font-weight: 500; color: #555;">
+        Built-in Libraries:
+      </p>
+      <ul class="list-none">
+        <li><a href="/sql/">SQL and DataFrames</a></li>
+        <li><a href="/streaming/">Spark Streaming</a></li>
+        <li><a href="/mllib/">MLlib (machine learning)</a></li>
+        <li><a href="/graphx/">GraphX (graph)</a></li>
+      </ul>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
+    </div>
+  </div>
+
+  <div class="col-md-9 col-md-pull-3">
+    <h2>Spark Release 2.3.0</h2>
+
+
+<p>Apache Spark 2.3.0 is the fourth release on the 2.x line. This release adds support for Continuous Processing in Structured Streaming along with a brand new Kubernetes Scheduler backend. Other major updates include the new DataSource and Structured Streaming v2 APIs, and a number of PySpark performance and enhancements. In addition, this release continues to focus on usability, stability, and polish while resolving around 1400 tickets.</p>
+
+<p>To download Apache Spark 2.3.0, visit the <a href="/downloads.html">downloads</a> page. You can consult JIRA for the <a href="https://s.apache.org/spark-2.3.0">detailed changes</a>. We have curated a list of high level changes here, grouped by major modules.</p>
+
+<ul id="markdown-toc">
+  <li><a href="#core-pyspark-and-spark-sql" id="markdown-toc-core-pyspark-and-spark-sql">Core, PySpark and Spark SQL</a></li>
+  <li><a href="#structured-streaming" id="markdown-toc-structured-streaming">Structured Streaming</a></li>
+  <li><a href="#mllib" id="markdown-toc-mllib">MLlib</a></li>
+  <li><a href="#sparkr" id="markdown-toc-sparkr">SparkR</a></li>
+  <li><a href="#graphx" id="markdown-toc-graphx">GraphX</a></li>
+  <li><a href="#deprecations" id="markdown-toc-deprecations">Deprecations</a></li>
+  <li><a href="#changes-of-behavior" id="markdown-toc-changes-of-behavior">Changes of behavior</a></li>
+  <li><a href="#known-issues" id="markdown-toc-known-issues">Known Issues</a></li>
+  <li><a href="#credits" id="markdown-toc-credits">Credits</a></li>
+</ul>
+
+<h3 id="core-pyspark-and-spark-sql">Core, PySpark and Spark SQL</h3>
+
+<ul>
+  <li><strong>Major features</strong>
+    <ul>
+      <li><strong>Spark on Kubernetes</strong>: [<a href="https://issues.apache.org/jira/browse/SPARK-18278">SPARK-18278</a>] A new kubernetes scheduler backend that supports native submission of spark jobs to a cluster managed by kubernetes. Note that this support is currently experimental and behavioral changes around configurations, container images and entrypoints should be expected.</li>
+      <li><strong>Vectorized ORC Reader</strong>: [<a href="https://issues.apache.org/jira/browse/SPARK-16060">SPARK-16060</a>] Adds support for new ORC reader that substantially improves the ORC scan throughput through vectorization (2-5x). To enable the reader, users can set <code>spark.sql.orc.impl</code> to <code>native</code>.</li>
+      <li><strong>Spark History Server V2</strong>: [<a href="https://issues.apache.org/jira/browse/SPARK-18085">SPARK-18085</a>] A new spark history server (SHS) backend that provides better scalability for large scale applications with a more efficient event storage mechanism.</li>
+      <li><strong>Data source API V2</strong>: [<a href="https://issues.apache.org/jira/browse/SPARK-15689">SPARK-15689</a>][<a href="https://issues.apache.org/jira/browse/SPARK-22386">SPARK-22386</a>] An experimental API for plugging in new data sources in Spark. The new API attempts to address several limitations of the V1 API and aims to facilitate development of high performant, easy-to-maintain, and extensible external data sources. Note that this API is still undergoing active development and breaking changes should be expected.</li>
+      <li><strong>PySpark Performance Enhancements</strong>: [<a href="https://issues.apache.org/jira/browse/SPARK-22216">SPARK-22216</a>][<a href="https://issues.apache.org/jira/browse/SPARK-21187">SPARK-21187</a>] Significant improvements in python performance and interoperability by fast data serialization and vectorized execution.</li>
+    </ul>
+  </li>
+  <li><strong>Performance and stability</strong>
+    <ul>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-21975">SPARK-21975</a>] Histogram support in cost-based optimizer</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-20331">SPARK-20331</a>] Better support for predicate pushdown for Hive partition pruning</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-19112">SPARK-19112</a>] Support for ZStandard compression codec</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-21113">SPARK-21113</a>] Support for read ahead input stream to amortize disk I/O cost in the spill reader</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22510">SPARK-22510</a>][<a href="https://issues.apache.org/jira/browse/SPARK-22692">SPARK-22692</a>][<a href="https://issues.apache.org/jira/browse/SPARK-21871">SPARK-21871</a>] Further stabilize the codegen framework to avoid hitting the <code>64KB</code> JVM bytecode limit on the Java method and Java compiler constant pool limit</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-23207">SPARK-23207</a>] Fixed a long standing bug in Spark where consecutive shuffle+repartition on a DataFrame could lead to incorrect answers in certain surgical cases</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22062">SPARK-22062</a>][<a href="https://issues.apache.org/jira/browse/SPARK-17788">SPARK-17788</a>][<a href="https://issues.apache.org/jira/browse/SPARK-21907">SPARK-21907</a>] Fix various causes of OOMs</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22489">SPARK-22489</a>][<a href="https://issues.apache.org/jira/browse/SPARK-22916">SPARK-22916</a>][<a href="https://issues.apache.org/jira/browse/SPARK-22895">SPARK-22895</a>][<a href="https://issues.apache.org/jira/browse/SPARK-20758">SPARK-20758</a>][<a href="https://issues.apache.org/jira/browse/SPARK-22266">SPARK-22266</a>][<a href="https://issues.apache.org/jira/browse/SPARK-19122">SPARK-19122</a>][<a href="https://issues.apache.org/jira/browse/SPARK-22662">SPARK-22662</a>][<a href="https://issues.apache.org/jira/browse/SPARK-21652">SPARK-21652</a>] Enhancements in rule-based optimizer and planner</li>
+    </ul>
+  </li>
+  <li><strong>Other notable changes</strong>
+    <ul>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-20236">SPARK-20236</a>] Support Hive style dynamic partition overwrite semantics.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-4131">SPARK-4131</a>] Support <code>INSERT OVERWRITE DIRECTORY</code> to directly write data into the filesystem from a query</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-19285">SPARK-19285</a>][<a href="https://issues.apache.org/jira/browse/SPARK-22945">SPARK-22945</a>][<a href="https://issues.apache.org/jira/browse/SPARK-21499">SPARK-21499</a>][<a href="https://issues.apache.org/jira/browse/SPARK-20586">SPARK-20586</a>][<a href="https://issues.apache.org/jira/browse/SPARK-20416">SPARK-20416</a>][<a href="https://issues.apache.org/jira/browse/SPARK-20668">SPARK-20668</a>] UDF enhancements</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-20463">SPARK-20463</a>][<a href="https://issues.apache.org/jira/browse/SPARK-19951">SPARK-19951</a>][<a href="https://issues.apache.org/jira/browse/SPARK-22934">SPARK-22934</a>][<a href="https://issues.apache.org/jira/browse/SPARK-21055">SPARK-21055</a>][<a href="https://issues.apache.org/jira/browse/SPARK-17729">SPARK-17729</a>][<a href="https://issues.apache.org/jira/browse/SPARK-20962">SPARK-20962</a>][<a href="https://issues.apache.org/jira/browse/SPARK-20963">SPARK-20963</a>][<a href="https://issues.apache.org/jira/browse/SPARK-20841">SPARK-20841</a>][<a href="https://issues.apache.org/jira/browse/SPARK-17642">SPARK-17642</a>][<a href="https://issues.apache.org/jira/browse/SPARK-22475">SPARK-22475</a>][<a href="https://issues.apache.org/jira/browse/SPARK-22934">SPARK-22934</a>] Improved ANSI SQL compliance and Hive compatibility</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-20746">SPARK-20746</a>] More comprehensive SQL built-in functions</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-21485">SPARK-21485</a>] Spark SQL documentation generation for built-in functions</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-19810">SPARK-19810</a>] Remove support for Scala <code>2.10</code></li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22324">SPARK-22324</a>] Upgrade Arrow to <code>0.8.0</code> and Netty to <code>4.1.17</code></li>
+    </ul>
+  </li>
+</ul>
+
+<p><em>Programming guides: <a href="/docs/2.3.0/rdd-programming-guide.html">Spark RDD Programming Guide</a> and <a href="/docs/2.3.0/sql-programming-guide.html">Spark SQL, DataFrames and Datasets Guide</a>.</em></p>
+
+<h3 id="structured-streaming">Structured Streaming</h3>
+
+<ul>
+  <li><strong>Continuous Processing</strong>
+    <ul>
+      <li>A new execution engine that can execute streaming queries with sub-millisecond end-to-end latency by changing only a single line of user code. To learn more see the programming guide.</li>
+    </ul>
+  </li>
+  <li><strong>Stream-Stream Joins</strong>
+    <ul>
+      <li>Ability to join two streams of data, buffering rows until matching tuples arrive in the other stream. Predicates can be used against event time columns to bound the amount of state that needs to be retained.</li>
+    </ul>
+  </li>
+  <li><strong>Streaming API V2</strong>
+    <ul>
+      <li>An experimental API for plugging in new source and sinks that works for batch, micro-batch, and continuous execution. Note this API is still undergoing active development and breaking changes should be expected.</li>
+    </ul>
+  </li>
+</ul>
+
+<p><em>Programming guide: <a href="/docs/2.3.0/structured-streaming-programming-guide.html">Structured Streaming Programming Guide</a>.</em></p>
+
+<h3 id="mllib">MLlib</h3>
+
+<ul>
+  <li><strong>Highlights</strong>
+    <ul>
+      <li>ML Prediction now works with Structured Streaming, using updated APIs. Details below.</li>
+    </ul>
+  </li>
+  <li><strong>New/Improved APIs</strong>
+    <ul>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-21866">SPARK-21866</a>]: Built-in support for reading images into a DataFrame (Scala/Java/Python)</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-19634">SPARK-19634</a>]: DataFrame functions for descriptive summary statistics over vector columns (Scala/Java)</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-14516">SPARK-14516</a>]: <code>ClusteringEvaluator</code> for tuning clustering algorithms, supporting Cosine silhouette and squared Euclidean silhouette metrics (Scala/Java/Python)</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-3181">SPARK-3181</a>]: Robust linear regression with Huber loss (Scala/Java/Python)</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-13969">SPARK-13969</a>]: <code>FeatureHasher</code> transformer (Scala/Java/Python)</li>
+      <li>Multiple column support for several feature transformers:
+        <ul>
+          <li>[<a href="https://issues.apache.org/jira/browse/SPARK-13030">SPARK-13030</a>]: <code>OneHotEncoderEstimator</code> (Scala/Java/Python)</li>
+          <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22397">SPARK-22397</a>]: <code>QuantileDiscretizer</code> (Scala/Java)</li>
+          <li>[<a href="https://issues.apache.org/jira/browse/SPARK-20542">SPARK-20542</a>]: <code>Bucketizer</code> (Scala/Java/Python)</li>
+        </ul>
+      </li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-21633">SPARK-21633</a>] and <a href="https://issues.apache.org/jira/browse/SPARK-21542">SPARK-21542</a>]: Improved support for custom pipeline components in Python.</li>
+    </ul>
+  </li>
+  <li><strong>New Features</strong>
+    <ul>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-21087">SPARK-21087</a>]: <code>CrossValidator</code> and <code>TrainValidationSplit</code> can collect all models when fitting (Scala/Java).  This allows you to inspect or save all fitted models.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-19357">SPARK-19357</a>]: Meta-algorithms <code>CrossValidator</code>, <code>TrainValidationSplit, </code>OneVsRest` support a parallelism Param for fitting multiple sub-models in parallel Spark jobs</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-17139">SPARK-17139</a>]: Model summary for multinomial logistic regression (Scala/Java/Python)</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-18710">SPARK-18710</a>]: Add offset in GLM</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-20199">SPARK-20199</a>]: Added <code>featureSubsetStrategy</code> Param to <code>GBTClassifier</code> and <code>GBTRegressor</code>.  Using this to subsample features can significantly improve training speed; this option has been a key strength of <code>xgboost</code>.</li>
+    </ul>
+  </li>
+  <li><strong>Other Notable Changes</strong>
+    <ul>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22156">SPARK-22156</a>] Fixed <code>Word2Vec</code> learning rate scaling with <code>num</code> iterations.  The new learning rate is set to match the original <code>Word2Vec</code> C code and should give better results from training.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22289">SPARK-22289</a>] Add <code>JSON</code> support for Matrix parameters (This fixed a bug for ML persistence with <code>LogisticRegressionModel</code> when using bounds on coefficients.)</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22700">SPARK-22700</a>] <code>Bucketizer.transform</code> incorrectly drops row containing <code>NaN</code>.  When Param <code>handleInvalid</code> was set to “skip,” <code>Bucketizer</code> would drop a row with a valid value in the input column if another (irrelevant) column had a <code>NaN</code> value.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22446">SPARK-22446</a>] Catalyst optimizer sometimes caused <code>StringIndexerModel</code> to throw an incorrect “Unseen label” exception when <code>handleInvalid</code> was set to “error.”  This could happen for filtered data, due to predicate push-down, causing errors even after invalid rows had already been filtered from the input dataset.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-21681">SPARK-21681</a>] Fixed an edge case bug in multinomial logistic regression that resulted in incorrect coefficients when some features had zero variance.</li>
+      <li>Major optimizations:
+        <ul>
+          <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22707">SPARK-22707</a>] Reduced memory consumption for <code>CrossValidator</code></li>
+          <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22949">SPARK-22949</a>] Reduced memory consumption for <code>TrainValidationSplit</code></li>
+          <li>[<a href="https://issues.apache.org/jira/browse/SPARK-21690">SPARK-21690</a>] <code>Imputer</code> should train using a single pass over the data</li>
+          <li>[<a href="https://issues.apache.org/jira/browse/SPARK-14371">SPARK-14371</a>] <code>OnlineLDAOptimizer</code> avoids collecting statistics to the driver for each mini-batch.</li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+</ul>
+
+<p><em>Programming guide: <a href="/docs/2.3.0/ml-guide.html">Machine Learning Library (MLlib) Guide</a>.</em></p>
+
+<h3 id="sparkr">SparkR</h3>
+
+<p>The main focus of SparkR in the 2.3.0 release was towards improving the stability of UDFs and adding several new SparkR wrappers around existing APIs:</p>
+
+<ul>
+  <li><strong>Major features</strong>
+    <ul>
+      <li>Improved function parity between SQL and R</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22933">SPARK-22933</a>]: Structured Streaming APIs for <code>withWatermark</code>, <code>trigger</code>, <code>partitionBy</code> and stream-stream joins</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-21266">SPARK-21266</a>]: SparkR UDF with DDL-formatted schema support</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-20726">SPARK-20726</a>][<a href="https://issues.apache.org/jira/browse/SPARK-22924">SPARK-22924</a>][<a href="https://issues.apache.org/jira/browse/SPARK-22843">SPARK-22843</a>] Several new Dataframe API Wrappers</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-15767">SPARK-15767</a>][<a href="https://issues.apache.org/jira/browse/SPARK-21622">SPARK-21622</a>][<a href="https://issues.apache.org/jira/browse/SPARK-20917">SPARK-20917</a>][<a href="https://issues.apache.org/jira/browse/SPARK-20307">SPARK-20307</a>][<a href="https://issues.apache.org/jira/browse/SPARK-20906">SPARK-20906</a>] Several new SparkML API Wrappers</li>
+    </ul>
+  </li>
+</ul>
+
+<p><em>Programming guide: <a href="/docs/2.3.0/sparkr.html">SparkR (R on Spark)</a>.</em></p>
+
+<h3 id="graphx">GraphX</h3>
+
+<ul>
+  <li><strong>Optimizations</strong>
+    <ul>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-5484">SPARK-5484</a>] Pregel now checkpoints periodically to avoid <code>StackOverflowErrors</code></li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-21491">SPARK-21491</a>] Small performance improvement in several places</li>
+    </ul>
+  </li>
+</ul>
+
+<p><em>Programming guide: <a href="/docs/2.3.0/graphx-programming-guide.html">GraphX Programming Guide</a>.</em></p>
+
+<h3 id="deprecations">Deprecations</h3>
+
+<ul>
+  <li><strong>Python</strong>
+    <ul>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-23122">SPARK-23122</a>] Deprecate <code>register*</code> for UDFs in <code>SQLContext</code> and <code>Catalog</code> in PySpark</li>
+    </ul>
+  </li>
+  <li><strong>MLlib</strong>
+    <ul>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-13030">SPARK-13030</a>] <code>OneHotEncoder</code> has been deprecated and will be removed in 3.0. It has been replaced by the new <code>OneHotEncoderEstimator</code>. Note that <code>OneHotEncoderEstimator</code> will be renamed to <code>OneHotEncoder</code> in 3.0 (but <code>OneHotEncoderEstimator</code> will be kept as an alias).</li>
+    </ul>
+  </li>
+</ul>
+
+<h3 id="changes-of-behavior">Changes of behavior</h3>
+
+<ul>
+  <li><strong>SparkSQL</strong>
+    <ul>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22036">SPARK-22036</a>]: By default arithmetic operations between decimals return a rounded value if an exact representation is not possible (instead of returning <code>NULL</code> in the prior versions)</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22937">SPARK-22937</a>]: When all inputs are binary, SQL <code>elt()</code> returns an output as binary. Otherwise, it returns as a string. In the prior versions, it always returns as a string despite of input types.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22895">SPARK-22895</a>]: The Join/Filter&#8217;s deterministic predicates that are after the first non-deterministic predicates are also pushed down/through the child operators, if possible. In the prior versions, these filters were not eligible for predicate pushdown.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22771">SPARK-22771</a>]: When all inputs are binary, <code>functions.concat()</code> returns an output as binary. Otherwise, it returns as a string. In the prior versions, it always returns as a string despite of input types.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22489">SPARK-22489</a>]: When either of the join sides is broadcastable, we prefer to broadcasting the table that is explicitly specified in a broadcast hint.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22165">SPARK-22165</a>]: Partition column inference previously found incorrect common type for different inferred types, for example, previously it ended up with <code>double</code> type as the common type for <code>double</code> type and <code>date</code> type. Now it finds the correct common type for such conflicts. For details, see the <a href="/docs/2.3.0/sql-programming-guide.html#migration-guide">migration guide</a>.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22100">SPARK-22100</a>]: The <code>percentile_approx</code> function previously accepted <code>numeric</code> type input and outputted <code>double</code> type results. Now it supports <code>date</code> type, <code>timestamp</code> type and <code>numeric</code> types as input types. The result type is also changed to be the same as the input type, which is more reasonable for percentiles.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-21610">SPARK-21610</a>]: the queries from raw JSON/CSV files are disallowed when the referenced columns only include the internal corrupt record column (named <code>_corrupt_record</code> by default). Instead, you can cache or save the parsed results and then send the same query.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-23421">SPARK-23421</a>]: Since Spark 2.2.1 and 2.3.0, the schema is always inferred at runtime when the data source tables have the columns that exist in both partition schema and data schema. The inferred schema does not have the partitioned columns. When reading the table, Spark respects the partition values of these overlapping columns instead of the values stored in the data source files. In 2.2.0 and 2.1.x release, the inferred schema is partitioned but the data of the table is invisible to users (i.e., the result set is empty).</li>
+    </ul>
+  </li>
+  <li><strong>PySpark</strong>
+    <ul>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-19732">SPARK-19732</a>]: <code>na.fill()</code> or <code>fillna</code> also accepts boolean and replaces nulls with booleans. In prior Spark versions, PySpark just ignores it and returns the original Dataset/DataFrame.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22395">SPARK-22395</a>]: Pandas <code>0.19.2</code> or upper is required for using Pandas related functionalities, such as <code>toPandas</code>, <code>createDataFrame</code> from Pandas DataFrame, etc.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-22395">SPARK-22395</a>]: The behavior of timestamp values for Pandas related functionalities was changed to respect session timezone, which is ignored in the prior versions.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-23328">SPARK-23328</a>]: <code>df.replace</code> does not allow to omit <code>value</code> when <code>to_replace</code> is not a dictionary. Previously, <code>value</code> could be omitted in the other cases and had <code>None</code> by default, which is counter-intuitive and error prone.</li>
+    </ul>
+  </li>
+  <li><strong>MLlib</strong>
+    <ul>
+      <li><strong>Breaking API Changes</strong>: The class and trait hierarchy for logistic regression model summaries was changed to be cleaner and better accommodate the addition of the multi-class summary. This is a breaking change for user code that casts a <code>LogisticRegressionTrainingSummary</code> to a <code>BinaryLogisticRegressionTrainingSummary</code>. Users should instead use the <code>model.binarySummary</code> method. See [<a href="https://issues.apache.org/jira/browse/SPARK-17139">SPARK-17139</a>] for more detail (note this is an <code>@Experimental</code> API). This does not affect the Python summary method, which will still work correctly for both multinomial and binary cases.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-21806">SPARK-21806</a>]: <code>BinaryClassificationMetrics.pr()</code>: first point (0.0, 1.0) is misleading and has been replaced by (0.0, p) where precision p matches the lowest recall point.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-16957">SPARK-16957</a>]: Decision trees now use weighted midpoints when choosing split values.  This may change results from model training.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-14657">SPARK-14657</a>]: <code>RFormula</code> without an intercept now outputs the reference category when encoding string terms, in order to match native R behavior.  This may change results from model training.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-21027">SPARK-21027</a>]: The default parallelism used in <code>OneVsRest</code> is now set to 1 (i.e. serial). In 2.2 and earlier versions, the level of parallelism was set to the default threadpool size in Scala.  This may change performance.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-21523">SPARK-21523</a>]: Upgraded Breeze to <code>0.13.2</code>.  This included an important bug fix in strong Wolfe line search for L-BFGS.</li>
+      <li>[<a href="https://issues.apache.org/jira/browse/SPARK-15526">SPARK-15526</a>]: The JPMML dependency is now shaded.</li>
+      <li>Also see the “Bug fixes” section for behavior changes resulting from fixing bugs.</li>
+    </ul>
+  </li>
+</ul>
+
+<h3 id="known-issues">Known Issues</h3>
+
+<ul>
+  <li>[<a href="https://issues.apache.org/jira/browse/SPARK-23523">SPARK-23523</a>][SQL] Incorrect result caused by the rule <code>OptimizeMetadataOnlyQuery</code></li>
+  <li>[<a href="https://issues.apache.org/jira/browse/SPARK-23406">SPARK-23406</a>] Bugs in stream-stream self-joins</li>
+</ul>
+
+<h3 id="credits">Credits</h3>
+<p>Last but not least, this release would not have been possible without the following contributors:
+ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Alberto Rodriguez De Lema, Alex Mikhailau, Alexander Istomin, Anderson Osagie, Andrea Zito, Andrew Ash, Andrew Korzhuev, Andrew Ray, Anirudh Ramanathan, Anton Okolnychyi, Arman Yazdani, Armin Braun, Arseniy Tashoyan, Arthur Rand, Atallah Hezbor, Attila Zsolt Piros, Ayush Singh, Bago Amirbekian, Ben Barnard, Bo Meng, Bo Xu, Bogdan Raducanu, Brad Kaiser, Bravo Zhang, Bruce Robbins, Bruce Xu, Bryan Cutler, Burak Yavuz, Carson Wang, Chang Chen, Charles Chen, Cheng Wang, Chenjun Zou, Chenzhao Guo, Chetan Khatri, Chie Hayashida, Chin Han Yu, Chunsheng Ji, Corey Woodfield, Daniel Li, Daniel Van Der Ende, Devaraj K, Dhruve Ashar, Dilip Biswal, Dmitry Parfenchik, Donghui Xu, Dongjoon Hyun, Eren Avsarogullari, Eric Vandenberg, Erik LaBianca, Eyal Farago, Favio Vazquez, Felix Cheung, Feng Liu, Feng Zhu, Fernando Pereira, Fokko Driesprong, Gabor Somogyi, Gene Pang, Gera Shegalov, German Schiavon, Glen Takahashi, Greg Owen, Grzegorz Slowikowski, Guilherme Berger, Guillaume Dardelet, Guo Xiao Long, He Qiao, Henry Robinson, Herman Van Hovell, Hideaki Tanaka, Holden Karau, Huang Tengfei, Huaxin Gao, Hyukjin Kwon, Ilya Matiach, Imran Rashid, Iurii Antykhovych, Ivan Sadikov, Jacek Laskowski, JackYangzg, Jakub Dubovsky, Jakub Nowacki, James Thompson, Jan Vrsovsky, Jane Wang, Jannik Arndt, Jason Taaffe, Jeff Zhang, Jen-Ming Chung, Jia Li, Jia-Xuan Liu, Jin Xing, Jinhua Fu, Jirka Kremser, Joachim Hereth, John Compitello, John Lee, John O&#8217;Leary, Jorge Machado, Jose Torres, Joseph K. Bradley, Josh Rosen, Juliusz Sompolski, Kalvin Chau, Kazuaki Ishizaki, Kent Yao, Kento NOZAWA, Kevin Yu, Kirby Linvill, Kohki Nishio, Kousuke Saruta, Kris Mok, Krishna Pandey, Kyle Kelley, Li Jin, Li Yichao, Li Yuanjian, Liang-Chi Hsieh, Lijia Liu, Liu Shaohui, Liu Xian, Liyun Zhang, Louis Lyu, Lubo Zhang, Luca Canali, Maciej Brynski, Maciej Szymkiewicz, Madhukara Phatak, Mahmut CAVDAR, Marcelo Vanzin, Marco Gaido, Marcos P, Marcos P. Sanchez, Mark Petruska, Maryann Xue, Masha Basmanova, Miao Wang, Michael Allman, Michael Armbrust, Michael Gummelt, Michael Mior, Michael Patterson, Michael Styles, Michal Senkyr, Mikhail Sveshnikov, Min Shen, Ming Jiang, Mingjie Tang, Mridul Muralidharan, Nan Zhu, Nathan Kronenfeld, Neil Alexander McQuarrie, Ngone51, Nicholas Chammas, Nick Pentreath, Ohad Raviv, Oleg Danilov, Onur Satici, PJ Fanning, Parth Gandhi, Patrick Woody, Paul Mackles, Peng Meng, Peng Xiao, Pengcheng Liu, Peter Szalai, Pralabh Kumar, Prashant Sharma, Rekha Joshi, Remis Haroon, Reynold Xin, Reza Safi, Riccardo Corbella, Rishabh Bhardwaj, Robert Kruszewski, Ron Hu, Ruben Berenguel Montoro, Ruben Janssen, Rui Zha, Rui Zhan, Ruifeng Zheng, Russell Spitzer, Ryan Blue, Sahil Takiar, Saisai Shao, Sameer Agarwal, Sandor Murakozi, Sanket Chintapalli, Santiago Saavedra, Sathiya Kumar, Sean Owen, Sergei Lebedev, Sergey Serebryakov, Sergey Zhemzhitsky, Seth Hendrickson, Shane Jarvie, Shashwat Anand, Shintaro Murakami, Shivaram Venkataraman, Shixiong Zhu, Shuangshuang Wang, Sid Murching, Sital Kedia, Soonmok Kwon, Srinivasa Reddy Vundela, Stavros Kontopoulos, Steve Loughran, Steven Rand, Sujith, Sujith Jay Nair, Sumedh Wale, Sunitha Kambhampati, Suresh Thalamati, Susan X. Huynh, Takeshi Yamamuro, Takuya UESHIN, Tathagata Das, Tejas Patil, Teng Peng, Thomas Graves, Tim Van Wassenhove, Travis Hegner, Tristan Stevens, Tucker Beck, Valeriy Avanesov, Vinitha Gankidi, Vinod KC, Wang Gengliang, Wayne Zhang, Weichen Xu, Wenchen Fan, Wieland Hoffmann, Wil Selwood, Wing Yew Poon, Xiang Gao, Xianjin YE, Xianyang Liu, Xiao Li, Xiaochen Ouyang, Xiaofeng Lin, Xiaokai Zhao, Xiayun Sun, Xin Lu, Xin Ren, Xingbo Jiang, Yan Facai (Yan Fa Cai), Yan Kit Li, Yanbo Liang, Yash Sharma, Yinan Li, Yong Tang, Youngbin Kim, Yuanjian Li, Yucai Yu, Yuhai Cen, Yuhao Yang, Yuming Wang, Yuval Itzchakov, Zhan Zhang, Zhang A Peng, Zhaokun Liu, Zheng RuiFeng, Zhenhua Wang, Zuo Tingbing, brandonJY, caneGuy, cxzl25, djvulee, eatoncys, heary-cao, ho3rexqj, lizhaoch, maclockard, neoremind, peay, shaofei007, wangjiaochun, zenglinxi0615</p>
+
+
+<p>
+<br/>
+<a href="/news/">Spark News Archive</a>
+</p>
+
+  </div>
+</div>
+
+
+
+<footer class="small">
+  <hr>
+  Apache Spark, Spark, Apache, and the Spark logo are <a href="/trademarks.html">trademarks</a> of
+  <a href="https://www.apache.org">The Apache Software Foundation</a>.
+  Copyright &copy; 2018 The Apache Software Foundation, Licensed under the
+  <a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache License, Version 2.0</a>.
+</footer>
+
+</div>
+
+</body>
+</html>

--- a/site/research.html
+++ b/site/research.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/security.html
+++ b/site/security.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -139,6 +139,14 @@
 </url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
+  <loc>https://spark.apache.org/releases/spark-release-2-3-0.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/news/spark-2-3-0-released.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/releases/spark-release-2-2-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -164,6 +164,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -172,9 +175,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -164,6 +164,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -172,9 +175,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -161,6 +161,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-0-released.html">Spark 2.3.0 released</a>
+          <span class="small">(Feb 28, 2018)</span></li>
+        
           <li><a href="/news/spark-2-2-1-released.html">Spark 2.2.1 released</a>
           <span class="small">(Dec 01, 2017)</span></li>
         
@@ -169,9 +172,6 @@
         
           <li><a href="/news/spark-summit-eu-2017-agenda-posted.html">Spark Summit Europe (October 24-26th, 2017, Dublin, Ireland) agenda posted</a>
           <span class="small">(Aug 28, 2017)</span></li>
-        
-          <li><a href="/news/spark-2-2-0-released.html">Spark 2.2.0 released</a>
-          <span class="small">(Jul 11, 2017)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>


### PR DESCRIPTION
This patch adds the release notes and relevant announcements for Spark 2.3.0.

Release notes: https://github.com/sameeragarwal/spark-website/blob/100f9cbc90241c8fb618d83141396748f81868a5/releases/_posts/2018-02-28-spark-release-2-3-0.md