### PR TITLE
Add a LTS release plan for 2.4.5/2.4.6

### DIFF
--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -290,6 +290,27 @@ of 2.3.0 in February 2018. No more 2.3.x releases should be expected after that 
 For example, 2.4.0 was released in November 2018, but will likely see releases for more than 18 months,
 beyond May 2020.</p>
 
+<h3>Spark 2.4 LTS Release Window</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th>Date</th>
+      <th>Event</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Jan 2020</td>
+      <td>Release 2.4.5</td>
+    </tr>
+    <tr>
+      <td>Jul 2020</td>
+      <td>Release 2.4.6</td>
+    </tr>
+  </tbody>
+</table>
+
   </div>
 </div>
 

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -74,3 +74,10 @@ of 2.3.0 in February 2018. No more 2.3.x releases should be expected after that 
 The last minor release within a major a release will typically be maintained for longer as an "LTS" release.
 For example, 2.4.0 was released in November 2018, but will likely see releases for more than 18 months,
 beyond May 2020.
+
+<h3>Spark 2.4 LTS Release Window</h3>
+
+| Date     | Event         |
+| -------- | ------------- |
+| Jan 2020 | Release 2.4.5 |
+| Jul 2020 | Release 2.4.6 |


### PR DESCRIPTION
This PR aims to add a LTS release plan for 2.4.5 and 2.4.6.
![screen](https://user-images.githubusercontent.com/9700541/70657502-c3e76e00-1c10-11ea-8783-5cf04ded04c3.png)
