### PR TITLE
Update configuration.html

### DIFF
--- a/site/docs/2.3.1/configuration.html
+++ b/site/docs/2.3.1/configuration.html
@@ -2632,7 +2632,7 @@ Spark&#8217;s classpath for each application. In a Spark cluster running on YARN
 files are set cluster-wide, and cannot safely be changed by the application.</p>
 
 <p>The better choice is to use spark hadoop properties in the form of <code>spark.hadoop.*</code>. 
-They can be considered as same as normal spark properties which can be set in <code>$SPARK_HOME/conf/spark-defalut.conf</code></p>
+They can be considered as same as normal spark properties which can be set in <code>$SPARK_HOME/conf/spark-defaults.conf</code></p>
 
 <p>In some cases, you may want to avoid hard-coding certain configurations in a <code>SparkConf</code>. For
 instance, Spark allows you to simply create an empty conf and set spark/spark hadoop properties.</p>


### PR DESCRIPTION
spelling mistake for mention of spark-defaults.conf

They can be considered as same as normal spark properties which can be set in <code>$SPARK_HOME/conf/spark-defaults.conf</code></p>

