### PR TITLE
Check if 'original_head' variable is defined in clean_up at merge script

### DIFF
--- a/merge_pr.py
+++ b/merge_pr.py
@@ -85,15 +85,15 @@ def continue_maybe(prompt):
         fail("Okay, exiting")
 
 def clean_up():
-    print "Restoring head pointer to %s" % original_head
-    run_cmd("git checkout %s" % original_head)
+    if 'original_head' in globals():
+        print "Restoring head pointer to %s" % original_head
+        run_cmd("git checkout %s" % original_head)
 
-    branches = run_cmd("git branch").replace(" ", "").split("\n")
+        branches = run_cmd("git branch").replace(" ", "").split("\n")
 
-    for branch in filter(lambda x: x.startswith(BRANCH_PREFIX), branches):
-        print "Deleting local branch %s" % branch
-        run_cmd("git branch -D %s" % branch)
-
+        for branch in filter(lambda x: x.startswith(BRANCH_PREFIX), branches):
+            print "Deleting local branch %s" % branch
+            run_cmd("git branch -D %s" % branch)
 
 # merge the requested PR and return the merge hash
 def merge_pr(pr_num, target_ref, title, body, pr_repo_desc):


### PR DESCRIPTION
This is the same fix as https://github.com/apache/spark/pull/21349