### PR TITLE
Add a project history page

### DIFF
--- a/_layouts/global.html
+++ b/_layouts/global.html
@@ -138,6 +138,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="{{site.baseurl}}/powered-by.html">Powered By</a></li>
           <li><a href="{{site.baseurl}}/committers.html">Project Committers</a></li>
+          <li><a href="{{site.baseurl}}/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/community.md
+++ b/community.md
@@ -72,7 +72,7 @@ Some quick tips when using email:
 and include only a few lines of the pertinent code / log within the email.
 - No jobs, sales, or solicitation is permitted on the Apache Spark mailing lists.
 
-<h5>Reporting Security issues</h5>
+<h5>Reporting Security Issues</h5>
 
 Please see the [Security](security.html) page for information on how to report sensitive security
 vulnerabilities, and for information on known security issues.
@@ -125,7 +125,7 @@ Chat rooms are great for quick questions or discussions on specialized topics. T
 </ul>
 
 <h4>Meetups</h4>
-Spark Meetups are grass-roots events organized and hosted by leaders and champions in the community around the world. Check out <a href="http://spark.meetup.com">http://spark.meetup.com</a> to find a Spark meetup in your part of the world. Below is a partial list of Spark meetups.
+Spark Meetups are grass-roots events organized and hosted by individuals in the community around the world. Check out <a href="https://www.meetup.com/topics/apache-spark/">meetup.com/topics/apache-spark</a> to find a Spark meetup in your part of the world. Below is a partial list of Spark meetups.
 <ul>
   <li>
     <a href="https://www.meetup.com/spark-users/">Bay Area Spark Meetup.</a>
@@ -212,7 +212,7 @@ Spark Meetups are grass-roots events organized and hosted by leaders and champio
   </li>
 </ul>
 
-<p>If you'd like your meetup added, email <a href="mailto:user@spark.apache.org">user@spark.apache.org</a>.</p>
+<p>If you'd like your meetup or conference added, please email <a href="mailto:user@spark.apache.org">user@spark.apache.org</a>.</p>
 
 <a name="issue-tracker"></a>
 <h3>Issue Tracker</h3>
@@ -221,20 +221,6 @@ Spark Meetups are grass-roots events organized and hosted by leaders and champio
 
 <h3>Powered By</h3>
 
-<p>Our wiki has a list of <a href="{{site.baseurl}}/powered-by.html">projects and organizations powered by Spark</a>.</p>
-
-<a name="history"></a>
-<h3>Project History</h3>
-
-
-<p>
-Spark started as a research project at the <a href="https://amplab.cs.berkeley.edu">UC Berkeley AMPLab</a>
-in 2009, and was open sourced in early 2010.
-Many of the ideas behind the system are presented in various
-<a href="{{site.baseurl}}/research.html">research papers</a>.
-</p>
-
-<p>
-After being released, Spark grew a developer community on GitHub and moved to Apache in 2013.
-A wide range of contributors now develop the project (over 400 developers from 100 companies).
+<p>Our site has a list of <a href="{{site.baseurl}}/powered-by.html">projects and organizations powered by Spark</a>.
+Add yours by emailing `dev@spark.apache.org`.
 </p>

--- a/history.md
+++ b/history.md
@@ -1,0 +1,29 @@
+---
+layout: global
+title: History
+type: "page singular"
+navigation:
+  weight: 5
+  show: true
+---
+
+<h2>Apache Spark History</h2>
+
+<p>
+Apache Spark started as a research project at the <a href="https://amplab.cs.berkeley.edu">UC Berkeley AMPLab</a>
+in 2009, and was open sourced in early 2010.
+Many of the ideas behind the system were presented in various
+<a href="{{site.baseurl}}/research.html">research papers</a> over the years.
+</p>
+
+<p>
+After being released, Spark grew into a broad developer community, and moved to the
+<a href="https://www.apache.org">Apache Software Foundation</a> in 2013.
+Today, the project is developed collaboratively by a community of hundreds of developers from
+hundreds of organizations.
+</p>
+
+<p>
+You can get involved in Apache Spark development by reading
+<a href="{{site.baseurl}}/contributing.html">how to contribute</a>.
+</p>

--- a/index.md
+++ b/index.md
@@ -129,8 +129,8 @@ navigation:
 
     <p>
       Spark is used at a wide range of organizations to process large datasets.
-      You can find example use cases at the <a href="https://spark-summit.org/">Spark Summit</a>
-      conference, or on the <a href="{{site.baseurl}}/powered-by.html">Powered By</a> page.
+      You can find many example use cases on the
+      <a href="{{site.baseurl}}/powered-by.html">Powered By</a> page.
     </p>
 
     <p>
@@ -138,8 +138,7 @@ navigation:
     </p>
     <ul class="list-narrow">
       <li>Use the <a href="{{site.baseurl}}/community.html#mailing-lists">mailing lists</a> to ask questions.</li>
