### PR TITLE
Redirect mean.html to column_aggregate_functions

### DIFF
--- a/site/docs/2.3.0/api/R/mean.html
+++ b/site/docs/2.3.0/api/R/mean.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="refresh" content="0; url=column_aggregate_functions.html">
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
This is a temporary fix to handle SparkR 2.3.0 where the vignette contains a link to mean.html but the page was removed in the release. 

https://github.com/apache/spark/pull/20711 fixes the problem for future releases but users who download the current SparkR 2.3.0 package will see a 404. 

