### PR TITLE
Fix 2-4-6 web build

### DIFF
--- a/site/news/spark-2-4-6.html
+++ b/site/news/spark-2-4-6.html
@@ -6,13 +6,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Mailing Lists | Apache Spark
+     Spark 2.4.6 released | Apache Spark
     
   </title>
 
-  
-    <meta http-equiv="refresh" content="0; url=/community.html">
-    <link rel="canonical" href="https://spark.apache.org/community.html" />
   
 
   
@@ -203,7 +200,16 @@
   </div>
 
   <div class="col-md-9 col-md-pull-3">
-    
+    <h2>Spark 2.4.6 released</h2>
+
+
+<p>We are happy to announce the availability of <a href="/releases/spark-release-2-4-6.html" title="Spark Release 2.4.6">Spark 2.4.6</a>! Visit the <a href="/releases/spark-release-2-4-6.html" title="Spark Release 2.4.6">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+
+
+<p>
+<br/>
+<a href="/news/">Spark News Archive</a>
+</p>
 
   </div>
 </div>

--- a/site/releases/spark-release-2-4-6.html
+++ b/site/releases/spark-release-2-4-6.html
@@ -6,13 +6,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Mailing Lists | Apache Spark
+     Spark Release 2.4.6 | Apache Spark
     
   </title>
 
-  
-    <meta http-equiv="refresh" content="0; url=/community.html">
-    <link rel="canonical" href="https://spark.apache.org/community.html" />
   
 
   
@@ -203,7 +200,56 @@
   </div>
 
   <div class="col-md-9 col-md-pull-3">
