### PR TITLE
Add a note about Spark build requirement at PySpark testing guide in Developer Tools

### DIFF
--- a/developer-tools.md
+++ b/developer-tools.md
@@ -131,6 +131,8 @@ build/mvn test -DwildcardSuites=none -Dtest=org.apache.spark.streaming.JavaAPISu
 <h4>Testing PySpark</h4>
 
 To run individual PySpark tests, you can use `run-tests` script under `python` directory. Test cases are located at `tests` package under each PySpark packages.
+Note that, if you add some changes into Scala or Python side in Apache Spark, you need to manually build Apache Spark again before running PySpark tests in order to apply the changes.
+Running PySpark testing script does not automatically build it.
 
 To run test cases in a specific module:
 

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -313,7 +313,9 @@ $ build/mvn package -DskipTests -pl core
 
 <h4>Testing PySpark</h4>
 
-<p>To run individual PySpark tests, you can use <code>run-tests</code> script under <code>python</code> directory. Test cases are located at <code>tests</code> package under each PySpark packages.</p>
+<p>To run individual PySpark tests, you can use <code>run-tests</code> script under <code>python</code> directory. Test cases are located at <code>tests</code> package under each PySpark packages.
+Note that, if you add some changes into Scala or Python side in Apache Spark, you need to manually build Apache Spark again before running PySpark tests in order to apply the changes.
+Running PySpark testing script does not automatically build it.</p>
 
 <p>To run test cases in a specific module:</p>
 


### PR DESCRIPTION
I received some feedback about running PySpark tests via a private channel. Unlike SBT or Maven testing, PySpark testing script requires to build Apache Spark manually.
I also realised that it might be confusing when we think about SBT, Maven and PySpark testing.
