### PR TITLE
Add Alluxio back to replace Tachyon as one possible data source

### DIFF
--- a/index.md
+++ b/index.md
@@ -115,6 +115,7 @@ df.<span style="color: #000000;">where</span><span style="color: #F78811;">&#40;
       on <a href="https://mesos.apache.org">Mesos</a>, or 
       on <a href="https://kubernetes.io/">Kubernetes</a>.
       Access data in <a href="https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html">HDFS</a>, 
+      <a href="https://alluxio.org">Alluxio</a>,
       <a href="https://cassandra.apache.org">Apache Cassandra</a>, 
       <a href="https://hbase.apache.org">Apache HBase</a>,
       <a href="https://hive.apache.org">Apache Hive</a>, 

--- a/site/index.html
+++ b/site/index.html
@@ -302,6 +302,7 @@ df.<span style="color: #000000;">where</span><span style="color: #F78811;">&#40;
       on <a href="https://mesos.apache.org">Mesos</a>, or 
       on <a href="https://kubernetes.io/">Kubernetes</a>.
       Access data in <a href="https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/HdfsUserGuide.html">HDFS</a>, 
+      <a href="https://alluxio.org">Alluxio</a>,
       <a href="https://cassandra.apache.org">Apache Cassandra</a>, 
       <a href="https://hbase.apache.org">Apache HBase</a>,
       <a href="https://hive.apache.org">Apache Hive</a>, 


### PR DESCRIPTION
In the index page, "Tachyon" as one data source is removed in https://github.com/apache/spark-website/pull/109. This Pull Request adds its successor Alluxio back (Tachyon was renamed into Alluxio in 2016).
