### PR TITLE
[SPARK-27458][DOC] remind developers to reset maven home in IntelliJ

### DIFF
--- a/developer-tools.md
+++ b/developer-tools.md
@@ -401,9 +401,9 @@ Projects" button in the "Maven Projects" tool window to manually generate these 
 the action "Generate Sources and Update Folders For All Projects" could fail silently. 
 Please remember to reset the Maven home directory 
 (`Preference -> Build, Execution, Deployment -> Maven -> Maven home directory`) of your project to 
-point to a newer installation of Maven. You may also build Spark with script `build/mvn` first.
-If the script cannot locate a new enough Maven installation, it will download and install a proper 
-Maven to folder `build/apache-maven-<version>/`. 
+point to a newer installation of Maven. You may also build Spark with the script `build/mvn` first.
+If the script cannot locate a new enough Maven installation, it will download and install a recent 
+version of Maven to folder `build/apache-maven-<version>/`.
 - Some of the modules have pluggable source directories based on Maven profiles (i.e. to support 
 both Scala 2.11 and 2.10 or to allow cross building against different versions of Hive). In some 
 cases IntelliJ's does not correctly detect use of the maven-build-plugin to add source directories. 

--- a/developer-tools.md
+++ b/developer-tools.md
@@ -397,6 +397,18 @@ Other tips:
 - "Rebuild Project" can fail the first time the project is compiled, because generate source files 
 are not automatically generated. Try clicking the "Generate Sources and Update Folders For All 
 Projects" button in the "Maven Projects" tool window to manually generate these sources.
+- Maven bundled in IntelliJ may not meet the minimum version requirement of the Spark. If that happens,
+the action "Generate Sources and Update Folders For All Projects" could fail silently. If you saw error like
+``` 
+2019-04-14 16:05:24,796 [ 314609]   INFO -      #org.jetbrains.idea.maven - [WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireMavenVersion failed with message:
+Detected Maven Version: 3.3.9 is not in the allowed range 3.6.0.
+2019-04-14 16:05:24,813 [ 314626]   INFO -      #org.jetbrains.idea.maven - org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce (enforce-versions) on project spark-parent_2.12: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed.
+java.lang.RuntimeException: org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce (enforce-versions) on project spark-parent_2.12: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed.
+``` 
+in IntelliJ log file (`Help -> Show Log in Finder/Explorer`), you should reset the maven home directory 
+(`Preference -> Build, Execution, Deployment -> Maven -> Maven home directory`) of your project to the 
+maven meeting the minimum version requirement.
+
 - Some of the modules have pluggable source directories based on Maven profiles (i.e. to support 
 both Scala 2.11 and 2.10 or to allow cross building against different versions of Hive). In some 
 cases IntelliJ's does not correctly detect use of the maven-build-plugin to add source directories. 

--- a/developer-tools.md
+++ b/developer-tools.md
@@ -400,9 +400,10 @@ Projects" button in the "Maven Projects" tool window to manually generate these 
 - The version of Maven bundled with IntelliJ may not be new enough for Spark. If that happens,
 the action "Generate Sources and Update Folders For All Projects" could fail silently. 
 Please remember to reset the Maven home directory 
-(`Preference -> Build, Execution, Deployment -> Maven -> Maven home directory`) of your project to the 
-version is new enough.
-
+(`Preference -> Build, Execution, Deployment -> Maven -> Maven home directory`) of your project to 
+point to a newer installation of Maven. You may also build Spark with script `build/mvn` first.
+If the script cannot locate a new enough Maven installation, it will download and install a proper 
+Maven to folder `build/apache-maven-<version>/`. 
 - Some of the modules have pluggable source directories based on Maven profiles (i.e. to support 
 both Scala 2.11 and 2.10 or to allow cross building against different versions of Hive). In some 
 cases IntelliJ's does not correctly detect use of the maven-build-plugin to add source directories. 

--- a/developer-tools.md
+++ b/developer-tools.md
@@ -397,17 +397,11 @@ Other tips:
 - "Rebuild Project" can fail the first time the project is compiled, because generate source files 
 are not automatically generated. Try clicking the "Generate Sources and Update Folders For All 
 Projects" button in the "Maven Projects" tool window to manually generate these sources.
