### PR TITLE
[SPARK-24679] Download page should not link to unreleased code

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -211,6 +211,15 @@ this explicitly, by submitting any copyrighted material via pull request, email,
 you agree to license the material under the project's open source license and warrant that you 
 have the legal authority to do so.**
 
+<h3>Cloning the Apache Spark source code</h3>
+
+If you are interested in working with the newest under-development code or contributing to Apache Spark development, you can check out the master branch from Git:
+
+    # Master development branch
+    git clone git://github.com/apache/spark.git
+
+Once you've downloaded Spark, you can find instructions for installing and building it on the <a href="{{site.baseurl}}/documentation.html">documentation page</a>.
+
 <h3>JIRA</h3>
 
 Generally, Spark uses JIRA to track logical issues, including bugs and improvements, and uses 

--- a/downloads.md
+++ b/downloads.md
@@ -53,17 +53,6 @@ Spark artifacts are [hosted in Maven Central](https://search.maven.org/#search%7
 ### Installing with PyPi
 <a href="https://pypi.python.org/pypi/pyspark">PySpark</a> is now available in pypi. To install just run `pip install pyspark`.
 
-### Spark Source Code Management
-If you are interested in working with the newest under-development code or contributing to Apache Spark development, you can also check out the master branch from Git:
-
-    # Master development branch
-    git clone git://github.com/apache/spark.git
-
-    # Maintenance branch with stability fixes on top of Spark 2.3.1
-    git clone git://github.com/apache/spark.git -b branch-2.3
-
-Once you've downloaded Spark, you can find instructions for installing and building it on the <a href="{{site.baseurl}}/documentation.html">documentation page</a>.
-
 ### Release Notes for Stable Releases
 
 <ul id="sparkReleaseNotes"></ul>
@@ -72,6 +61,4 @@ Once you've downloaded Spark, you can find instructions for installing and build
 
 As new Spark releases come out for each development stream, previous ones will be archived, but they are still available at [Spark release archives](https://archive.apache.org/dist/spark/).
 
-### Nightly Packages and Artifacts
-For developers, Spark maintains nightly builds and SNAPSHOT artifacts. More information is available on the [the Developer Tools page](/developer-tools.html#nightly-builds).
 

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -423,6 +423,16 @@ this explicitly, by submitting any copyrighted material via pull request, email,
 you agree to license the material under the project&#8217;s open source license and warrant that you 
 have the legal authority to do so.</strong></p>
 
+<h3>Cloning the Apache Spark source code</h3>
+
+<p>If you are interested in working with the newest under-development code or contributing to Apache Spark development, you can check out the master branch from Git:</p>
+
+<pre><code># Master development branch
+git clone git://github.com/apache/spark.git
+</code></pre>
+
+<p>Once you&#8217;ve downloaded Spark, you can find instructions for installing and building it on the <a href="/documentation.html">documentation page</a>.</p>
+
 <h3>JIRA</h3>
 
 <p>Generally, Spark uses JIRA to track logical issues, including bugs and improvements, and uses 

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -254,18 +254,6 @@ version: 2.3.1
 <h3 id="installing-with-pypi">Installing with PyPi</h3>
 <p><a href="https://pypi.python.org/pypi/pyspark">PySpark</a> is now available in pypi. To install just run <code>pip install pyspark</code>.</p>
 
-<h3 id="spark-source-code-management">Spark Source Code Management</h3>
-<p>If you are interested in working with the newest under-development code or contributing to Apache Spark development, you can also check out the master branch from Git:</p>
-
-<pre><code># Master development branch
-git clone git://github.com/apache/spark.git
-
-# Maintenance branch with stability fixes on top of Spark 2.3.1
-git clone git://github.com/apache/spark.git -b branch-2.3
-</code></pre>
-
-<p>Once you&#8217;ve downloaded Spark, you can find instructions for installing and building it on the <a href="/documentation.html">documentation page</a>.</p>
-
 <h3 id="release-notes-for-stable-releases">Release Notes for Stable Releases</h3>
 
 <ul id="sparkReleaseNotes"></ul>
@@ -273,9 +261,6 @@ git clone git://github.com/apache/spark.git -b branch-2.3
 <h3 id="archived-releases">Archived Releases</h3>
 
 <p>As new Spark releases come out for each development stream, previous ones will be archived, but they are still available at <a href="https://archive.apache.org/dist/spark/">Spark release archives</a>.</p>
-
-<h3 id="nightly-packages-and-artifacts">Nightly Packages and Artifacts</h3>
-<p>For developers, Spark maintains nightly builds and SNAPSHOT artifacts. More information is available on the <a href="/developer-tools.html#nightly-builds">the Developer Tools page</a>.</p>
 
 
   </div>


### PR DESCRIPTION
Remove instructions to checkout code which will download the
full repository including unreleased code. Also remove links
to nightly builds as these are not released code.