-      <li>In-person events include numerous <a href="http://www.meetup.com/topics/apache-spark/">meetup groups</a> and
-      <a href="https://spark-summit.org/">Spark Summit</a>.</li>
+      <li>In-person events include numerous <a href="{{site.baseurl}}/community.html#events">meetup groups and conferences</a>.</li>
       <li>We use <a href="https://issues.apache.org/jira/browse/SPARK">JIRA</a> for issue tracking.</li>
     </ul>
   </div>
@@ -155,7 +154,7 @@ navigation:
     <p>
       The project's
       <a href="{{site.baseurl}}/committers.html">committers</a>
-      come from 19 organizations.
+      come from more than 20 organizations.
     </p>
 
     <p>
@@ -167,13 +166,10 @@ navigation:
   <div class="col-md-4 col-padded">
     <h3>Getting Started</h3>
 
-    <p>Learning Spark is easy whether you come from a Java or Python background:</p>
+    <p>Learning Apache Spark is easy whether you come from a Java, Scala, Python or R background:</p>
     <ul class="list-narrow">
-      <li><a href="{{site.baseurl}}/downloads.html">Download</a> the latest release &mdash; you can run Spark locally on your laptop.</li>
+      <li><a href="{{site.baseurl}}/downloads.html">Download</a> the latest release: you can run Spark locally on your laptop.</li>
       <li>Read the <a href="{{site.baseurl}}/docs/latest/quick-start.html">quick start guide</a>.</li>
-      <li>
-        Spark Summit 2014 contained free <a href="https://spark-summit.org/2014/training">training videos and exercises</a>.
-      </li>
       <li>Learn how to <a href="{{site.baseurl}}/docs/latest/#launching-on-a-cluster">deploy</a> Spark on a cluster.</li>
     </ul>
   </div>

--- a/site/committers.html
+++ b/site/committers.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/community.html
+++ b/site/community.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -272,7 +273,7 @@ and include only a few lines of the pertinent code / log within the email.</li>
   <li>No jobs, sales, or solicitation is permitted on the Apache Spark mailing lists.</li>
 </ul>
 
-<h5>Reporting Security issues</h5>
+<h5>Reporting Security Issues</h5>
 
 <p>Please see the <a href="security.html">Security</a> page for information on how to report sensitive security
 vulnerabilities, and for information on known security issues.</p>
@@ -325,7 +326,7 @@ vulnerabilities, and for information on known security issues.</p>
 </ul>
 
 <h4>Meetups</h4>
-<p>Spark Meetups are grass-roots events organized and hosted by leaders and champions in the community around the world. Check out <a href="http://spark.meetup.com">http://spark.meetup.com</a> to find a Spark meetup in your part of the world. Below is a partial list of Spark meetups.</p>
+<p>Spark Meetups are grass-roots events organized and hosted by individuals in the community around the world. Check out <a href="https://www.meetup.com/topics/apache-spark/">meetup.com/topics/apache-spark</a> to find a Spark meetup in your part of the world. Below is a partial list of Spark meetups.</p>
 <ul>
   <li>
     <a href="https://www.meetup.com/spark-users/">Bay Area Spark Meetup.</a>
@@ -412,7 +413,7 @@ vulnerabilities, and for information on known security issues.</p>
   </li>
 </ul>
 
-<p>If you'd like your meetup added, email <a href="mailto:user@spark.apache.org">user@spark.apache.org</a>.</p>
+<p>If you'd like your meetup or conference added, please email <a href="mailto:user@spark.apache.org">user@spark.apache.org</a>.</p>
 
 <p><a name="issue-tracker"></a></p>
 <h3>Issue Tracker</h3>
@@ -421,21 +422,8 @@ vulnerabilities, and for information on known security issues.</p>
 
 <h3>Powered By</h3>
 
-<p>Our wiki has a list of <a href="/powered-by.html">projects and organizations powered by Spark</a>.</p>
-
-<p><a name="history"></a></p>
-<h3>Project History</h3>
-
-<p>
-Spark started as a research project at the <a href="https://amplab.cs.berkeley.edu">UC Berkeley AMPLab</a>
-in 2009, and was open sourced in early 2010.
-Many of the ideas behind the system are presented in various
-<a href="/research.html">research papers</a>.
-</p>
-
-<p>
-After being released, Spark grew a developer community on GitHub and moved to Apache in 2013.
-A wide range of contributors now develop the project (over 400 developers from 100 companies).
+<p>Our site has a list of <a href="/powered-by.html">projects and organizations powered by Spark</a>.
+Add yours by emailing `dev@spark.apache.org`.
 </p>
 
   </div>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/examples.html
+++ b/site/examples.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/faq.html
+++ b/site/faq.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -126,6 +126,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/history.html
+++ b/site/history.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark tips from Quantifind | Apache Spark
+     History | Apache Spark
     
   </title>
 
@@ -195,20 +195,25 @@
   </div>
 
   <div class="col-md-9 col-md-pull-3">
