### PR TITLE
Update the artifactId in the Download Page

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -40,7 +40,7 @@ The latest preview release is Spark 3.0.0-preview2, published on Dec 23, 2019.
 Spark artifacts are [hosted in Maven Central](https://search.maven.org/search?q=g:org.apache.spark). You can add a Maven dependency with the following coordinates:
 
     groupId: org.apache.spark
-    artifactId: spark-core_2.11
+    artifactId: spark-core_2.12
     version: 3.0.0
 
 ### Installing with PyPi

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -240,7 +240,7 @@ The latest preview release is Spark 3.0.0-preview2, published on Dec 23, 2019.</
 <p>Spark artifacts are <a href="https://search.maven.org/search?q=g:org.apache.spark">hosted in Maven Central</a>. You can add a Maven dependency with the following coordinates:</p>
 
 <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>groupId: org.apache.spark
-artifactId: spark-core_2.11
+artifactId: spark-core_2.12
 version: 3.0.0
 </code></pre></div></div>
 


### PR DESCRIPTION
The existing artifactId is not correct. We need to update it from 2.11 to 2.12

![Screen Shot 2020-06-23 at 4 34 33 PM](https://user-images.githubusercontent.com/11567269/85477700-af950e00-b56f-11ea-915e-f027d383a73e.png)