-- Maven bundled in IntelliJ may not meet the minimum version requirement of the Spark. If that happens,
-the action "Generate Sources and Update Folders For All Projects" could fail silently. If you saw error like
-``` 
-2019-04-14 16:05:24,796 [ 314609]   INFO -      #org.jetbrains.idea.maven - [WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireMavenVersion failed with message:
-Detected Maven Version: 3.3.9 is not in the allowed range 3.6.0.
-2019-04-14 16:05:24,813 [ 314626]   INFO -      #org.jetbrains.idea.maven - org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce (enforce-versions) on project spark-parent_2.12: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed.
-java.lang.RuntimeException: org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce (enforce-versions) on project spark-parent_2.12: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed.
-``` 
-in IntelliJ log file (`Help -> Show Log in Finder/Explorer`), you should reset the maven home directory 
+- The version of Maven bundled with IntelliJ may not be new enough for Spark. If that happens,
+the action "Generate Sources and Update Folders For All Projects" could fail silently. 
+Please remember to reset the Maven home directory 
 (`Preference -> Build, Execution, Deployment -> Maven -> Maven home directory`) of your project to the 
-maven meeting the minimum version requirement.
+version is new enough.
 
 - Some of the modules have pluggable source directories based on Maven profiles (i.e. to support 
 both Scala 2.11 and 2.10 or to allow cross building against different versions of Hive). In some 

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -574,9 +574,9 @@ Projects&#8221; button in the &#8220;Maven Projects&#8221; tool window to manual
 the action &#8220;Generate Sources and Update Folders For All Projects&#8221; could fail silently. 
 Please remember to reset the Maven home directory 
 (<code>Preference -&gt; Build, Execution, Deployment -&gt; Maven -&gt; Maven home directory</code>) of your project to 
-point to a newer installation of Maven. You may also build Spark with script <code>build/mvn</code> first.
-If the script cannot locate a new enough Maven installation, it will download and install a proper 
-Maven to folder <code>build/apache-maven-&lt;version&gt;/</code>.</li>
+point to a newer installation of Maven. You may also build Spark with the script <code>build/mvn</code> first.
+If the script cannot locate a new enough Maven installation, it will download and install a recent 
+version of Maven to folder <code>build/apache-maven-&lt;version&gt;/</code>.</li>
   <li>Some of the modules have pluggable source directories based on Maven profiles (i.e. to support 
 both Scala 2.11 and 2.10 or to allow cross building against different versions of Hive). In some 
 cases IntelliJ&#8217;s does not correctly detect use of the maven-build-plugin to add source directories. 

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -570,16 +570,12 @@ enable profiles <code>yarn</code> and <code>hadoop-2.7</code>. These selections 
   <li>&#8220;Rebuild Project&#8221; can fail the first time the project is compiled, because generate source files 
 are not automatically generated. Try clicking the &#8220;Generate Sources and Update Folders For All 
 Projects&#8221; button in the &#8220;Maven Projects&#8221; tool window to manually generate these sources.</li>
-  <li>Maven bundled in IntelliJ may not meet the minimum version requirement of the Spark. If that happens,
-the action &#8220;Generate Sources and Update Folders For All Projects&#8221; could fail silently. If you saw error like
-    <pre><code>2019-04-14 16:05:24,796 [ 314609]   INFO -      #org.jetbrains.idea.maven - [WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireMavenVersion failed with message:
-Detected Maven Version: 3.3.9 is not in the allowed range 3.6.0.
-2019-04-14 16:05:24,813 [ 314626]   INFO -      #org.jetbrains.idea.maven - org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce (enforce-versions) on project spark-parent_2.12: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed.
-java.lang.RuntimeException: org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce (enforce-versions) on project spark-parent_2.12: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed.
-</code></pre>
-    <p>in IntelliJ log file (<code>Help -&gt; Show Log in Finder/Explorer</code>), you should reset the maven home directory 
+  <li>
+    <p>The version of Maven bundled with IntelliJ may not be new enough for Spark. If that happens,
+the action &#8220;Generate Sources and Update Folders For All Projects&#8221; could fail silently. 
+Please remember to reset the Maven home directory 
 (<code>Preference -&gt; Build, Execution, Deployment -&gt; Maven -&gt; Maven home directory</code>) of your project to the 
