### PR TITLE
Fix Python 2 examples of Pi Estimation

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -88,9 +88,9 @@ def inside(p):
     x, y = random.random(), random.random()
     return x*x + y*y < 1
 
-count = sc.parallelize(xrange(0, NUM_SAMPLES)) \
+count = sc.parallelize(range(0, NUM_SAMPLES)) \
              .filter(inside).count()
-print "Pi is roughly %f" % (4.0 * count / NUM_SAMPLES)
+print("Pi is roughly %f" % (4.0 * count / NUM_SAMPLES))
 {% endhighlight %}
 </div>
 </div>

--- a/site/examples.html
+++ b/site/examples.html
@@ -282,9 +282,9 @@ In this page, we will show examples using RDD API as well as examples using high
     <span class="n">x</span><span class="p">,</span> <span class="n">y</span> <span class="o">=</span> <span class="n">random</span><span class="o">.</span><span class="n">random</span><span class="p">(),</span> <span class="n">random</span><span class="o">.</span><span class="n">random</span><span class="p">()</span>
     <span class="k">return</span> <span class="n">x</span><span class="o">*</span><span class="n">x</span> <span class="o">+</span> <span class="n">y</span><span class="o">*</span><span class="n">y</span> <span class="o">&lt;</span> <span class="mi">1</span>
 
-<span class="n">count</span> <span class="o">=</span> <span class="n">sc</span><span class="o">.</span><span class="n">parallelize</span><span class="p">(</span><span class="nb">xrange</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="n">NUM_SAMPLES</span><span class="p">))</span> \
+<span class="n">count</span> <span class="o">=</span> <span class="n">sc</span><span class="o">.</span><span class="n">parallelize</span><span class="p">(</span><span class="nb">range</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="n">NUM_SAMPLES</span><span class="p">))</span> \
              <span class="o">.</span><span class="nb">filter</span><span class="p">(</span><span class="n">inside</span><span class="p">)</span><span class="o">.</span><span class="n">count</span><span class="p">()</span>
-<span class="k">print</span> <span class="s">"Pi is roughly </span><span class="si">%</span><span class="s">f"</span> <span class="o">%</span> <span class="p">(</span><span class="mf">4.0</span> <span class="o">*</span> <span class="n">count</span> <span class="o">/</span> <span class="n">NUM_SAMPLES</span><span class="p">)</span></code></pre></figure>
+<span class="k">print</span><span class="p">(</span><span class="s">"Pi is roughly </span><span class="si">%</span><span class="s">f"</span> <span class="o">%</span> <span class="p">(</span><span class="mf">4.0</span> <span class="o">*</span> <span class="n">count</span> <span class="o">/</span> <span class="n">NUM_SAMPLES</span><span class="p">))</span></code></pre></figure>
 
 </div>
 </div>


### PR DESCRIPTION
I tried to run [Pi Estimation example](https://spark.apache.org/examples.html)  with Python 3, but it is not working.

According to [latest docs](https://spark.apache.org/docs/latest/) ,
> Python 2 and Python 3 prior to version 3.6 support is deprecated as of Spark 3.0.0.

[Basic example](https://github.com/apache/spark/tree/master/examples/src/main/python) seemed to be fixed already.

