### PR TITLE
Update doc related to gpg key exports

### DIFF
--- a/release-process.md
+++ b/release-process.md
@@ -43,8 +43,8 @@ After generating the gpg key, you need to upload your key to a public key server
 <a href="https://www.apache.org/dev/openpgp.html#generate-key">https://www.apache.org/dev/openpgp.html#generate-key</a>
 for details.
 
-If you want to do the release on another machine, you can transfer your gpg key to that machine
-via the `gpg --export` and `gpg --import` commands.
+If you want to do the release on another machine, you can transfer your secret key to that machine
+via the `gpg --export-secret-keys` and `gpg --import` commands.
 
 The last step is to update the KEYS file with your code signing key
 <a href="https://www.apache.org/dev/openpgp.html#export-public-key">https://www.apache.org/dev/openpgp.html#export-public-key</a>


### PR DESCRIPTION
When preparing for 3.0.1-rc, I encounted issues related to gpg keys:
1, locally: I generated keys and used `gpg --export` to export it;
2, on an AWS EC2 instance: then imported keys by `gpg --import` commands and then run the `do-release-docker.sh`. I found that the script can not find the key.

That is because:
according to [export-secret-key](https://infra.apache.org/openpgp.html#export-secret-key)

> To ensure that you do not accidentally expose private keys, the GnuPG --export operation exports only public keys.

`gpg --export` only exports **public** keys, while `do-release-docker.sh` needs a **secret/private** key. So we should use `gpg --export-secret-keys` instead `gpg --export`.

![image](https://user-images.githubusercontent.com/7322292/92091702-afcd4780-ee03-11ea-87cf-8edcf0889215.png)
