### PR TITLE
Replace test-only to testOnly in Developer tools page

### DIFF
--- a/developer-tools.md
+++ b/developer-tools.md
@@ -267,7 +267,7 @@ it's due to a classpath issue (some classes were probably not compiled). To fix 
 sufficient to run a test from the command line:
 
 ```
-build/sbt "test-only org.apache.spark.rdd.SortingSuite"
+build/sbt "testOnly org.apache.spark.rdd.SortingSuite"
 ```
 
 <h3>Running Different Test Permutations on Jenkins</h3>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -447,7 +447,7 @@ java.lang.NullPointerException
 it&#8217;s due to a classpath issue (some classes were probably not compiled). To fix this, it 
 sufficient to run a test from the command line:</p>
 
-<div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>build/sbt "test-only org.apache.spark.rdd.SortingSuite"
+<div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>build/sbt "testOnly org.apache.spark.rdd.SortingSuite"
 </code></pre></div></div>
 
 <h3>Running Different Test Permutations on Jenkins</h3>


### PR DESCRIPTION
See also https://github.com/apache/spark/pull/30028. After SBT was upgraded to 1.3, `test-only` should be `testOnly`.