### PR TITLE
Change the URL "www.apache.org/dist" to "downloads.apache.org" as structural change on ASF INFRA

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -24,7 +24,7 @@ $(document).ready(function() {
 
 3. Download Spark: <span id="spanDownloadLink"></span>
 
-4. Verify this release using the <span id="sparkDownloadVerify"></span> and [project release KEYS](https://www.apache.org/dist/spark/KEYS).
+4. Verify this release using the <span id="sparkDownloadVerify"></span> and [project release KEYS](https://downloads.apache.org/spark/KEYS).
 
 Note that, Spark is pre-built with Scala 2.11 except version 2.4.2, which is pre-built with Scala 2.12.
 

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -117,8 +117,8 @@ function updateDownloadLink() {
   var contents = "<a href=\"" + downloadHref + "\" onClick=\"" + onClick + "\">" + text + "</a>";
   append(downloadLink, contents);
 
-  var sigHref = "https://www.apache.org/dist/spark/spark-" + version + "/" + artifactName + ".asc";
-  var checksumHref = "https://www.apache.org/dist/spark/spark-" + version + "/" + artifactName + ".sha512";
+  var sigHref = "https://downloads.apache.org/spark/spark-" + version + "/" + artifactName + ".asc";
+  var checksumHref = "https://downloads.apache.org/spark/spark-" + version + "/" + artifactName + ".sha512";
   var verifyLinks = versionShort(version) + " <a href=\"" + sigHref + "\">signatures</a>, <a href=\"" +
     checksumHref + "\">checksums</a>";
   append(verifyLink, verifyLinks);

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -117,8 +117,8 @@ function updateDownloadLink() {
   var contents = "<a href=\"" + downloadHref + "\" onClick=\"" + onClick + "\">" + text + "</a>";
   append(downloadLink, contents);
 
-  var sigHref = "https://www.apache.org/dist/spark/spark-" + version + "/" + artifactName + ".asc";
-  var checksumHref = "https://www.apache.org/dist/spark/spark-" + version + "/" + artifactName + ".sha512";
+  var sigHref = "https://downloads.apache.org/spark/spark-" + version + "/" + artifactName + ".asc";
+  var checksumHref = "https://downloads.apache.org/spark/spark-" + version + "/" + artifactName + ".sha512";
   var verifyLinks = versionShort(version) + " <a href=\"" + sigHref + "\">signatures</a>, <a href=\"" +
     checksumHref + "\">checksums</a>";
   append(verifyLink, verifyLinks);

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -347,7 +347,7 @@ curl "https://dist.apache.org/repos/dist/dev/spark/KEYS" &gt; svn-spark/KEYS
 (cd svn-spark &amp;&amp; svn ci --username $ASF_USERNAME --password "$ASF_PASSWORD" -m"Update KEYS")
 </code></pre></div></div>
 
-<p>Verify that the resources are present in <a href="https://www.apache.org/dist/spark/">https://www.apache.org/dist/spark/</a>.
+<p>Verify that the resources are present in <a href="https://downloads.apache.org/spark/">https://downloads.apache.org/spark/</a>.
 It may take a while for them to be visible. This will be mirrored throughout the Apache network.
 Check the release checker result of the release at <a href="https://checker.apache.org/projs/spark.html">https://checker.apache.org/projs/spark.html</a>.</p>
 


### PR DESCRIPTION
Recently, ASF INFRA team has sent an email "[NOTICE] Structural changes to Apache downloads" to encourage ASF projects to change links from `www.apache.org/dist/` to `downloads.apache.org/`.

According to the mail content it's not a thing to be hurry as the old URL would be redirected with new URL, but as the old URL will be deprecated soon, it would be better to handle it early and forget about it.

This patch only changes URLs which is a straightforward change - so I simply skipped building content - please let me know if we would want to build and double-check.