-    <h2>Spark tips from Quantifind</h2>
-
-
-<p><a href="http://www.quantifind.com">Quantifind</a>, one of the Bay Area companies that has been using Spark for predictive analytics, recently posted two useful entries on working with Spark in their tech blog:</p>
-<ul>
-<li><a href="http://blog.quantifind.com/posts/spark-unit-test/">Unit testing with Spark</a></li>
-<li><a href="http://blog.quantifind.com/posts/logging-post/">Configuring Spark's logs</a></li>
-</ul>
-<p>Thanks for sharing this, and looking forward to see others!</p>
-
+    <h2>Apache Spark History</h2>
 
 <p>
-<br/>
-<a href="/news/">Spark News Archive</a>
+Apache Spark started as a research project at the <a href="https://amplab.cs.berkeley.edu">UC Berkeley AMPLab</a>
+in 2009, and was open sourced in early 2010.
+Many of the ideas behind the system were presented in various
+<a href="/research.html">research papers</a> over the years.
+</p>
+
+<p>
+After being released, Spark grew into a broad developer community, and moved to the
+<a href="https://www.apache.org">Apache Software Foundation</a> in 2013.
+Today, the project is developed collaboratively by a community of hundreds of developers from
+hundreds of organizations.
+</p>
+
+<p>
+You can get involved in Apache Spark development by reading
+<a href="/contributing.html">how to contribute</a>.
 </p>
 
   </div>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/index.html
+++ b/site/index.html
@@ -125,6 +125,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">
@@ -310,8 +311,8 @@
 
     <p>
       Spark is used at a wide range of organizations to process large datasets.
-      You can find example use cases at the <a href="https://spark-summit.org/">Spark Summit</a>
-      conference, or on the <a href="/powered-by.html">Powered By</a> page.
+      You can find many example use cases on the
+      <a href="/powered-by.html">Powered By</a> page.
     </p>
 
     <p>
@@ -319,8 +320,7 @@
     </p>
     <ul class="list-narrow">
       <li>Use the <a href="/community.html#mailing-lists">mailing lists</a> to ask questions.</li>
-      <li>In-person events include numerous <a href="http://www.meetup.com/topics/apache-spark/">meetup groups</a> and
-      <a href="https://spark-summit.org/">Spark Summit</a>.</li>
+      <li>In-person events include numerous <a href="/community.html#events">meetup groups and conferences</a>.</li>
       <li>We use <a href="https://issues.apache.org/jira/browse/SPARK">JIRA</a> for issue tracking.</li>
     </ul>
   </div>
@@ -336,7 +336,7 @@
     <p>
       The project's
       <a href="/committers.html">committers</a>
-      come from 19 organizations.
+      come from more than 20 organizations.
     </p>
 
     <p>
@@ -348,13 +348,10 @@
   <div class="col-md-4 col-padded">
     <h3>Getting Started</h3>
 
-    <p>Learning Spark is easy whether you come from a Java or Python background:</p>
+    <p>Learning Apache Spark is easy whether you come from a Java, Scala, Python or R background:</p>
     <ul class="list-narrow">
-      <li><a href="/downloads.html">Download</a> the latest release &mdash; you can run Spark locally on your laptop.</li>
+      <li><a href="/downloads.html">Download</a> the latest release: you can run Spark locally on your laptop.</li>
       <li>Read the <a href="/docs/latest/quick-start.html">quick start guide</a>.</li>
-      <li>
-        Spark Summit 2014 contained free <a href="https://spark-summit.org/2014/training">training videos and exercises</a>.
-      </li>
       <li>Learn how to <a href="/docs/latest/#launching-on-a-cluster">deploy</a> Spark on a cluster.</li>
     </ul>
   </div>

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -126,6 +126,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -126,6 +126,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-summit-east-agenda-posted.html
+++ b/site/news/spark-summit-east-agenda-posted.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/research.html
+++ b/site/research.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/security.html
+++ b/site/security.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -680,6 +680,10 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
+  <loc>http://localhost:4000/history.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>http://localhost:4000/improvement-proposals.html</loc>
   <changefreq>weekly</changefreq>
 </url>
@@ -688,11 +692,7 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/sql/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>http://localhost:4000/screencasts/</loc>
+  <loc>http://localhost:4000/mllib/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
@@ -700,15 +700,19 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>http://localhost:4000/mllib/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
   <loc>http://localhost:4000/news/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>http://localhost:4000/screencasts/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>http://localhost:4000/sql/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>http://localhost:4000/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -126,6 +126,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -126,6 +126,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -123,6 +123,7 @@
           <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
           <li><a href="/powered-by.html">Powered By</a></li>
           <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
         </ul>
       </li>
       <li class="dropdown">


### PR DESCRIPTION
This moves our history text to its own page and adds it in the nav structure, which people suggested to make it easier to find. I also fixed some stale text and links throughout.