### PR TITLE
Use "Apache Foo" consistently; remove defunct Tachyon and EC2 refs

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -23,7 +23,7 @@ Spark is a fast and general processing engine compatible with Hadoop data. It ca
 
 <p class="question">Does my data need to fit in memory to use Spark?</p>
 
-<p class="answer">No. Spark's operators spill data to disk if it does not fit in memory, allowing it to run well on any sized data. Likewise, cached datasets that do not fit in memory are either spilled to disk or recomputed on the fly when needed, as determined by the RDD's <a href="{{site.baseurl}}/docs/latest/scala-programming-guide.html#rdd-persistence">storage level</a>.
+<p class="answer">No. Spark's operators spill data to disk if it does not fit in memory, allowing it to run well on any sized data. Likewise, cached datasets that do not fit in memory are either spilled to disk or recomputed on the fly when needed, as determined by the RDD's <a href="{{site.baseurl}}/docs/latest/rdd-programming-guide.html#rdd-persistence">storage level</a>.
 
 <p class="question">How can I run Spark on a cluster?</p>
 <p class="answer">You can use either the <a href="{{site.baseurl}}/docs/latest/spark-standalone.html">standalone deploy mode</a>, which only needs Java to be installed on each node, or the <a href="{{site.baseurl}}/docs/latest/running-on-mesos.html">Mesos</a> and <a href="{{site.baseurl}}/docs/latest/running-on-yarn.html">YARN</a> cluster managers. If you'd like to run on Amazon EC2, AMPLab provides <a href="https://github.com/amplab/spark-ec2#readme">EC2 scripts</a> to automatically launch a cluster.</p>

--- a/index.md
+++ b/index.md
@@ -20,7 +20,7 @@ navigation:
 
     <p class="lead">
       Run programs up to 100x faster than
-      Hadoop MapReduce in memory, or 10x faster on disk.
+      Apache Hadoop MapReduce in memory, or 10x faster on disk.
     </p>
 
     <p>
@@ -109,13 +109,20 @@ navigation:
     <h2>Runs Everywhere</h2>
 
     <p class="lead">
-      Spark runs on Hadoop, Mesos, Kubernetes, standalone, or in the cloud. It can access diverse data sources including HDFS, Cassandra, HBase, and S3.
+      Spark runs on Hadoop, Apache Mesos, Kubernetes, standalone, or in the cloud. It can access diverse data sources.
     </p>
 
     <p>
-      You can run Spark using its <a href="{{site.baseurl}}/docs/latest/spark-standalone.html">standalone cluster mode</a>, on <a href="https://github.com/amplab/spark-ec2">EC2</a>, on <a href="https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YARN.html">Hadoop YARN</a>, on <a href="https://mesos.apache.org">Apache Mesos</a>, or on <a href="https://kubernetes.io/">Kubernetes</a>.
-      Access data in <a href="https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html">HDFS</a>, <a href="https://cassandra.apache.org">Cassandra</a>, <a href="https://hbase.apache.org">HBase</a>,
-      <a href="https://hive.apache.org">Hive</a>, <a href="http://tachyon-project.org">Tachyon</a>, and any Hadoop data source.
+      You can run Spark using its <a href="{{site.baseurl}}/docs/latest/spark-standalone.html">standalone cluster mode</a>, 
+      on <a href="https://github.com/amplab/spark-ec2">EC2</a>, 
+      on <a href="https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YARN.html">Hadoop YARN</a>, 
+      on <a href="https://mesos.apache.org">Mesos</a>, or 
+      on <a href="https://kubernetes.io/">Kubernetes</a>.
+      Access data in <a href="https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html">HDFS</a>, 
+      <a href="https://cassandra.apache.org">Apache Cassandra</a>, 
+      <a href="https://hbase.apache.org">Apache HBase</a>,
+      <a href="https://hive.apache.org">Apache Hive</a>, 
+      and any Hadoop data source.
     </p>
   </div>
   <div class="col-md-5 col-sm-5 col-padded-top col-center">
@@ -148,13 +155,13 @@ navigation:
 
     <p>
       Apache Spark is built by a wide set of developers from over 200 companies.
-      Since 2009, more than 1000 developers have contributed to Spark!
+      Since 2009, more than 1100 developers have contributed to Spark!
     </p>
 
     <p>
       The project's
       <a href="{{site.baseurl}}/committers.html">committers</a>
-      come from more than 20 organizations.
+      come from more than 25 organizations.
     </p>
 
     <p>

--- a/mllib/index.md
+++ b/mllib/index.md
@@ -68,7 +68,7 @@ subproject: MLlib
     <p>
       If you have a Hadoop 2 cluster, you can run Spark and MLlib without any pre-installation.
       Otherwise, Spark is easy to run <a href="{{site.baseurl}}/docs/latest/spark-standalone.html">standalone</a>
-      or on <a href="{{site.baseurl}}/docs/latest/ec2-scripts.html">EC2</a> or <a href="https://mesos.apache.org">Mesos</a>.
+      or other supported cluster resource managers.
       You can read from <a href="https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html">HDFS</a>, <a href="https://hbase.apache.org">HBase</a>, or any Hadoop data source.
     </p>
   </div>

--- a/site/faq.html
+++ b/site/faq.html
@@ -211,7 +211,7 @@ Spark is a fast and general processing engine compatible with Hadoop data. It ca
 
 <p class="question">Does my data need to fit in memory to use Spark?</p>
 
