### PR TITLE
CVE-2019-10099

### DIFF
--- a/security.md
+++ b/security.md
@@ -35,7 +35,7 @@ Prior to Spark 2.3.3, in certain situations Spark would write user data to local
 
 Mitigation:
 
-- 1.x, 2.0.x, 2.1.x, 2.2.x, 2.3.x  users should upgrade to 2.3.3 or newer
+- 1.x, 2.0.x, 2.1.x, 2.2.x, 2.3.x  users should upgrade to 2.3.3 or newer, including 2.4.x
 
 Credit:
 

--- a/security.md
+++ b/security.md
@@ -36,7 +36,6 @@ Prior to Spark 2.3.3, in certain situations Spark would write user data to local
 Mitigation:
 
 - 1.x, 2.0.x, 2.1.x, 2.2.x, 2.3.x  users should upgrade to 2.3.3 or newer
-- 2.3.x users should upgrade to 2.3.3 or newer.
 
 Credit:
 

--- a/security.md
+++ b/security.md
@@ -18,6 +18,31 @@ non-public list that will reach the Apache Security team, as well as the Spark P
 
 <h2>Known Security Issues</h2>
 
+<h3 id="CVE-2019-10099">CVE-2019-10099: Apache Spark unencrypted data on local disk</h3>
+
+Severity: Important
+
+Vendor: The Apache Software Foundation
+
+Versions affected:
+- All Spark 1.x, Spark 2.0.x, Spark 2.1.x, and 2.2.x versions
+- Spark 2.3.0 to 2.3.2
+
+Description:
+
+Prior to Spark 2.3.3, in certain situations Spark would write user data to local disk unencrypted, even if `spark.io.encryption.enabled=true`.  This includes cached blocks that are fetched to disk (controlled by `spark.maxRemoteBlockSizeFetchToMem`); in SparkR, using parallelize; in Pyspark, using broadcast and parallelize; and use of python udfs.
+
+
+Mitigation:
+
+- 1.x, 2.0.x, 2.1.x, 2.2.x, 2.3.x  users should upgrade to 2.3.3 or newer
+- 2.3.x users should upgrade to 2.3.3 or newer.
+
+Credit:
+
+- This issue was reported by Thomas Graves of NVIDIA.
+
+
 <h3 id="CVE-2018-11760">CVE-2018-11760: Apache Spark local privilege escalation vulnerability</h3>
 
 Severity: Important

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -299,11 +299,13 @@ changes or in the release news on the website later.</p>
 <p>Also check that all build and test passes are green from the RISELab Jenkins: https://amplab.cs.berkeley.edu/jenkins/ particularly look for Spark Packaging, QA Compile, QA Test.
 Note that not all permutations are run on PR therefore it is important to check Jenkins runs.</p>
 
-<p>To cut a release candidate, there are 4 steps:
-1. Create a git tag for the release candidate.
-1. Package the release binaries &amp; sources, and upload them to the Apache staging SVN repo.
-1. Create the release docs, and upload them to the Apache staging SVN repo.
-1. Publish a snapshot to the Apache staging Maven repo.</p>
+<p>To cut a release candidate, there are 4 steps:</p>
+<ol>
+  <li>Create a git tag for the release candidate.</li>
+  <li>Package the release binaries &amp; sources, and upload them to the Apache staging SVN repo.</li>
+  <li>Create the release docs, and upload them to the Apache staging SVN repo.</li>
+  <li>Publish a snapshot to the Apache staging Maven repo.</li>
+</ol>
 
 <p>The process of cutting a release candidate has been automated via the <code>dev/create-release/do-release-docker.sh</code> script.
 Run this script, type information it requires, and wait until it finishes. You can also do a single step via the <code>-s</code> option.

--- a/site/security.html
+++ b/site/security.html
@@ -211,6 +211,35 @@ non-public list that will reach the Apache Security team, as well as the Spark P
 
 <h2>Known Security Issues</h2>
 
+<h3 id="CVE-2019-10099">CVE-2019-10099: Apache Spark unencrypted data on local disk</h3>
+
+<p>Severity: Important</p>
+
+<p>Vendor: The Apache Software Foundation</p>
+
+<p>Versions affected:</p>
+<ul>
+  <li>All Spark 1.x, Spark 2.0.x, Spark 2.1.x, and 2.2.x versions</li>
+  <li>Spark 2.3.0 to 2.3.2</li>
+</ul>
+
+<p>Description:</p>
+
+<p>Prior to Spark 2.3.3, in certain situations Spark would write user data to local disk unencrypted, even if <code>spark.io.encryption.enabled=true</code>.  This includes cached blocks that are fetched to disk (controlled by <code>spark.maxRemoteBlockSizeFetchToMem</code>); in SparkR, using parallelize; in Pyspark, using broadcast and parallelize; and use of python udfs.</p>
+
+<p>Mitigation:</p>
+
+<ul>
+  <li>1.x, 2.0.x, 2.1.x, 2.2.x, 2.3.x  users should upgrade to 2.3.3 or newer</li>
+  <li>2.3.x users should upgrade to 2.3.3 or newer.</li>
+</ul>
+
+<p>Credit:</p>
+
+<ul>
+  <li>This issue was reported by Thomas Graves of NVIDIA.</li>
+</ul>
+
 <h3 id="CVE-2018-11760">CVE-2018-11760: Apache Spark local privilege escalation vulnerability</h3>
 
 <p>Severity: Important</p>

--- a/site/security.html
+++ b/site/security.html
@@ -230,7 +230,7 @@ non-public list that will reach the Apache Security team, as well as the Spark P
 <p>Mitigation:</p>
 
 <ul>
-  <li>1.x, 2.0.x, 2.1.x, 2.2.x, 2.3.x  users should upgrade to 2.3.3 or newer</li>
+  <li>1.x, 2.0.x, 2.1.x, 2.2.x, 2.3.x  users should upgrade to 2.3.3 or newer, including 2.4.x</li>
 </ul>
 
 <p>Credit:</p>

--- a/site/security.html
+++ b/site/security.html
@@ -231,7 +231,6 @@ non-public list that will reach the Apache Security team, as well as the Spark P
 
 <ul>
   <li>1.x, 2.0.x, 2.1.x, 2.2.x, 2.3.x  users should upgrade to 2.3.3 or newer</li>
-  <li>2.3.x users should upgrade to 2.3.3 or newer.</li>
 </ul>
 
 <p>Credit:</p>


### PR DESCRIPTION
ran jekyll build / serve locally.

Also updated a random formatting issue on the release process page -- (fixed just by running jekyll build).