### PR TITLE
Add SQL migration guide for 2.4.4

### DIFF
--- a/site/docs/2.4.4/sql-migration-guide-upgrade.html
+++ b/site/docs/2.4.4/sql-migration-guide-upgrade.html
@@ -238,6 +238,7 @@
                     
 
                     <ul id="markdown-toc">
+  <li><a href="#upgrading-from-spark-sql-243-to-244" id="markdown-toc-upgrading-from-spark-sql-243-to-244">Upgrading from Spark SQL 2.4.3 to 2.4.4</a></li>
   <li><a href="#upgrading-from-spark-sql-24-to-241" id="markdown-toc-upgrading-from-spark-sql-24-to-241">Upgrading from Spark SQL 2.4 to 2.4.1</a></li>
   <li><a href="#upgrading-from-spark-sql-23-to-24" id="markdown-toc-upgrading-from-spark-sql-23-to-24">Upgrading From Spark SQL 2.3 to 2.4</a></li>
   <li><a href="#upgrading-from-spark-sql-230-to-231-and-above" id="markdown-toc-upgrading-from-spark-sql-230-to-231-and-above">Upgrading From Spark SQL 2.3.0 to 2.3.1 and above</a></li>
@@ -262,6 +263,12 @@
       <li><a href="#python-datatypes-no-longer-singletons" id="markdown-toc-python-datatypes-no-longer-singletons">Python DataTypes No Longer Singletons</a></li>
     </ul>
   </li>
+</ul>
+
+<h2 id="upgrading-from-spark-sql-243-to-244">Upgrading from Spark SQL 2.4.3 to 2.4.4</h2>
+
+<ul>
+  <li> Since Spark 2.4.4, according to <a href="https://docs.microsoft.com/en-us/sql/connect/jdbc/using-basic-data-types?view=sql-server-2017">MsSqlServer Guide</a>, MsSQLServer JDBC Dialect uses ShortType and FloatType for SMALLINT and REAL, respectively. Previously, IntegerType and DoubleType is used.</li>
 </ul>
 
 <h2 id="upgrading-from-spark-sql-24-to-241">Upgrading from Spark SQL 2.4 to 2.4.1</h2>


### PR DESCRIPTION
This PR adds to a section to `Spark SQL Upgrading Guide` page of 2.4.4 document.

- https://spark.apache.org/docs/latest/sql-migration-guide-upgrade.html

**AFTER**

![Screen Shot 2020-01-17 at 5 47 22 PM](https://user-images.githubusercontent.com/9700541/72656618-6e118e80-3951-11ea-8db3-4b98de8ed51c.png)