### PR TITLE
Add some guides for testing individual PySpark tests at Developer Tools

### DIFF
--- a/developer-tools.md
+++ b/developer-tools.md
@@ -128,6 +128,52 @@ To run individual Java tests, you can use the `-Dtest` flag:
 build/mvn test -DwildcardSuites=none -Dtest=org.apache.spark.streaming.JavaAPISuite test
 ```
 
+<h4>Testing PySpark</h4>
+
+To run individual PySpark tests, you can use `run-tests` script under `python` directory. Test cases are located at `tests` package under each PySpark packages.
+
+To run test cases in a specific module:
+
+```
+$ python/run-tests --testnames pyspark.sql.tests.test_arrow
+```
+
+To run test cases in a specific class:
+
+```
+$ python/run-tests --testnames 'pyspark.sql.tests.test_arrow ArrowTests'
+```
+
+To run single test case in a specific class:
+
+```
+$ python/run-tests --testnames 'pyspark.sql.tests.test_arrow ArrowTests.test_null_conversion'
+```
+
+You can also run doctests in a specific module:
+
+```
+$ python/run-tests --testnames pyspark.sql.dataframe
+```
+
+Lastly, there is another script called `run-tests-with-coverage` in the same location, which generates coverage report for PySpark tests. It accepts same arguments with `run-tests`.
+
+```
+$ python/run-tests-with-coverage --testnames pyspark.sql.tests.test_arrow --python-executables=python
+...
+Name                              Stmts   Miss Branch BrPart  Cover
+-------------------------------------------------------------------
+pyspark/__init__.py                  42      4      8      2    84%
+pyspark/_globals.py                  16      3      4      2    75%
+...
+Generating HTML files for PySpark coverage under /.../spark/python/test_coverage/htmlcov
+```
+
+You can check the coverage report visually by HTMLs under `/.../spark/python/test_coverage/htmlcov`.
+
+Please check other available options via `python/run-tests[-with-coverage] --help`.
+
+
 <h3>ScalaTest Issues</h3>
 
 If the following error occurs when running ScalaTest

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -311,6 +311,46 @@ $ build/mvn package -DskipTests -pl core
 <pre><code>build/mvn test -DwildcardSuites=none -Dtest=org.apache.spark.streaming.JavaAPISuite test
 </code></pre>
 
+<h4>Testing PySpark</h4>
+
+<p>To run individual PySpark tests, you can use <code>run-tests</code> script under <code>python</code> directory. Test cases are located at <code>tests</code> package under each PySpark packages.</p>
+
+<p>To run test cases in a specific module:</p>
+
+<pre><code>$ python/run-tests --testnames pyspark.sql.tests.test_arrow
+</code></pre>
+
+<p>To run test cases in a specific class:</p>
+
+<pre><code>$ python/run-tests --testnames 'pyspark.sql.tests.test_arrow ArrowTests'
+</code></pre>
+
+<p>To run single test case in a specific class:</p>
+
+<pre><code>$ python/run-tests --testnames 'pyspark.sql.tests.test_arrow ArrowTests.test_null_conversion'
+</code></pre>
+
+<p>You can also run doctests in a specific module:</p>
+
+<pre><code>$ python/run-tests --testnames pyspark.sql.dataframe
+</code></pre>
+
+<p>Lastly, there is another script called <code>run-tests-with-coverage</code> in the same location, which generates coverage report for PySpark tests. It accepts same arguments with <code>run-tests</code>.</p>
+
+<pre><code>$ python/run-tests-with-coverage --testnames pyspark.sql.tests.test_arrow --python-executables=python
+...
+Name                              Stmts   Miss Branch BrPart  Cover
+-------------------------------------------------------------------
+pyspark/__init__.py                  42      4      8      2    84%
+pyspark/_globals.py                  16      3      4      2    75%
+...
+Generating HTML files for PySpark coverage under /.../spark/python/test_coverage/htmlcov
+</code></pre>
+
+<p>You can check the coverage report visually by HTMLs under <code>/.../spark/python/test_coverage/htmlcov</code>.</p>
+
+<p>Please check other available options via <code>python/run-tests[-with-coverage] --help</code>.</p>
+
 <h3>ScalaTest Issues</h3>
 
 <p>If the following error occurs when running ScalaTest</p>


### PR DESCRIPTION
This PR adds some guides for testing individual PySpark tests, and also some information about PySpark coverage.

![screen shot 2018-12-05 at 3 59 50 pm](https://user-images.githubusercontent.com/6477701/49498733-014f4800-f8a7-11e8-8b51-b96e25fbc1bc.png)

See also https://github.com/apache/spark/pull/23203 and SPARK-26252