-<p class="answer">No. Spark's operators spill data to disk if it does not fit in memory, allowing it to run well on any sized data. Likewise, cached datasets that do not fit in memory are either spilled to disk or recomputed on the fly when needed, as determined by the RDD's <a href="/docs/latest/scala-programming-guide.html#rdd-persistence">storage level</a>.
+<p class="answer">No. Spark's operators spill data to disk if it does not fit in memory, allowing it to run well on any sized data. Likewise, cached datasets that do not fit in memory are either spilled to disk or recomputed on the fly when needed, as determined by the RDD's <a href="/docs/latest/rdd-programming-guide.html#rdd-persistence">storage level</a>.
 
 <p class="question">How can I run Spark on a cluster?</p>
 <p class="answer">You can use either the <a href="/docs/latest/spark-standalone.html">standalone deploy mode</a>, which only needs Java to be installed on each node, or the <a href="/docs/latest/running-on-mesos.html">Mesos</a> and <a href="/docs/latest/running-on-yarn.html">YARN</a> cluster managers. If you'd like to run on Amazon EC2, AMPLab provides <a href="https://github.com/amplab/spark-ec2#readme">EC2 scripts</a> to automatically launch a cluster.</p>

--- a/site/index.html
+++ b/site/index.html
@@ -207,7 +207,7 @@
 
     <p class="lead">
       Run programs up to 100x faster than
-      Hadoop MapReduce in memory, or 10x faster on disk.
+      Apache Hadoop MapReduce in memory, or 10x faster on disk.
     </p>
 
     <p>
@@ -291,13 +291,20 @@
     <h2>Runs Everywhere</h2>
 
     <p class="lead">
-      Spark runs on Hadoop, Mesos, Kubernetes, standalone, or in the cloud. It can access diverse data sources including HDFS, Cassandra, HBase, and S3.
+      Spark runs on Hadoop, Apache Mesos, Kubernetes, standalone, or in the cloud. It can access diverse data sources.
     </p>
 
     <p>
-      You can run Spark using its <a href="/docs/latest/spark-standalone.html">standalone cluster mode</a>, on <a href="https://github.com/amplab/spark-ec2">EC2</a>, on <a href="https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YARN.html">Hadoop YARN</a>, on <a href="https://mesos.apache.org">Apache Mesos</a>, or on <a href="https://kubernetes.io/">Kubernetes</a>.
-      Access data in <a href="https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html">HDFS</a>, <a href="https://cassandra.apache.org">Cassandra</a>, <a href="https://hbase.apache.org">HBase</a>,
-      <a href="https://hive.apache.org">Hive</a>, <a href="http://tachyon-project.org">Tachyon</a>, and any Hadoop data source.
+      You can run Spark using its <a href="/docs/latest/spark-standalone.html">standalone cluster mode</a>, 
+      on <a href="https://github.com/amplab/spark-ec2">EC2</a>, 
+      on <a href="https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YARN.html">Hadoop YARN</a>, 
+      on <a href="https://mesos.apache.org">Mesos</a>, or 
+      on <a href="https://kubernetes.io/">Kubernetes</a>.
+      Access data in <a href="https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html">HDFS</a>, 
+      <a href="https://cassandra.apache.org">Apache Cassandra</a>, 
+      <a href="https://hbase.apache.org">Apache HBase</a>,
+      <a href="https://hive.apache.org">Apache Hive</a>, 
+      and any Hadoop data source.
     </p>
   </div>
   <div class="col-md-5 col-sm-5 col-padded-top col-center">
@@ -330,13 +337,13 @@
 
     <p>
       Apache Spark is built by a wide set of developers from over 200 companies.
-      Since 2009, more than 1000 developers have contributed to Spark!
+      Since 2009, more than 1100 developers have contributed to Spark!
     </p>
 
     <p>
       The project's
       <a href="/committers.html">committers</a>
-      come from more than 20 organizations.
+      come from more than 25 organizations.
     </p>
 
     <p>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -260,7 +260,7 @@
     <p>
       If you have a Hadoop 2 cluster, you can run Spark and MLlib without any pre-installation.
       Otherwise, Spark is easy to run <a href="/docs/latest/spark-standalone.html">standalone</a>
-      or on <a href="/docs/latest/ec2-scripts.html">EC2</a> or <a href="https://mesos.apache.org">Mesos</a>.
+      or other supported cluster resource managers.
       You can read from <a href="https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html">HDFS</a>, <a href="https://hbase.apache.org">HBase</a>, or any Hadoop data source.
     </p>
   </div>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -287,7 +287,7 @@
     </p>
     <p>
       You can run Spark Streaming on Spark's <a href="/docs/latest/spark-standalone.html">standalone cluster mode</a>
-      or <a href="/docs/latest/ec2-scripts.html">EC2</a>.
+      or other supported cluster resource managers.
       It also includes a local run mode for development.
       In production,
       Spark Streaming uses <a href="https://zookeeper.apache.org">ZooKeeper</a> and <a href="https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html">HDFS</a> for high availability.

--- a/streaming/index.md
+++ b/streaming/index.md
@@ -98,7 +98,7 @@ subproject: Streaming
     </p>
     <p>
       You can run Spark Streaming on Spark's <a href="{{site.baseurl}}/docs/latest/spark-standalone.html">standalone cluster mode</a>
-      or <a href="{{site.baseurl}}/docs/latest/ec2-scripts.html">EC2</a>.
+      or other supported cluster resource managers.
       It also includes a local run mode for development.
       In production,
       Spark Streaming uses <a href="https://zookeeper.apache.org">ZooKeeper</a> and <a href="https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html">HDFS</a> for high availability.


### PR DESCRIPTION
This fixes a few broken links, like to the old EC2 docs, which occurred in places where resource managers don't need enumeration anyway.

It also uses "Apache Foo" first more consistently on the home page; being prominent, seems good to get it slavishly correct. I removed some redundant wording in the relevant section (listed managers and sources basically twice, a little differently) and removed the ref to Tachyon as defunct.