### PR TITLE
Update 2.3.1 to use archive

### DIFF
--- a/js/downloads.js
+++ b/js/downloads.js
@@ -34,7 +34,7 @@ var packagesV9 = [hadoop2p7, hadoop2p6, hadoopFree, scala2p12_hadoopFree, source
 
 addRelease("2.4.0", new Date("11/02/2018"), packagesV9, true, true);
 addRelease("2.3.2", new Date("09/24/2018"), packagesV8, true, true);
-addRelease("2.3.1", new Date("06/08/2018"), packagesV8, true, true);
+addRelease("2.3.1", new Date("06/08/2018"), packagesV8, true, false);
 addRelease("2.3.0", new Date("02/28/2018"), packagesV8, true, false);
 addRelease("2.2.3", new Date("01/11/2019"), packagesV8, true, true);
 addRelease("2.2.2", new Date("07/02/2018"), packagesV8, true, false);

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -34,7 +34,7 @@ var packagesV9 = [hadoop2p7, hadoop2p6, hadoopFree, scala2p12_hadoopFree, source
 
 addRelease("2.4.0", new Date("11/02/2018"), packagesV9, true, true);
 addRelease("2.3.2", new Date("09/24/2018"), packagesV8, true, true);
-addRelease("2.3.1", new Date("06/08/2018"), packagesV8, true, true);
+addRelease("2.3.1", new Date("06/08/2018"), packagesV8, true, false);
 addRelease("2.3.0", new Date("02/28/2018"), packagesV8, true, false);
 addRelease("2.2.3", new Date("01/11/2019"), packagesV8, true, true);
 addRelease("2.2.2", new Date("07/02/2018"), packagesV8, true, false);


### PR DESCRIPTION
We need to update 2.3.1 download to use the archive URL and remove it from mirror. 