### PR TITLE
[SPARK-27885] Announce plan for dropping Python 2 support

### DIFF
--- a/news/_posts/2019-05-31-plan-for-dropping-python-2-support.md
+++ b/news/_posts/2019-05-31-plan-for-dropping-python-2-support.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title: Plan for dropping Python 2 support
+categories:
+- News
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+As many of you already knew, Python core development team and many utilized Python packages like
+Pandas and NumPy will drop Python 2 support in or before 2020/01/01.
+Apache Spark has supported both Python 2 and 3 since Spark 1.4 release in 2015.
+However, maintaining Python 2/3 compatibility is an increasing burden and it essentially limits
+the use of Python 3 features in Spark.
+Given the end of life (EOL) of Python 2 is coming, we plan to eventually drop Python 2 support as
+well. The current plan is as follows:
+
+* In the next major release in 2019, we will deprecate Python 2 support.
+  PySpark users will see a deprecation warning if Python 2 is used.
+  We will publish a migration guide for PySpark users to migrate to Python 3.
+* We will drop Python 2 support in a future release in 2020, after Python 2 EOL on 2020/01/01.
+  PySpark users will see an error if Python 2 is used.
+* For releases that support Python 2, e.g., Spark 2.4, their patch releases will continue supporting
+  Python 2. However, after Python 2 EOL, we might not take patches that are specific to Python 2.

--- a/news/_posts/2019-06-03-plan-for-dropping-python-2-support.md
+++ b/news/_posts/2019-06-03-plan-for-dropping-python-2-support.md
@@ -22,7 +22,7 @@ well. The current plan is as follows:
 * In the next major release in 2019, we will deprecate Python 2 support.
   PySpark users will see a deprecation warning if Python 2 is used.
   We will publish a migration guide for PySpark users to migrate to Python 3.
-* We will drop Python 2 support in a future release in 2020, after Python 2 EOL on 2020/01/01.
-  PySpark users will see an error if Python 2 is used.
+* We will drop Python 2 support in a future release (excluding patch release) in 2020,
+  after Python 2 EOL on 2020/01/01. PySpark users will see an error if Python 2 is used.
 * For releases that support Python 2, e.g., Spark 2.4, their patch releases will continue supporting
   Python 2. However, after Python 2 EOL, we might not take patches that are specific to Python 2.

--- a/site/committers.html
+++ b/site/committers.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/community.html
+++ b/site/community.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -433,6 +433,7 @@ your pull request to change testing behavior. This includes:</p>
 <ul>
   <li><code>[test-maven]</code> - signals to test the pull request using maven</li>
   <li><code>[test-hadoop2.7]</code> - signals to test using Spark&#8217;s Hadoop 2.7 profile</li>
+  <li><code>[test-hadoop3.2]</code> - signals to test using Spark&#8217;s Hadoop 3.2 profile</li>
 </ul>
 
 <h3>Binary compatibility</h3>
