### PR TITLE
Add a guide for adding a JIRA prefix in the test name

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -304,6 +304,12 @@ Example: `Fix typos in Foo scaladoc`
 1. Clone your fork, create a new branch, push commits to the branch.
 1. Consider whether documentation or tests need to be added or updated as part of the change, 
 and add them as needed.
+      1. When you add tests, make sure the tests are self-descriptive.
+      1. Also, you should consider adding a JIRA ID as a prefix of the tests when your PR targets
+      to fix a specific issue. In practice, usually it is added when a JIRA type is a bug
+      or a PR adds a couple of tests to an existing test class.
+      1. The JIRA prefix in the test name usually conforms to JIRA ID with a trailing colon, for example,
+      "SPARK-XXXXX: test name".
 1. Run all tests with `./dev/run-tests` to verify that the code still compiles, passes tests, and 
 passes style checks. If style checks fail, review the Code Style Guide below.
 1. <a href="https://help.github.com/articles/using-pull-requests/">Open a pull request</a> against 

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -537,7 +537,16 @@ Example: <code>Fix typos in Foo scaladoc</code></li>
 <a href="https://github.com/apache/spark">https://github.com/apache/spark</a> if you haven&#8217;t already</li>
   <li>Clone your fork, create a new branch, push commits to the branch.</li>
   <li>Consider whether documentation or tests need to be added or updated as part of the change, 
-and add them as needed.</li>
+and add them as needed.
+    <ol>
+      <li>When you add tests, make sure the tests are self-descriptive.</li>
+      <li>Also, you should consider adding a JIRA ID as a prefix of the tests when your PR targets
+   to fix a specific issue. In practice, usually it is added when a JIRA type is a bug
+   or a PR adds a couple of tests to an existing test class.</li>
+      <li>The JIRA prefix in the test name usually conforms to JIRA ID with a trailing colon, for example,
+   &#8220;SPARK-XXXXX: test name&#8221;.</li>
+    </ol>
+  </li>
   <li>Run all tests with <code>./dev/run-tests</code> to verify that the code still compiles, passes tests, and 
 passes style checks. If style checks fail, review the Code Style Guide below.</li>
   <li><a href="https://help.github.com/articles/using-pull-requests/">Open a pull request</a> against 


### PR DESCRIPTION
As discussed in http://apache-spark-developers-list.1001551.n3.nabble.com/Adding-JIRA-ID-as-the-prefix-for-the-test-case-name-td28289.html
