### PR TITLE
Update the code freeze date of SPARK 3.0

### DIFF
--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -266,15 +266,15 @@ in between feature releases. Major releases do not happen according to a fixed s
       <td>Preview release</td>
     </tr>
     <tr>
-      <td>Early Dec 2019</td>
+      <td>01/31/2020</td>
       <td>Code freeze. Release branch cut.</td>
     </tr>
     <tr>
-      <td>Late Dec 2019</td>
+      <td>Early Feb 2020</td>
       <td>QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.</td>
     </tr>
     <tr>
-      <td>Jan 2020</td>
+      <td>Mid Feb 2020</td>
       <td>Release candidates (RC), voting, etc. until final release passes</td>
     </tr>
   </tbody>

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -61,9 +61,9 @@ in between feature releases. Major releases do not happen according to a fixed s
 | Date  | Event |
 | ----- | ----- |
 | Late Oct 2019 | Preview release |
-| Early Dec 2019 | Code freeze. Release branch cut.|
-| Late Dec 2019 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
-| Jan 2020 | Release candidates (RC), voting, etc. until final release passes|
+| 01/31/2020 | Code freeze. Release branch cut.|
+| Early Feb 2020 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
+| Mid Feb 2020 | Release candidates (RC), voting, etc. until final release passes|
 
 <h2>Maintenance Releases and EOL</h2>
 


### PR DESCRIPTION
This PR is to update the code freeze date of SPARK 3.0 based on the [discussion](http://apache-spark-developers-list.1001551.n3.nabble.com/Spark-3-0-branch-cut-and-code-freeze-on-Jan-31-td28575.html) in the mailing list 