@@ -596,13 +597,13 @@ compiler options&#8221; field.  It will work then although the option will come 
 reimports.  If you try to build any of the projects using quasiquotes (eg., sql) then you will 
 need to make that jar a compiler plugin (just below &#8220;Additional compiler options&#8221;). 
 Otherwise you will see errors like:
-    <pre><code>/Users/irashid/github/spark/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+<code>
+/Users/irashid/github/spark/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
 Error:(147, 9) value q is not a member of StringContext
  Note: implicit class Evaluate2 is not applicable here because it comes after the application point and it lacks an explicit result type
       q"""
       ^ 
-</code></pre>
-  </li>
+</code></li>
 </ul>
 
 <h4>Eclipse</h4>
@@ -674,12 +675,12 @@ consider mirroring this file or including it on a custom AMI.</li>
   <li>Copy the expanded YourKit files to each node using copy-dir: <code>~/spark-ec2/copy-dir /root/YourKit-JavaProfiler-2017.02</code></li>
   <li>Configure the Spark JVMs to use the YourKit profiling agent by editing <code>~/spark/conf/spark-env.sh</code> 
 and adding the lines
-    <pre><code>SPARK_DAEMON_JAVA_OPTS+=" -agentpath:/root/YourKit-JavaProfiler-2017.02/bin/linux-x86-64/libyjpagent.so=sampling"
+<code>
+SPARK_DAEMON_JAVA_OPTS+=" -agentpath:/root/YourKit-JavaProfiler-2017.02/bin/linux-x86-64/libyjpagent.so=sampling"
 export SPARK_DAEMON_JAVA_OPTS
 SPARK_EXECUTOR_OPTS+=" -agentpath:/root/YourKit-JavaProfiler-2017.02/bin/linux-x86-64/libyjpagent.so=sampling"
 export SPARK_EXECUTOR_OPTS
-</code></pre>
-  </li>
+</code></li>
   <li>Copy the updated configuration to each node: <code>~/spark-ec2/copy-dir ~/spark/conf/spark-env.sh</code></li>
   <li>Restart your Spark cluster: <code>~/spark/bin/stop-all.sh</code> and <code>~/spark/bin/start-all.sh</code></li>
   <li>By default, the YourKit profiler agents use ports <code>10001-10010</code>. To connect the YourKit desktop

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -207,7 +207,7 @@ $(document).ready(function() {
 });
 </script>
 
-<h2 id="download-apache-spark">Download Apache Spark&#8482;</h2>
+<h2 id="download-apache-sparktrade">Download Apache Spark&#8482;</h2>
 
 <ol>
   <li>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/examples.html
+++ b/site/examples.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/faq.html
+++ b/site/faq.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/history.html
+++ b/site/history.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/index.html
+++ b/site/index.html
@@ -164,6 +164,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -172,9 +175,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
@@ -201,6 +201,22 @@
 
   <div class="col-md-9 col-md-pull-3">
     <h2 id="spark-news">Spark News</h2>
+
+<article class="hentry">
+    <header class="entry-header">
+      <h3 class="entry-title"><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a></h3>
+      <div class="entry-date">June 3, 2019</div>
+    </header>
+    <div class="entry-content"><p>As many of you already knew, Python core development team and many utilized Python packages like
+Pandas and NumPy will drop Python 2 support in or before 2020/01/01.
+Apache Spark has supported both Python 2 and 3 since Spark 1.4 release in 2015.
+However, maintaining Python 2/3 compatibility is an increasing burden and it essentially limits
+the use of Python 3 features in Spark.
+Given the end of life (EOL) of Python 2 is coming, we plan to eventually drop Python 2 support as
+well. The current plan is as follows:</p>
+
+</div>
+  </article>
 
 <article class="hentry">
     <header class="entry-header">

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/plan-for-dropping-python-2-support.html
+++ b/site/news/plan-for-dropping-python-2-support.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark Release 2.1.3 | Apache Spark
+     Plan for dropping Python 2 support | Apache Spark
     
   </title>
 
@@ -200,14 +200,26 @@
   </div>
 
   <div class="col-md-9 col-md-pull-3">
-    <h2>Spark Release 2.1.3</h2>
+    <h2>Plan for dropping Python 2 support</h2>
 
 
-<p>Spark 2.1.3 is a maintenance release containing stability fixes. This release is based on the branch-2.1 maintenance branch of Spark. We strongly recommend all 2.1.x users to upgrade to this stable release.</p>
+<p>As many of you already knew, Python core development team and many utilized Python packages like
+Pandas and NumPy will drop Python 2 support in or before 2020/01/01.
+Apache Spark has supported both Python 2 and 3 since Spark 1.4 release in 2015.
+However, maintaining Python 2/3 compatibility is an increasing burden and it essentially limits
+the use of Python 3 features in Spark.
+Given the end of life (EOL) of Python 2 is coming, we plan to eventually drop Python 2 support as
+well. The current plan is as follows:</p>
 
-<p>You can consult JIRA for the <a href="https://s.apache.org/spark-2.1.3-release-notes">detailed changes</a>.</p>
-
-<p>We would like to acknowledge all community members for contributing patches to this release.</p>
+<ul>
+  <li>In the next major release in 2019, we will deprecate Python 2 support.
+PySpark users will see a deprecation warning if Python 2 is used.
+We will publish a migration guide for PySpark users to migrate to Python 3.</li>
+  <li>We will drop Python 2 support in a future release (excluding patch release) in 2020,
+after Python 2 EOL on 2020/01/01. PySpark users will see an error if Python 2 is used.</li>
+  <li>For releases that support Python 2, e.g., Spark 2.4, their patch releases will continue supporting
+Python 2. However, after Python 2 EOL, we might not take patches that are specific to Python 2.</li>
+</ul>
 
 
 <p>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-3-released.html
+++ b/site/news/spark-2-1-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-2-released.html
+++ b/site/news/spark-2-2-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-1-released.html
+++ b/site/news/spark-2-3-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-2-released.html
+++ b/site/news/spark-2-3-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-3-released.html
+++ b/site/news/spark-2-3-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-0-released.html
+++ b/site/news/spark-2-4-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-1-released.html
+++ b/site/news/spark-2-4-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-2-released.html
+++ b/site/news/spark-2-4-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-3-released.html
+++ b/site/news/spark-2-4-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-apr-2019-agenda-posted.html
+++ b/site/news/spark-ai-summit-apr-2019-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-release-2-2-3.html
+++ b/site/news/spark-release-2-2-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted.html
+++ b/site/news/spark-summit-east-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-oct-2018-agenda-posted.html
+++ b/site/news/spark-summit-oct-2018-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -299,13 +299,11 @@ changes or in the release news on the website later.</p>
 <p>Also check that all build and test passes are green from the RISELab Jenkins: https://amplab.cs.berkeley.edu/jenkins/ particularly look for Spark Packaging, QA Compile, QA Test.
 Note that not all permutations are run on PR therefore it is important to check Jenkins runs.</p>
 
-<p>To cut a release candidate, there are 4 steps:</p>
-<ol>
-  <li>Create a git tag for the release candidate.</li>
-  <li>Package the release binaries &amp; sources, and upload them to the Apache staging SVN repo.</li>
-  <li>Create the release docs, and upload them to the Apache staging SVN repo.</li>
-  <li>Publish a snapshot to the Apache staging Maven repo.</li>
-</ol>
+<p>To cut a release candidate, there are 4 steps:
+1. Create a git tag for the release candidate.
+1. Package the release binaries &amp; sources, and upload them to the Apache staging SVN repo.
+1. Create the release docs, and upload them to the Apache staging SVN repo.
+1. Publish a snapshot to the Apache staging Maven repo.</p>
 
 <p>The process of cutting a release candidate has been automated via the <code>dev/create-release/do-release-docker.sh</code> script.
 Run this script, type information it requires, and wait until it finishes. You can also do a single step via the <code>-s</code> option.

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-2.html
+++ b/site/releases/spark-release-2-2-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-3.html
+++ b/site/releases/spark-release-2-2-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-1.html
+++ b/site/releases/spark-release-2-3-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-2.html
+++ b/site/releases/spark-release-2-3-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-3.html
+++ b/site/releases/spark-release-2-3-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-0.html
+++ b/site/releases/spark-release-2-4-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-1.html
+++ b/site/releases/spark-release-2-4-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-2.html
+++ b/site/releases/spark-release-2-4-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-3.html
+++ b/site/releases/spark-release-2-4-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/research.html
+++ b/site/research.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/security.html
+++ b/site/security.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -139,6 +139,10 @@
 </url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
+  <loc>https://spark.apache.org/news/plan-for-dropping-python-2-support.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/releases/spark-release-2-4-3.html</loc>
   <changefreq>weekly</changefreq>
 </url>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -780,10 +780,6 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/news/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
   <loc>https://spark.apache.org/mllib/</loc>
   <changefreq>weekly</changefreq>
 </url>
@@ -792,11 +788,15 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/sql/</loc>
+  <loc>https://spark.apache.org/news/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
   <loc>https://spark.apache.org/screencasts/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/sql/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/plan-for-dropping-python-2-support.html">Plan for dropping Python 2 support</a>
+          <span class="small">(Jun 03, 2019)</span></li>
+        
           <li><a href="/news/spark-2-4-3-released.html">Spark 2.4.3 released</a>
           <span class="small">(May 08, 2019)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-1-released.html">Spark 2.4.1 released</a>
           <span class="small">(Mar 31, 2019)</span></li>
-        
-          <li><a href="/news/spark-2-3-3-released.html">Spark 2.3.3 released</a>
-          <span class="small">(Feb 15, 2019)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>


### PR DESCRIPTION
Draft plan for dropping Python 2 support following discussion at https://lists.apache.org/thread.html/69cded1df4fa949ebeb831e805945d82de65033de5568ed6ed1cfa49@%3Cdev.spark.apache.org%3E.