### PR TITLE
improve the document about contributing to bug reports

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -89,7 +89,8 @@ first. Unreproducible bugs, or simple error reports, may be closed.
 
 It's very helpful if the bug report has a description about how the bug was introduced, by 
 which commit, so that reviewers can easily understand the bug. It also helps committers to 
-decide how far the bug fix should be backported, when the pull request is merged.
+decide how far the bug fix should be backported, when the pull request is merged. The pull 
+request to fix the bug should narrow down the problem to the root cause.
 
 Performance regression is also one kind of bug. The pull request to fix a performance regression 
 must provide a benchmark to prove the problem is indeed fixed.

--- a/contributing.md
+++ b/contributing.md
@@ -87,6 +87,16 @@ and ideally reproduce the bug. Simply encountering an error does not mean a bug 
 reported; as below, search JIRA and search and inquire on the Spark user / dev mailing lists 
 first. Unreproducible bugs, or simple error reports, may be closed.
 
+It's very helpful if the bug report has a description about how the bug was introduced, by 
+which commit, so that reviewers can easily understand the bug. It also helps committers to 
+decide how far the bug fix should be backported, when the pull request is merged.
+
+Performance regression is also one kind of bug. The pull request to fix a performance regression 
+must provide a benchmark to prove the problem is indeed fixed.
+
+Note that, data correctness/data loss bugs are very serious. If the bug report doesn't get 
+enough attention, please send an email to `dev@spark.apache.org`, to draw more attentions.
+
 It is possible to propose new features as well. These are generally not helpful unless 
 accompanied by detail, such as a design document and/or code change. Large new contributions 
 should consider <a href="https://spark-packages.org/">spark-packages.org</a> first (see above), 

--- a/contributing.md
+++ b/contributing.md
@@ -94,7 +94,8 @@ decide how far the bug fix should be backported, when the pull request is merged
 Performance regression is also one kind of bug. The pull request to fix a performance regression 
 must provide a benchmark to prove the problem is indeed fixed.
 
-Note that, data correctness/data loss bugs are very serious. If the bug report doesn't get 
+Note that, data correctness/data loss bugs are very serious. Make sure the corresponding bug 
+report JIRA ticket is labeled as `correctness` or `data-loss`. If the bug report doesn't get 
 enough attention, please send an email to `dev@spark.apache.org`, to draw more attentions.
 
 It is possible to propose new features as well. These are generally not helpful unless 

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -287,7 +287,8 @@ decide how far the bug fix should be backported, when the pull request is merged
 <p>Performance regression is also one kind of bug. The pull request to fix a performance regression 
 must provide a benchmark to prove the problem is indeed fixed.</p>
 
-<p>Note that, data correctness/data loss bugs are very serious. If the bug report doesn&#8217;t get 
+<p>Note that, data correctness/data loss bugs are very serious. Make sure the corresponding bug 
+report JIRA ticket is labeled as <code>correctness</code> or <code>data-loss</code>. If the bug report doesn&#8217;t get 
 enough attention, please send an email to <code>dev@spark.apache.org</code>, to draw more attentions.</p>
 
 <p>It is possible to propose new features as well. These are generally not helpful unless 

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -280,6 +280,16 @@ and ideally reproduce the bug. Simply encountering an error does not mean a bug 
 reported; as below, search JIRA and search and inquire on the Spark user / dev mailing lists 
 first. Unreproducible bugs, or simple error reports, may be closed.</p>
 
+<p>It&#8217;s very helpful if the bug report has a description about how the bug was introduced, by 
+which commit, so that reviewers can easily understand the bug. It also helps committers to 
+decide how far the bug fix should be backported, when the pull request is merged.</p>
+
+<p>Performance regression is also one kind of bug. The pull request to fix a performance regression 
+must provide a benchmark to prove the problem is indeed fixed.</p>
+
+<p>Note that, data correctness/data loss bugs are very serious. If the bug report doesn&#8217;t get 
+enough attention, please send an email to <code>dev@spark.apache.org</code>, to draw more attentions.</p>
+
 <p>It is possible to propose new features as well. These are generally not helpful unless 
 accompanied by detail, such as a design document and/or code change. Large new contributions 
 should consider <a href="https://spark-packages.org/">spark-packages.org</a> first (see above), 


### PR DESCRIPTION
Recently we hit many correctness bugs, and some of them do not get enough attention. I want to highlight the importance of data correctness/data loss issues, and suggest contributors to describe how the bug was introduced, so that people can quickly understand the bug. It's also possible that the reporter doesn't realize it's a correctness bug, by looking at how the bug was introduced, other people can point it out.