### PR TITLE
Add signals to test with JDK 11

### DIFF
--- a/developer-tools.md
+++ b/developer-tools.md
@@ -255,6 +255,7 @@ your pull request to change testing behavior. This includes:
 - `[test-maven]` - signals to test the pull request using maven
 - `[test-hadoop2.7]` - signals to test using Spark's Hadoop 2.7 profile
 - `[test-hadoop3.2]` - signals to test using Spark's Hadoop 3.2 profile
+- `[test-hadoop3.2][test-java11]` - signals to test with JDK 11
 
 <h3>Binary compatibility</h3>
 

--- a/developer-tools.md
+++ b/developer-tools.md
@@ -255,7 +255,7 @@ your pull request to change testing behavior. This includes:
 - `[test-maven]` - signals to test the pull request using maven
 - `[test-hadoop2.7]` - signals to test using Spark's Hadoop 2.7 profile
 - `[test-hadoop3.2]` - signals to test using Spark's Hadoop 3.2 profile
-- `[test-hadoop3.2][test-java11]` - signals to test with JDK 11
+- `[test-hadoop3.2][test-java11]` - signals to test using Spark's Hadoop 3.2 profile with JDK 11
 
 <h3>Binary compatibility</h3>
 

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -434,6 +434,7 @@ your pull request to change testing behavior. This includes:</p>
   <li><code>[test-maven]</code> - signals to test the pull request using maven</li>
   <li><code>[test-hadoop2.7]</code> - signals to test using Spark&#8217;s Hadoop 2.7 profile</li>
   <li><code>[test-hadoop3.2]</code> - signals to test using Spark&#8217;s Hadoop 3.2 profile</li>
+  <li><code>[test-hadoop3.2][test-java11]</code> - signals to test with JDK 11</li>
 </ul>
 
 <h3>Binary compatibility</h3>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -434,7 +434,7 @@ your pull request to change testing behavior. This includes:</p>
   <li><code>[test-maven]</code> - signals to test the pull request using maven</li>
   <li><code>[test-hadoop2.7]</code> - signals to test using Spark&#8217;s Hadoop 2.7 profile</li>
   <li><code>[test-hadoop3.2]</code> - signals to test using Spark&#8217;s Hadoop 3.2 profile</li>
-  <li><code>[test-hadoop3.2][test-java11]</code> - signals to test with JDK 11</li>
+  <li><code>[test-hadoop3.2][test-java11]</code> - signals to test using Spark&#8217;s Hadoop 3.2 profile with JDK 11</li>
 </ul>
 
 <h3>Binary compatibility</h3>


### PR DESCRIPTION
[SPARK-28701](https://issues.apache.org/jira/browse/SPARK-28701) added support test PRBs against java11. This PR add `[test-hadoop3.2][test-java11]` signal to docs.

More details:
https://issues.apache.org/jira/browse/SPARK-28701
http://apache-spark-developers-list.1001551.n3.nabble.com/JDK11-Support-in-Apache-Spark-td27721.html