-    
+    <h2>Spark Release 2.4.6</h2>
+
+
+<p>Spark 2.4.6 is a maintenance release containing stability, correctness, and security fixes. This release is based on the branch-2.4 maintenance branch of Spark. We strongly recommend all 2.4 users to upgrade to this stable release.</p>
+
+<h3 id="notable-changes">Notable changes</h3>
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-29419">[SPARK-29419]</a>: Seq.toDS / spark.createDataset(Seq) is not thread-safe</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-31519">[SPARK-31519]</a>: Cast in having aggregate expressions returns the wrong result</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-26293">[SPARK-26293]</a>: Cast exception when having python udf in subquery</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-30826">[SPARK-30826]</a>: LIKE returns wrong result from external table using parquet</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-30857">[SPARK-30857]</a>: Wrong truncations of timestamps before the epoch to hours and days</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-31256">[SPARK-31256]</a>: Dropna doesn&#8217;t work for struct columns</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-31312">[SPARK-31312]</a>: Transforming Hive simple UDF (using JAR) expression may incur CNFE in later evaluation</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-31420">[SPARK-31420]</a>: Infinite timeline redraw in job details page</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-31485">[SPARK-31485]</a>: Barrier stage can hang if only partial tasks launched</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-31500">[SPARK-31500]</a>: collect_set() of BinaryType returns duplicate elements</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-31503">[SPARK-31503]</a>: fix the SQL string of the TRIM functions</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-31663">[SPARK-31663]</a>: Grouping sets with having clause returns the wrong result</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-26908">[SPARK-26908]</a>: Fix toMilis</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-31563">[SPARK-31563]</a>: Failure of Inset.sql for UTF8String collection</li>
+</ul>
+
+<h3 id="dependency-changes">Dependency Changes</h3>
+
+<p>While being a maintence release we did still upgrade some dependencies in this release they are:</p>
+<ul>
+  <li>netty-all to 4.1.47.Final (<a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-20445">[CVE-2019-20445]</a>)</li>
+  <li>Janino to 3.0.16 (SQL Generated code)</li>
+  <li>aws-java-sdk-sts to 1.11.655 (required for kinesis client upgrade)</li>
+  <li>snappy 1.1.7.5 (stability improvements &amp; ppc64le performance)</li>
+</ul>
+
+<h3 id="known-issues">Known issues</h3>
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-31170">[SPARK-31170]</a>: Spark Cli does not respect hive-site.xml and spark.sql.warehouse.dir</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-26021">[SPARK-26021]</a>: -0.0 and 0.0 not treated consistently, doesn&#8217;t match Hive</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-26154">[SPARK-26154]</a>: Stream-stream joins - left outer join gives inconsistent outpu</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-28344">[SPARK-28344]</a>: Fail the query if detect ambiguous self join</li>
+</ul>
+
+<p>You can consult JIRA for the <a href="https://s.apache.org/spark-2.4.6">detailed changes</a>.</p>
+
+<p>We would like to acknowledge all community members for contributing patches to this release.</p>
+
+
+<p>
+<br/>
+<a href="/news/">Spark News Archive</a>
+</p>
 
   </div>
 </div>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -139,745 +139,745 @@
 </url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-4-6.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-4-6.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-4-6.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-4-6.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-4-5.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-4-5.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-4-5-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-4-5-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-3.0.0-preview2.html</loc>
+  <loc>https://spark.apache.org/news/spark-3.0.0-preview2.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-3.0.0-preview.html</loc>
+  <loc>https://spark.apache.org/news/spark-3.0.0-preview.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-3-4.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-3-4.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-3-4-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-3-4-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-4-4.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-4-4.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-4-4-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-4-4-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/plan-for-dropping-python-2-support.html</loc>
+  <loc>https://spark.apache.org/news/plan-for-dropping-python-2-support.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-4-3.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-4-3.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-4-3-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-4-3-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-4-2.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-4-2.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-4-2-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-4-2-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-4-1.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-4-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-4-1-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-4-1-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-3-3.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-3-3.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-3-3-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-3-3-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-2-3.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-2-3.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-release-2-2-3.html</loc>
+  <loc>https://spark.apache.org/news/spark-release-2-2-3.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-ai-summit-apr-2019-agenda-posted.html</loc>
+  <loc>https://spark.apache.org/news/spark-ai-summit-apr-2019-agenda-posted.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-4-0.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-4-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-4-0-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-4-0-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-3-2.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-3-2.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-3-2-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-3-2-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-summit-oct-2018-agenda-posted.html</loc>
+  <loc>https://spark.apache.org/news/spark-summit-oct-2018-agenda-posted.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-2-2.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-2-2.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-2-2-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-2-2-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-1-3.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-1-3.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-1-3-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-1-3-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-3-1.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-3-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-3-1-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-3-1-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-summit-june-2018-agenda-posted.html</loc>
+  <loc>https://spark.apache.org/news/spark-summit-june-2018-agenda-posted.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-3-0.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-3-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-3-0-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-3-0-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-2-1.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-2-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-2-1-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-2-1-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-1-2.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-1-2.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-1-2-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-1-2-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-summit-eu-2017-agenda-posted.html</loc>
+  <loc>https://spark.apache.org/news/spark-summit-eu-2017-agenda-posted.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-2-0.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-2-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-2-0-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-2-0-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-1-1.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-1-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-1-1-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-1-1-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-summit-june-2017-agenda-posted.html</loc>
+  <loc>https://spark.apache.org/news/spark-summit-june-2017-agenda-posted.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-summit-east-2017-agenda-posted.html</loc>
+  <loc>https://spark.apache.org/news/spark-summit-east-2017-agenda-posted.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-1-0.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-1-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-1-0-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-1-0-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-wins-cloudsort-100tb-benchmark.html</loc>
+  <loc>https://spark.apache.org/news/spark-wins-cloudsort-100tb-benchmark.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-0-2.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-0-2.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-0-2-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-0-2-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-6-3.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-6-3.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-6-3-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-6-3-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-0-1.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-0-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-0-1-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-0-1-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-2-0-0.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-2-0-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2-0-0-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-2-0-0-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-6-2.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-6-2.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-6-2-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-6-2-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/submit-talks-to-spark-summit-eu-2016.html</loc>
+  <loc>https://spark.apache.org/news/submit-talks-to-spark-summit-eu-2016.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-2.0.0-preview.html</loc>
+  <loc>https://spark.apache.org/news/spark-2.0.0-preview.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-summit-june-2016-agenda-posted.html</loc>
+  <loc>https://spark.apache.org/news/spark-summit-june-2016-agenda-posted.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-6-1.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-6-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-6-1-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-6-1-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/submit-talks-to-spark-summit-2016.html</loc>
+  <loc>https://spark.apache.org/news/submit-talks-to-spark-summit-2016.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-summit-east-agenda-posted.html</loc>
+  <loc>https://spark.apache.org/news/spark-summit-east-agenda-posted.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-6-0.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-6-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-6-0-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-6-0-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-summit-east-2016-cfp-closing.html</loc>
+  <loc>https://spark.apache.org/news/spark-summit-east-2016-cfp-closing.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-5-2.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-5-2.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-5-2-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-5-2-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/submit-talks-to-spark-summit-east-2016.html</loc>
+  <loc>https://spark.apache.org/news/submit-talks-to-spark-summit-east-2016.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-5-1.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-5-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-5-1-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-5-1-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-5-0.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-5-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-5-0-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-5-0-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-summit-europe-agenda-posted.html</loc>
+  <loc>https://spark.apache.org/news/spark-summit-europe-agenda-posted.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-4-1.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-4-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-4-1-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-4-1-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-summit-2015-videos-posted.html</loc>
+  <loc>https://spark.apache.org/news/spark-summit-2015-videos-posted.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-4-0.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-4-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-4-0-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-4-0-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-summit-europe.html</loc>
+  <loc>https://spark.apache.org/news/spark-summit-europe.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/one-month-to-spark-summit-2015.html</loc>
+  <loc>https://spark.apache.org/news/one-month-to-spark-summit-2015.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-summit-east-2015-videos-posted.html</loc>
+  <loc>https://spark.apache.org/news/spark-summit-east-2015-videos-posted.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-3-1.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-3-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-2-2.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-2-2.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-2-2-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-2-2-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-3-0.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-3-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-3-0-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-3-0-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-2-1.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-2-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-2-1-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-2-1-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-summit-east-agenda-posted.html</loc>
+  <loc>https://spark.apache.org/news/spark-summit-east-agenda-posted.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-2-0.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-2-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-2-0-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-2-0-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-1-1.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-1-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-1-1-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-1-1-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/registration-open-for-spark-summit-east.html</loc>
+  <loc>https://spark.apache.org/news/registration-open-for-spark-summit-east.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-wins-daytona-gray-sort-100tb-benchmark.html</loc>
+  <loc>https://spark.apache.org/news/spark-wins-daytona-gray-sort-100tb-benchmark.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/proposals-open-for-spark-summit-east.html</loc>
+  <loc>https://spark.apache.org/news/proposals-open-for-spark-summit-east.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-1-0.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-1-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-1-0-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-1-0-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-0-2.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-0-2.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-0-2-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-0-2-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-0-9-2.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-0-9-2.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-0-9-2-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-0-9-2-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-summit-2014-videos-posted.html</loc>
+  <loc>https://spark.apache.org/news/spark-summit-2014-videos-posted.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-0-1.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-0-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-0-1-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-0-1-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/two-weeks-to-spark-summit-2014.html</loc>
+  <loc>https://spark.apache.org/news/two-weeks-to-spark-summit-2014.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-1-0-0.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-1-0-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-1-0-0-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-1-0-0-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-summit-agenda-posted.html</loc>
+  <loc>https://spark.apache.org/news/spark-summit-agenda-posted.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-0-9-1.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-0-9-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-0-9-1-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-0-9-1-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/submit-talks-to-spark-summit-2014.html</loc>
+  <loc>https://spark.apache.org/news/submit-talks-to-spark-summit-2014.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-becomes-tlp.html</loc>
+  <loc>https://spark.apache.org/news/spark-becomes-tlp.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-0-9-0.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-0-9-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-0-9-0-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-0-9-0-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-0-8-1.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-0-8-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-0-8-1-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-0-8-1-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-summit-2013-is-a-wrap.html</loc>
+  <loc>https://spark.apache.org/news/spark-summit-2013-is-a-wrap.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/announcing-the-first-spark-summit.html</loc>
+  <loc>https://spark.apache.org/news/announcing-the-first-spark-summit.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-0-8-0.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-0-8-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-0-8-0-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-0-8-0-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-user-survey-and-powered-by-page.html</loc>
+  <loc>https://spark.apache.org/news/spark-user-survey-and-powered-by-page.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/fourth-spark-screencast-published.html</loc>
+  <loc>https://spark.apache.org/news/fourth-spark-screencast-published.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/screencasts/4-a-standalone-job-in-spark.html</loc>
+  <loc>https://spark.apache.org/screencasts/4-a-standalone-job-in-spark.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/amp-camp-2013-registration-ope.html</loc>
+  <loc>https://spark.apache.org/news/amp-camp-2013-registration-ope.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-mailing-lists-moving-to-apache.html</loc>
+  <loc>https://spark.apache.org/news/spark-mailing-lists-moving-to-apache.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-0-7-3.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-0-7-3.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-0-7-3-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-0-7-3-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-featured-in-wired.html</loc>
+  <loc>https://spark.apache.org/news/spark-featured-in-wired.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-accepted-into-apache-incubator.html</loc>
+  <loc>https://spark.apache.org/news/spark-accepted-into-apache-incubator.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-0-7-2.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-0-7-2.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-0-7-2-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-0-7-2-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/screencasts/3-transformations-and-caching.html</loc>
+  <loc>https://spark.apache.org/screencasts/3-transformations-and-caching.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-screencasts-published.html</loc>
+  <loc>https://spark.apache.org/news/spark-screencasts-published.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/screencasts/2-spark-documentation-overview.html</loc>
+  <loc>https://spark.apache.org/screencasts/2-spark-documentation-overview.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/screencasts/1-first-steps-with-spark.html</loc>
+  <loc>https://spark.apache.org/screencasts/1-first-steps-with-spark.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/strata-exercises-now-available-online.html</loc>
+  <loc>https://spark.apache.org/news/strata-exercises-now-available-online.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-0-7-0.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-0-7-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-0-7-0-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-0-7-0-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/run-spark-and-shark-on-amazon-emr.html</loc>
+  <loc>https://spark.apache.org/news/run-spark-and-shark-on-amazon-emr.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-0-6-2.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-0-6-2.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-0-6-2-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-0-6-2-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-tips-from-quantifind.html</loc>
+  <loc>https://spark.apache.org/news/spark-tips-from-quantifind.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/video-from-first-spark-development-meetup.html</loc>
+  <loc>https://spark.apache.org/news/video-from-first-spark-development-meetup.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-and-shark-in-the-news.html</loc>
+  <loc>https://spark.apache.org/news/spark-and-shark-in-the-news.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-0-6-1.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-0-6-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-0-5-2.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-0-5-2.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-0-6-1-and-0-5-2-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-0-6-1-and-0-5-2-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-0-6-0.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-0-6-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-version-0-6-0-released.html</loc>
+  <loc>https://spark.apache.org/news/spark-version-0-6-0-released.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-0-5-1.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-0-5-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-0-5-0.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-0-5-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/nsdi-paper.html</loc>
+  <loc>https://spark.apache.org/news/nsdi-paper.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/spark-meetups.html</loc>
+  <loc>https://spark.apache.org/news/spark-meetups.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/releases/spark-release-0-3.html</loc>
+  <loc>https://spark.apache.org/releases/spark-release-0-3.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 
 <url>
-  <loc>http://localhost:4000/committers.html</loc>
+  <loc>https://spark.apache.org/committers.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/community.html</loc>
+  <loc>https://spark.apache.org/community.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/contributing.html</loc>
+  <loc>https://spark.apache.org/contributing.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/developer-tools.html</loc>
+  <loc>https://spark.apache.org/developer-tools.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/documentation.html</loc>
+  <loc>https://spark.apache.org/documentation.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/downloads.html</loc>
+  <loc>https://spark.apache.org/downloads.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/examples.html</loc>
+  <loc>https://spark.apache.org/examples.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/faq.html</loc>
+  <loc>https://spark.apache.org/faq.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/history.html</loc>
+  <loc>https://spark.apache.org/history.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/improvement-proposals.html</loc>
+  <loc>https://spark.apache.org/improvement-proposals.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/graphx/</loc>
+  <loc>https://spark.apache.org/graphx/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/news/</loc>
+  <loc>https://spark.apache.org/news/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/mllib/</loc>
+  <loc>https://spark.apache.org/mllib/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/screencasts/</loc>
+  <loc>https://spark.apache.org/screencasts/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/streaming/</loc>
+  <loc>https://spark.apache.org/streaming/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/sql/</loc>
+  <loc>https://spark.apache.org/sql/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/</loc>
+  <loc>https://spark.apache.org/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/mailing-lists.html</loc>
+  <loc>https://spark.apache.org/mailing-lists.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/powered-by.html</loc>
+  <loc>https://spark.apache.org/powered-by.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/release-process.html</loc>
+  <loc>https://spark.apache.org/release-process.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/research.html</loc>
+  <loc>https://spark.apache.org/research.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/security.html</loc>
+  <loc>https://spark.apache.org/security.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 
 <url>
-  <loc>http://localhost:4000/third-party-projects.html</loc>
+  <loc>https://spark.apache.org/third-party-projects.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/trademarks.html</loc>
+  <loc>https://spark.apache.org/trademarks.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>http://localhost:4000/versioning-policy.html</loc>
+  <loc>https://spark.apache.org/versioning-policy.html</loc>
   <changefreq>weekly</changefreq>
 </url>
 


### PR DESCRIPTION
Fix the 2.4.6 web build, the jekyll serve wrote some localhost values in the sitemap we don't want and add the generated release files.