### PR TITLE
Add Data Mechanics to Powered By

### DIFF
--- a/powered-by.md
+++ b/powered-by.md
@@ -88,6 +88,12 @@ and external data sources, driving holistic and actionable insights.
   - We provided a <a href="https://www.databricks.com/product">cloud-optimized platform</a>
     to run Spark and ML applications on Amazon Web Services and Azure, as well as a comprehensive
     <a href="https://databricks.com/training">training program</a>.
+- <a href="https://www.datamechanics.co">Data Mechanics</a>
+  - Data Mechanics is a cloud-native Spark platform that can be deployed on a Kubernetes cluster
+    inside its customers AWS, GCP, or Azure cloud environments.
+  - Our focus is to make Spark easy-to-use and cost-effective for data engineering workloads.
+    We also develop the free, cross-platform, and partially open-source Spark monitoring tool 
+    <a href="https://www.datamechanics.co/delight">Data Mechanics Delight.</a>  
 - <a href="https://datapipelines.com">Data Pipelines</a>
   - Build and schedule ETL pipelines step-by-step via a simple no-code UI.
 - <a href="http://dianping.com">Dianping.com</a>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -221,7 +221,7 @@ always allowed, as in &#8220;BigCoProduct is a widget for Apache Spark&#8221;.</
 
 <h2>Companies and Organizations</h2>
 
-<p>To add yourself to the list, please email <code class="language-plaintext highlighter-rouge">dev@spark.apache.org</code> with your organization name, URL, 
+<p>To add yourself to the list, please email <code class="highlighter-rouge">dev@spark.apache.org</code> with your organization name, URL, 
 a list of which Spark components you are using, and a short description of your use case.</p>
 
 <ul>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -221,7 +221,7 @@ always allowed, as in &#8220;BigCoProduct is a widget for Apache Spark&#8221;.</
 
 <h2>Companies and Organizations</h2>
 
-<p>To add yourself to the list, please email <code class="highlighter-rouge">dev@spark.apache.org</code> with your organization name, URL, 
+<p>To add yourself to the list, please email <code class="language-plaintext highlighter-rouge">dev@spark.apache.org</code> with your organization name, URL, 
 a list of which Spark components you are using, and a short description of your use case.</p>
 
 <ul>
@@ -319,6 +319,15 @@ committed to keeping all our work on Spark open source.</li>
       <li>We provided a <a href="https://www.databricks.com/product">cloud-optimized platform</a>
 to run Spark and ML applications on Amazon Web Services and Azure, as well as a comprehensive
 <a href="https://databricks.com/training">training program</a>.</li>
+    </ul>
+  </li>
+  <li><a href="https://www.datamechanics.co">Data Mechanics</a>
+    <ul>
+      <li>Data Mechanics is a cloud-native Spark platform that can be deployed on a Kubernetes cluster
+inside its customers AWS, GCP, or Azure cloud environments.</li>
+      <li>Our focus is to make Spark easy-to-use and cost-effective for data engineering workloads.
+We also develop the free, cross-platform, and partially open-source Spark monitoring tool 
+<a href="https://www.datamechanics.co/delight">Data Mechanics Delight.</a></li>
     </ul>
   </li>
   <li><a href="https://datapipelines.com">Data Pipelines</a>


### PR DESCRIPTION
Data Mechanics is a managed Spark platform that can be deployed on a Kubernetes cluster inside our customers cloud accounts. We'd love to be on the Powered By Spark page (along other Spark platforms). 

We contribute to open source projets in the Spark ecosystem (Spark on Kubernetes operator, Data Mechanics Delight). We also use Spark internally for our recommendation engine and logs processing.

I tried to be objective / avoid marketing in the description, but I'm open to feedback on changing it. Thanks!