### PR TITLE
[SPARK-27175] Add test-hadoop3.2 signal to developer-tools.md

### DIFF
--- a/developer-tools.md
+++ b/developer-tools.md
@@ -254,6 +254,7 @@ your pull request to change testing behavior. This includes:
 
 - `[test-maven]` - signals to test the pull request using maven
 - `[test-hadoop2.7]` - signals to test using Spark's Hadoop 2.7 profile
+- `[test-hadoop3.2]` - signals to test using Spark's Hadoop 3.2 profile
 
 <h3>Binary compatibility</h3>
 


### PR DESCRIPTION
https://github.com/apache/spark/pull/24106 add `test-hadoop3.2` signal to test using Spark's Hadoop 3.2 profile.
This pr add it to developer-tools.md.
