### PR TITLE
Update the guide for adding a JIRA prefix in the test cases for other languages

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -305,11 +305,32 @@ Example: `Fix typos in Foo scaladoc`
 1. Consider whether documentation or tests need to be added or updated as part of the change, 
 and add them as needed.
       1. When you add tests, make sure the tests are self-descriptive.
-      1. Also, you should consider adding a JIRA ID as a prefix of the tests when your PR targets
-      to fix a specific issue. In practice, usually it is added when a JIRA type is a bug
-      or a PR adds a couple of tests to an existing test class.
-      1. The JIRA prefix in the test name usually conforms to JIRA ID with a trailing colon, for example,
-      "SPARK-XXXXX: test name".
+      1. Also, you should consider writing a JIRA ID in the tests when your pull request targets to fix
+      a specific issue. In practice, usually it is added when a JIRA type is a bug or a PR adds
+      a couple of tests to an existing test class. See the examples below:
+          - Scala
+            ```
+            test("SPARK-12345: a short description of the test") {
+              ...
+            ```
+          - Java
+            ```
+            @Test
+            public void testCase() {
+              // SPARK-12345: a short description of the test
+              ...
+            ```
+          - Python
+            ```
+            def test_case(self):
+                # SPARK-12345: a short description of the test
+                ...
+            ```
+          - R
+            ```
+            test_that("SPARK-12345: a short description of the test", {
+              ...
+            ```
 1. Run all tests with `./dev/run-tests` to verify that the code still compiles, passes tests, and 
 passes style checks. If style checks fail, review the Code Style Guide below.
 1. <a href="https://help.github.com/articles/using-pull-requests/">Open a pull request</a> against 

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -540,11 +540,35 @@ Example: <code class="highlighter-rouge">Fix typos in Foo scaladoc</code></li>
 and add them as needed.
     <ol>
       <li>When you add tests, make sure the tests are self-descriptive.</li>
-      <li>Also, you should consider adding a JIRA ID as a prefix of the tests when your PR targets
-   to fix a specific issue. In practice, usually it is added when a JIRA type is a bug
-   or a PR adds a couple of tests to an existing test class.</li>
-      <li>The JIRA prefix in the test name usually conforms to JIRA ID with a trailing colon, for example,
-   &#8220;SPARK-XXXXX: test name&#8221;.</li>
+      <li>Also, you should consider writing a JIRA ID in the tests when your pull request targets to fix
+   a specific issue. In practice, usually it is added when a JIRA type is a bug or a PR adds
+   a couple of tests to an existing test class. See the examples below:
+        <ul>
+          <li>Scala
+            <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>test("SPARK-12345: a short description of the test") {
+  ...
+</code></pre></div>            </div>
+          </li>
+          <li>Java
+            <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>@Test
+public void testCase() {
+  // SPARK-12345: a short description of the test
+  ...
+</code></pre></div>            </div>
+          </li>
+          <li>Python
+            <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>def test_case(self):
+    # SPARK-12345: a short description of the test
+    ...
+</code></pre></div>            </div>
+          </li>
+          <li>R
+            <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>test_that("SPARK-12345: a short description of the test", {
+  ...
+</code></pre></div>            </div>
+          </li>
+        </ul>
+      </li>
     </ol>
   </li>
   <li>Run all tests with <code class="highlighter-rouge">./dev/run-tests</code> to verify that the code still compiles, passes tests, and 


### PR DESCRIPTION
![Screen Shot 2019-11-22 at 12 31 14 PM](https://user-images.githubusercontent.com/6477701/69396030-512b5700-0d24-11ea-8b3c-ffd3b1dbcb3f.png)

I was a bit hesitant about adding an actual example to the guideline as it looks a bit overwhelming  .. but I think ideally we should have such examples more in this page in the future.

Also, I was a bit wondering if this is a code style guide or pull request guide. I think it's kind of in between ..

It's discussed at http://apache-spark-developers-list.1001551.n3.nabble.com/Adding-JIRA-ID-as-the-prefix-for-the-test-case-name-td28289.html