### PR TITLE
Adds Kotlin to the list of third-party language bindings

### DIFF
--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -298,6 +298,12 @@ transforming, and analyzing genomic data using Apache Spark</li>
   <li><a href="https://github.com/dfdx/Spark.jl">Spark.jl</a></li>
 </ul>
 
+<h3>Kotlin</h3>
+
+<ul>
+  <li><a href="https://github.com/JetBrains/kotlin-spark-api">Kotlin for Apache Spark</a></li>
+</ul>
+
   </div>
 </div>
 

--- a/third-party-projects.md
+++ b/third-party-projects.md
@@ -90,3 +90,7 @@ transforming, and analyzing genomic data using Apache Spark
 <h3>Julia</h3>
 
 - <a href="https://github.com/dfdx/Spark.jl">Spark.jl</a>
+
+<h3>Kotlin</h3>
+
+- <a href="https://github.com/JetBrains/kotlin-spark-api">Kotlin for Apache Spark</a>


### PR DESCRIPTION
This PR adds a link to Kotlin for Apache Spark repo as a third-party language binding. 