### PR TITLE
Add back IBM Spectrum Conductor to third party list 

### DIFF
--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -240,6 +240,7 @@ against Spark, and data scientists to use Javascript in Jupyter notebooks.</li>
 OLTP + OLAP database integrated with Spark on the same JVMs.</li>
   <li><a href="https://github.com/Hydrospheredata/mist">Mist</a> - Serverless proxy for Spark cluster (spark middleware)</li>
   <li><a href="https://github.com/GoogleCloudPlatform/spark-on-k8s-operator">K8S Operator for Apache Spark</a> - Kubernetes operator for specifying and managing the lifecycle of Apache Spark applications on Kubernetes.</li>
+  <li><a href="https://developer.ibm.com/storage/products/ibm-spectrum-conductor-spark/">IBM Spectrum Conductor</a> - Cluster management software that integrates with Spark and modern computing frameworks.</li>
 </ul>
 
 <h2>Applications Using Spark</h2>

--- a/third-party-projects.md
+++ b/third-party-projects.md
@@ -46,6 +46,7 @@ against Spark, and data scientists to use Javascript in Jupyter notebooks.
 OLTP + OLAP database integrated with Spark on the same JVMs.
 - <a href="https://github.com/Hydrospheredata/mist">Mist</a> - Serverless proxy for Spark cluster (spark middleware)
 - <a href="https://github.com/GoogleCloudPlatform/spark-on-k8s-operator">K8S Operator for Apache Spark</a> - Kubernetes operator for specifying and managing the lifecycle of Apache Spark applications on Kubernetes.
+- <a href="https://developer.ibm.com/storage/products/ibm-spectrum-conductor-spark/">IBM Spectrum Conductor</a> - Cluster management software that integrates with Spark and mordern application frameworks.
 
 <h2>Applications Using Spark</h2>
 

--- a/third-party-projects.md
+++ b/third-party-projects.md
@@ -46,7 +46,7 @@ against Spark, and data scientists to use Javascript in Jupyter notebooks.
 OLTP + OLAP database integrated with Spark on the same JVMs.
 - <a href="https://github.com/Hydrospheredata/mist">Mist</a> - Serverless proxy for Spark cluster (spark middleware)
 - <a href="https://github.com/GoogleCloudPlatform/spark-on-k8s-operator">K8S Operator for Apache Spark</a> - Kubernetes operator for specifying and managing the lifecycle of Apache Spark applications on Kubernetes.
-- <a href="https://developer.ibm.com/storage/products/ibm-spectrum-conductor-spark/">IBM Spectrum Conductor</a> - Cluster management software that integrates with Spark and mordern application frameworks.
+- <a href="https://developer.ibm.com/storage/products/ibm-spectrum-conductor-spark/">IBM Spectrum Conductor</a> - Cluster management software that integrates with Spark and modern computing frameworks.
 
 <h2>Applications Using Spark</h2>
 


### PR DESCRIPTION
IBM Spectrum Conductor (old name IBM Spectrum Conductor with Spark) was part of the list of third party projects but was removed as it had a dead link. This to bring it back with an updated link.