### PR TITLE
Make the committer list up-to-date

### DIFF
--- a/committers.md
+++ b/committers.md
@@ -23,7 +23,7 @@ navigation:
 |Aaron Davidson|Databricks|
 |Thomas Dudziak|Facebook|
 |Erik Erlandson|Red Hat|
-|Robert Evans|Oath|
+|Robert Evans|NVIDIA|
 |Wenchen Fan|Databricks|
 |Joseph Gonzalez|UC Berkeley|
 |Thomas Graves|NVIDIA|
@@ -37,7 +37,7 @@ navigation:
 |Dongjoon Hyun|Apple|
 |Kazuaki Ishizaki|IBM|
 |Xingbo Jiang|Databricks|
-|Holden Karau|Google|
+|Holden Karau|Apple|
 |Shane Knapp|UC Berkeley|
 |Cody Koeninger|Nexstar Digital|
 |Andy Konwinski|Databricks|

--- a/committers.md
+++ b/committers.md
@@ -48,16 +48,16 @@ navigation:
 |Yinan Li|Google|
 |Davies Liu|Juicedata|
 |Cheng Lian|Databricks|
-|Yanbo Liang|Hortonworks|
+|Yanbo Liang|Facebook|
 |Sean McNamara|Oracle|
 |Xiangrui Meng|Databricks|
-|Mridul Muralidharam|Hortonworks|
+|Mridul Muralidharam|Google|
 |Andrew Or|Princeton University|
 |Kay Ousterhout|LightStep|
 |Sean Owen|Databricks|
 |Tejas Patil|Facebook|
 |Nick Pentreath|IBM|
-|Anirudh Ramanathan|Google|
+|Anirudh Ramanathan|Rockset|
 |Imran Rashid|Cloudera|
 |Charles Reiss|University of Virginia|
 |Josh Rosen|Stripe|

--- a/site/committers.html
+++ b/site/committers.html
@@ -264,7 +264,7 @@
     </tr>
     <tr>
       <td>Robert Evans</td>
-      <td>Oath</td>
+      <td>NVIDIA</td>
     </tr>
     <tr>
       <td>Wenchen Fan</td>
@@ -320,7 +320,7 @@
     </tr>
     <tr>
       <td>Holden Karau</td>
-      <td>Google</td>
+      <td>Apple</td>
     </tr>
     <tr>
       <td>Shane Knapp</td>
@@ -364,7 +364,7 @@
     </tr>
     <tr>
       <td>Yanbo Liang</td>
-      <td>Hortonworks</td>
+      <td>Facebook</td>
     </tr>
     <tr>
       <td>Sean McNamara</td>
@@ -376,7 +376,7 @@
     </tr>
     <tr>
       <td>Mridul Muralidharam</td>
-      <td>Hortonworks</td>
+      <td>Google</td>
     </tr>
     <tr>
       <td>Andrew Or</td>
@@ -400,7 +400,7 @@
     </tr>
     <tr>
       <td>Anirudh Ramanathan</td>
-      <td>Google</td>
+      <td>Rockset</td>
     </tr>
     <tr>
       <td>Imran Rashid</td>


### PR DESCRIPTION
With 2.4.4 announcement, we added more committers to the committer list. This PR aims to make it up-to-date for the existing committers to give a fresh information for the page visitors.