-maven meeting the minimum version requirement.</p>
+version is new enough.</p>
   </li>
   <li>Some of the modules have pluggable source directories based on Maven profiles (i.e. to support 
 both Scala 2.11 and 2.10 or to allow cross building against different versions of Hive). In some 

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -570,13 +570,13 @@ enable profiles <code>yarn</code> and <code>hadoop-2.7</code>. These selections 
   <li>&#8220;Rebuild Project&#8221; can fail the first time the project is compiled, because generate source files 
 are not automatically generated. Try clicking the &#8220;Generate Sources and Update Folders For All 
 Projects&#8221; button in the &#8220;Maven Projects&#8221; tool window to manually generate these sources.</li>
-  <li>
-    <p>The version of Maven bundled with IntelliJ may not be new enough for Spark. If that happens,
+  <li>The version of Maven bundled with IntelliJ may not be new enough for Spark. If that happens,
 the action &#8220;Generate Sources and Update Folders For All Projects&#8221; could fail silently. 
 Please remember to reset the Maven home directory 
-(<code>Preference -&gt; Build, Execution, Deployment -&gt; Maven -&gt; Maven home directory</code>) of your project to the 
-version is new enough.</p>
-  </li>
+(<code>Preference -&gt; Build, Execution, Deployment -&gt; Maven -&gt; Maven home directory</code>) of your project to 
+point to a newer installation of Maven. You may also build Spark with script <code>build/mvn</code> first.
+If the script cannot locate a new enough Maven installation, it will download and install a proper 
+Maven to folder <code>build/apache-maven-&lt;version&gt;/</code>.</li>
   <li>Some of the modules have pluggable source directories based on Maven profiles (i.e. to support 
 both Scala 2.11 and 2.10 or to allow cross building against different versions of Hive). In some 
 cases IntelliJ&#8217;s does not correctly detect use of the maven-build-plugin to add source directories. 

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -570,6 +570,17 @@ enable profiles <code>yarn</code> and <code>hadoop-2.7</code>. These selections 
   <li>&#8220;Rebuild Project&#8221; can fail the first time the project is compiled, because generate source files 
 are not automatically generated. Try clicking the &#8220;Generate Sources and Update Folders For All 
 Projects&#8221; button in the &#8220;Maven Projects&#8221; tool window to manually generate these sources.</li>
+  <li>Maven bundled in IntelliJ may not meet the minimum version requirement of the Spark. If that happens,
+the action &#8220;Generate Sources and Update Folders For All Projects&#8221; could fail silently. If you saw error like
+    <pre><code>2019-04-14 16:05:24,796 [ 314609]   INFO -      #org.jetbrains.idea.maven - [WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireMavenVersion failed with message:
+Detected Maven Version: 3.3.9 is not in the allowed range 3.6.0.
+2019-04-14 16:05:24,813 [ 314626]   INFO -      #org.jetbrains.idea.maven - org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce (enforce-versions) on project spark-parent_2.12: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed.
+java.lang.RuntimeException: org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce (enforce-versions) on project spark-parent_2.12: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed.
+</code></pre>
+    <p>in IntelliJ log file (<code>Help -&gt; Show Log in Finder/Explorer</code>), you should reset the maven home directory 
+(<code>Preference -&gt; Build, Execution, Deployment -&gt; Maven -&gt; Maven home directory</code>) of your project to the 
+maven meeting the minimum version requirement.</p>
+  </li>
   <li>Some of the modules have pluggable source directories based on Maven profiles (i.e. to support 
 both Scala 2.11 and 2.10 or to allow cross building against different versions of Hive). In some 
 cases IntelliJ&#8217;s does not correctly detect use of the maven-build-plugin to add source directories. 


### PR DESCRIPTION

I tried to follow the guide at 'http://spark.apache.org/developer-tools.html' to setup an IntelliJ project for Spark. However, the project was failed to build. It was due to missing classes generated via antlr on sql/catalyst project even thought I clicked the 'Generate Sources and Update Folders For All Projects' button in IntelliJ as per suggested.

It turned out that I forgot to reset the maven home in my IntelliJ and the IntelliJ failed the 'Generate Sources and Update Folders For All Projects' action silently. That was why ANTLR4 files were not generated as expected. 

To help other developers, I would like to enhance 'http://spark.apache.org/developer-tools.html' to add a note to remind developer to check if the 'Generate Sources and Update Folders For All Projects' action was failed silently due to incorrect maven version. If so, they should update the maven home in IntelliJ accordingly 