### PR TITLE
Update Release Window from 3.0 to 3.1

### DIFF
--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -328,7 +328,7 @@ available APIs.</p>
 generally be released about 6 months after 2.2.0. Maintenance releases happen as needed
 in between feature releases. Major releases do not happen according to a fixed schedule.</p>
 
-<h3>Spark 3.0 Release Window</h3>
+<h3>Spark 3.1 Release Window</h3>
 
 <table>
   <thead>
@@ -339,19 +339,15 @@ in between feature releases. Major releases do not happen according to a fixed s
   </thead>
   <tbody>
     <tr>
-      <td>Late Oct 2019</td>
-      <td>Preview release</td>
-    </tr>
-    <tr>
-      <td>01/31/2020</td>
+      <td>Early Nov 2020</td>
       <td>Code freeze. Release branch cut.</td>
     </tr>
     <tr>
-      <td>Early Feb 2020</td>
+      <td>Mid Nov 2020</td>
       <td>QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.</td>
     </tr>
     <tr>
-      <td>Mid Feb 2020</td>
+      <td>Early Dec 2020</td>
       <td>Release candidates (RC), voting, etc. until final release passes</td>
     </tr>
   </tbody>

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -103,14 +103,13 @@ In general, feature ("minor") releases occur about every 6 months. Hence, Spark 
 generally be released about 6 months after 2.2.0. Maintenance releases happen as needed
 in between feature releases. Major releases do not happen according to a fixed schedule.
 
-<h3>Spark 3.0 Release Window</h3>
+<h3>Spark 3.1 Release Window</h3>
 
 | Date  | Event |
 | ----- | ----- |
-| Late Oct 2019 | Preview release |
-| 01/31/2020 | Code freeze. Release branch cut.|
-| Early Feb 2020 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
-| Mid Feb 2020 | Release candidates (RC), voting, etc. until final release passes|
+| Early Nov 2020 | Code freeze. Release branch cut.|
+| Mid Nov 2020 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
+| Early Dec 2020 | Release candidates (RC), voting, etc. until final release passes|
 
 <h2>Maintenance Releases and EOL</h2>
 


### PR DESCRIPTION
According to our release cadence, this PR aims to make our website up-to-date by updating next release window content from 3.0 to 3.1. This follows the general guideline, and we can adjust later based on our situation.
> In general, feature minor releases occur about every 6 months.