### PR TITLE
Add Apache Spark 2.3.3 release news and update links

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -13,6 +13,7 @@ navigation:
 
 <ul>
   <li><a href="{{site.baseurl}}/docs/2.4.0/">Spark 2.4.0</a></li>
+  <li><a href="{{site.baseurl}}/docs/2.3.3/">Spark 2.3.3</a></li>
   <li><a href="{{site.baseurl}}/docs/2.3.2/">Spark 2.3.2</a></li>
   <li><a href="{{site.baseurl}}/docs/2.3.1/">Spark 2.3.1</a></li>
   <li><a href="{{site.baseurl}}/docs/2.3.0/">Spark 2.3.0</a></li>

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -23,7 +23,7 @@ var packagesV8 = [hadoop2p7, hadoop2p6, hadoopFree, sources];
 var packagesV9 = [hadoop2p7, hadoop2p6, hadoopFree, scala2p12_hadoopFree, sources];
 
 addRelease("2.4.0", new Date("11/02/2018"), packagesV9, true);
-addRelease("2.3.2", new Date("09/24/2018"), packagesV8, true);
+addRelease("2.3.3", new Date("02/15/2019"), packagesV8, true);
 addRelease("2.2.3", new Date("01/11/2019"), packagesV8, true);
 
 function append(el, contents) {

--- a/news/_posts/2019-02-15-spark-2-3-3-released.md
+++ b/news/_posts/2019-02-15-spark-2-3-3-released.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: Spark 2.3.3 released
+categories:
+- News
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+We are happy to announce the availability of <a href="{{site.baseurl}}/releases/spark-release-2-3-3.html" title="Spark Release 2.3.3">Spark 2.3.3</a>! Visit the <a href="{{site.baseurl}}/releases/spark-release-2-3-3.html" title="Spark Release 2.3.3">release notes</a> to read about the new features, or <a href="{{site.baseurl}}/downloads.html">download</a> the release today.

--- a/releases/_posts/2019-02-15-spark-release-2-3-3.md
+++ b/releases/_posts/2019-02-15-spark-release-2-3-3.md
@@ -1,0 +1,18 @@
+---
+layout: post
+title: Spark Release 2.3.3
+categories: []
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+
+Spark 2.3.3 is a maintenance release containing stability fixes. This release is based on the branch-2.3 maintenance branch of Spark. We strongly recommend all 2.3.2 users to upgrade to this stable release.
+
+You can consult JIRA for the [detailed changes](https://s.apache.org/spark-2.3.3).
+
+We would like to acknowledge all community members for contributing patches to this release.

--- a/site/committers.html
+++ b/site/committers.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/community.html
+++ b/site/community.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
@@ -206,6 +206,7 @@
 
 <ul>
   <li><a href="/docs/2.4.0/">Spark 2.4.0</a></li>
+  <li><a href="/docs/2.3.3/">Spark 2.3.3</a></li>
   <li><a href="/docs/2.3.2/">Spark 2.3.2</a></li>
   <li><a href="/docs/2.3.1/">Spark 2.3.1</a></li>
   <li><a href="/docs/2.3.0/">Spark 2.3.0</a></li>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/examples.html
+++ b/site/examples.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/faq.html
+++ b/site/faq.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/history.html
+++ b/site/history.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/index.html
+++ b/site/index.html
@@ -164,6 +164,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -172,9 +175,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -23,7 +23,7 @@ var packagesV8 = [hadoop2p7, hadoop2p6, hadoopFree, sources];
 var packagesV9 = [hadoop2p7, hadoop2p6, hadoopFree, scala2p12_hadoopFree, sources];
 
 addRelease("2.4.0", new Date("11/02/2018"), packagesV9, true);
-addRelease("2.3.2", new Date("09/24/2018"), packagesV8, true);
+addRelease("2.3.3", new Date("02/15/2019"), packagesV8, true);
 addRelease("2.2.3", new Date("01/11/2019"), packagesV8, true);
 
 function append(el, contents) {

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
@@ -201,6 +201,15 @@
 
   <div class="col-md-9 col-md-pull-3">
     <h2 id="spark-news">Spark News</h2>
+
+<article class="hentry">
+    <header class="entry-header">
+      <h3 class="entry-title"><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a></h3>
+      <div class="entry-date">February 15, 2019</div>
+    </header>
+    <div class="entry-content"><p>We are happy to announce the availability of <a href="/releases/spark-release-2-3-3.html" title="Spark Release 2.3.3">Spark 2.3.3</a>! Visit the <a href="/releases/spark-release-2-3-3.html" title="Spark Release 2.3.3">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+</div>
+  </article>
 
 <article class="hentry">
     <header class="entry-header">

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-3-released.html
+++ b/site/news/spark-2-1-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-2-released.html
+++ b/site/news/spark-2-2-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-1-released.html
+++ b/site/news/spark-2-3-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-2-released.html
+++ b/site/news/spark-2-3-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-3-released.html
+++ b/site/news/spark-2-3-3-released.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark 2.2.3 released | Apache Spark
+     Spark 2.3.3 released | Apache Spark
     
   </title>
 
@@ -200,10 +200,10 @@
   </div>
 
   <div class="col-md-9 col-md-pull-3">
-    <h2>Spark 2.2.3 released</h2>
+    <h2>Spark 2.3.3 released</h2>
 
 
-<p>We are happy to announce the availability of <a href="/releases/spark-release-2-2-3.html" title="Spark Release 2.2.3">Spark 2.2.3</a>! Visit the <a href="/releases/spark-release-2-2-3.html" title="Spark Release 2.2.3">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+<p>We are happy to announce the availability of <a href="/releases/spark-release-2-3-3.html" title="Spark Release 2.3.3">Spark 2.3.3</a>! Visit the <a href="/releases/spark-release-2-3-3.html" title="Spark Release 2.3.3">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
 
 
 <p>

--- a/site/news/spark-2-4-0-released.html
+++ b/site/news/spark-2-4-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-apr-2019-agenda-posted.html
+++ b/site/news/spark-ai-summit-apr-2019-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted.html
+++ b/site/news/spark-summit-east-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-oct-2018-agenda-posted.html
+++ b/site/news/spark-summit-oct-2018-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-3.html
+++ b/site/releases/spark-release-2-1-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-2.html
+++ b/site/releases/spark-release-2-2-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-3.html
+++ b/site/releases/spark-release-2-2-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-1.html
+++ b/site/releases/spark-release-2-3-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-2.html
+++ b/site/releases/spark-release-2-3-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-3.html
+++ b/site/releases/spark-release-2-3-3.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark 2.2.3 released | Apache Spark
+     Spark Release 2.3.3 | Apache Spark
     
   </title>
 
@@ -200,10 +200,14 @@
   </div>
 
   <div class="col-md-9 col-md-pull-3">
-    <h2>Spark 2.2.3 released</h2>
+    <h2>Spark Release 2.3.3</h2>
 
 
-<p>We are happy to announce the availability of <a href="/releases/spark-release-2-2-3.html" title="Spark Release 2.2.3">Spark 2.2.3</a>! Visit the <a href="/releases/spark-release-2-2-3.html" title="Spark Release 2.2.3">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+<p>Spark 2.3.3 is a maintenance release containing stability fixes. This release is based on the branch-2.3 maintenance branch of Spark. We strongly recommend all 2.3.2 users to upgrade to this stable release.</p>
+
+<p>You can consult JIRA for the <a href="https://s.apache.org/spark-2.3.3">detailed changes</a>.</p>
+
+<p>We would like to acknowledge all community members for contributing patches to this release.</p>
 
 
 <p>

--- a/site/releases/spark-release-2-4-0.html
+++ b/site/releases/spark-release-2-4-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/research.html
+++ b/site/research.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/security.html
+++ b/site/security.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -139,6 +139,14 @@
 </url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
+  <loc>https://spark.apache.org/releases/spark-release-2-3-3.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/news/spark-2-3-3-released.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/releases/spark-release-2-2-3.html</loc>
   <changefreq>weekly</changefreq>
 </url>
@@ -752,10 +760,6 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/streaming/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
   <loc>https://spark.apache.org/news/</loc>
   <changefreq>weekly</changefreq>
 </url>
@@ -765,6 +769,10 @@
 </url>
 <url>
   <loc>https://spark.apache.org/sql/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/streaming/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
+          <span class="small">(Feb 15, 2019)</span></li>
+        
           <li><a href="/news/spark-release-2-2-3.html">Spark 2.2.3 released</a>
           <span class="small">(Jan 11, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-0-released.html">Spark 2.4.0 released</a>
           <span class="small">(Nov 02, 2018)</span></li>
-        
-          <li><a href="/news/spark-2-3-2-released.html">Spark 2.3.2 released</a>
-          <span class="small">(Sep 24, 2018)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>


### PR DESCRIPTION
This PR aims to the Spark 2.3.3 release news and update links.