### PR TITLE
Update Spark 3.1 Release Window

### DIFF
--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -339,15 +339,15 @@ in between feature releases. Major releases do not happen according to a fixed s
   </thead>
   <tbody>
     <tr>
-      <td>Early Nov 2020</td>
+      <td>Early Dec 2020</td>
       <td>Code freeze. Release branch cut.</td>
     </tr>
     <tr>
-      <td>Mid Nov 2020</td>
+      <td>Mid Dec 2020</td>
       <td>QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.</td>
     </tr>
     <tr>
-      <td>Early Dec 2020</td>
+      <td>Early Jan 2020</td>
       <td>Release candidates (RC), voting, etc. until final release passes</td>
     </tr>
   </tbody>

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -107,9 +107,9 @@ in between feature releases. Major releases do not happen according to a fixed s
 
 | Date  | Event |
 | ----- | ----- |
-| Early Nov 2020 | Code freeze. Release branch cut.|
-| Mid Nov 2020 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
-| Early Dec 2020 | Release candidates (RC), voting, etc. until final release passes|
+| Early Dec 2020 | Code freeze. Release branch cut.|
+| Mid Dec 2020 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
+| Early Jan 2020 | Release candidates (RC), voting, etc. until final release passes|
 
 <h2>Maintenance Releases and EOL</h2>
 


### PR DESCRIPTION
This PR is to update the release window based on the public discussion in the dev list: http://apache-spark-developers-list.1001551.n3.nabble.com/Re-Apache-Spark-3-1-Preparation-Status-Oct-2020-td30255.html

