### PR TITLE
Fix call to input() for Python 2

### DIFF
--- a/merge_pr.py
+++ b/merge_pr.py
@@ -30,6 +30,9 @@ import subprocess
 import sys
 import urllib2
 
+if sys.version < '3':
+    input = raw_input  # noqa
+
 
 # Remote name which points to the Github site
 PR_REMOTE_NAME = os.environ.get("PR_REMOTE_NAME", "apache-github")


### PR DESCRIPTION
We need to redirect `input` to `raw_input` in Python 2 as the main Spark merge script does.