### PR TITLE
Add news about the next release as Spark 3.1.1

### DIFF
--- a/news/_posts/2021-01-07-next-official-release-spark-3.1.1.md
+++ b/news/_posts/2021-01-07-next-official-release-spark-3.1.1.md
@@ -12,7 +12,7 @@ meta:
   _wpas_done_all: '1'
 ---
 The next official Spark release is Spark 3.1.1 instead of Spark 3.1.0.
-There was an accident during Spark 3.1.0 RC1 preparation,
+There was a technical issue during Spark 3.1.0 RC1 preparation,
 see [[VOTE] Release Spark 3.1.0 (RC1)](https://www.mail-archive.com/dev@spark.apache.org/msg27133.html) in the Spark dev mailing list.
 
 In short, Spark 3.1.0 RC1 was [unexpectedly published into Maven as Spark 3.1.0](https://repo1.maven.org/maven2/org/apache/spark/spark-core_2.12/3.1.0/)

--- a/news/_posts/2021-01-07-next-official-release-spark-3.1.1.md
+++ b/news/_posts/2021-01-07-next-official-release-spark-3.1.1.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "Next official release: Spark 3.1.1" 
+categories:
+- News
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+The next official Spark release is Spark 3.1.1 instead of Spark 3.1.0.
+There was an accident during Spark 3.1.0 RC1 preparation,
+see [[VOTE] Release Spark 3.1.0 (RC1)](http://apache-spark-developers-list.1001551.n3.nabble.com/VOTE-Release-Spark-3-1-0-RC1-td30524.html) in the Spark dev mailing list.
+
+In short, Spark 3.1.0 RC1 was [unexpectedly published into Maven as Spark 3.1.0](https://repo1.maven.org/maven2/org/apache/spark/spark-core_2.12/3.1.0/)
+while it is not officially released to Apache mirrors. We plan to skip this release
+and choose 3.1.1 as the next release to prevent the potential problems to the end
+users.
+
+Therefore, Spark 3.1.1 will supersede the unofficial Spark 3.1.0 unexpectedly
+published to Maven. We discourage to use this Spark 3.1.0 for any purpose, and there
+are no guarantees on using it such as binary compatibility.
+

--- a/news/_posts/2021-01-07-next-official-release-spark-3.1.1.md
+++ b/news/_posts/2021-01-07-next-official-release-spark-3.1.1.md
@@ -13,11 +13,11 @@ meta:
 ---
 The next official Spark release is Spark 3.1.1 instead of Spark 3.1.0.
 There was an accident during Spark 3.1.0 RC1 preparation,
-see [[VOTE] Release Spark 3.1.0 (RC1)](http://apache-spark-developers-list.1001551.n3.nabble.com/VOTE-Release-Spark-3-1-0-RC1-td30524.html) in the Spark dev mailing list.
+see [[VOTE] Release Spark 3.1.0 (RC1)](https://www.mail-archive.com/dev@spark.apache.org/msg27133.html) in the Spark dev mailing list.
 
 In short, Spark 3.1.0 RC1 was [unexpectedly published into Maven as Spark 3.1.0](https://repo1.maven.org/maven2/org/apache/spark/spark-core_2.12/3.1.0/)
-while it is not officially released to Apache mirrors. We plan to skip this release
-and choose 3.1.1 as the next release to prevent the potential problems to the end
+while it is not officially released to Apache mirrors. We plan to skip Spark 3.1.0 release
+and choose Spark 3.1.1 as the next release to prevent the potential problems to the end
 users.
 
 Therefore, Spark 3.1.1 will supersede the unofficial Spark 3.1.0 unexpectedly

--- a/site/committers.html
+++ b/site/committers.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/community.html
+++ b/site/community.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/examples.html
+++ b/site/examples.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/faq.html
+++ b/site/faq.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/history.html
+++ b/site/history.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/index.html
+++ b/site/index.html
@@ -164,6 +164,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -172,9 +175,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
@@ -201,6 +201,17 @@
 
   <div class="col-md-9 col-md-pull-3">
     <h2 id="spark-news">Spark News</h2>
+
+<article class="hentry">
+    <header class="entry-header">
+      <h3 class="entry-title"><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a></h3>
+      <div class="entry-date">January 7, 2021</div>
+    </header>
+    <div class="entry-content"><p>The next official Spark release is Spark 3.1.1 instead of Spark 3.1.0.
+There was an accident during Spark 3.1.0 RC1 preparation,
+see <a href="http://apache-spark-developers-list.1001551.n3.nabble.com/VOTE-Release-Spark-3-1-0-RC1-td30524.html">[VOTE] Release Spark 3.1.0 (RC1)</a> in the Spark dev mailing list.</p>
+</div>
+  </article>
 
 <article class="hentry">
     <header class="entry-header">

--- a/site/news/next-official-release-spark-3.1.1.html
+++ b/site/news/next-official-release-spark-3.1.1.html
@@ -205,11 +205,11 @@
 
 <p>The next official Spark release is Spark 3.1.1 instead of Spark 3.1.0.
 There was an accident during Spark 3.1.0 RC1 preparation,
-see <a href="http://apache-spark-developers-list.1001551.n3.nabble.com/VOTE-Release-Spark-3-1-0-RC1-td30524.html">[VOTE] Release Spark 3.1.0 (RC1)</a> in the Spark dev mailing list.</p>
+see <a href="https://www.mail-archive.com/dev@spark.apache.org/msg27133.html">[VOTE] Release Spark 3.1.0 (RC1)</a> in the Spark dev mailing list.</p>
 
 <p>In short, Spark 3.1.0 RC1 was <a href="https://repo1.maven.org/maven2/org/apache/spark/spark-core_2.12/3.1.0/">unexpectedly published into Maven as Spark 3.1.0</a>
-while it is not officially released to Apache mirrors. We plan to skip this release
-and choose 3.1.1 as the next release to prevent the potential problems to the end
+while it is not officially released to Apache mirrors. We plan to skip Spark 3.1.0 release
+and choose Spark 3.1.1 as the next release to prevent the potential problems to the end
 users.</p>
 
 <p>Therefore, Spark 3.1.1 will supersede the unofficial Spark 3.1.0 unexpectedly

--- a/site/news/next-official-release-spark-3.1.1.html
+++ b/site/news/next-official-release-spark-3.1.1.html
@@ -204,7 +204,7 @@
 
 
 <p>The next official Spark release is Spark 3.1.1 instead of Spark 3.1.0.
-There was an accident during Spark 3.1.0 RC1 preparation,
+There was a technical issue during Spark 3.1.0 RC1 preparation,
 see <a href="https://www.mail-archive.com/dev@spark.apache.org/msg27133.html">[VOTE] Release Spark 3.1.0 (RC1)</a> in the Spark dev mailing list.</p>
 
 <p>In short, Spark 3.1.0 RC1 was <a href="https://repo1.maven.org/maven2/org/apache/spark/spark-core_2.12/3.1.0/">unexpectedly published into Maven as Spark 3.1.0</a>

--- a/site/news/next-official-release-spark-3.1.1.html
+++ b/site/news/next-official-release-spark-3.1.1.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark Release 0.5.2 | Apache Spark
+     Next official release: Spark 3.1.1 | Apache Spark
     
   </title>
 
@@ -200,12 +200,22 @@
   </div>
 
   <div class="col-md-9 col-md-pull-3">
-    <h2>Spark Release 0.5.2</h2>
+    <h2>Next official release: Spark 3.1.1</h2>
 
 
-<p>Spark 0.5.2 is a minor release, whose main addition is to allow Spark to compile against Hadoop 2 distributions. To do this, edit <code>project/SparkBuild.scala</code> and change both the <code>HADOOP_VERSION</code> and <code>HADOOP_MAJOR_VERSION</code> variables, then recompile Spark. This change was contributed by Thomas Dudziak.</p>
+<p>The next official Spark release is Spark 3.1.1 instead of Spark 3.1.0.
+There was an accident during Spark 3.1.0 RC1 preparation,
+see <a href="http://apache-spark-developers-list.1001551.n3.nabble.com/VOTE-Release-Spark-3-1-0-RC1-td30524.html">[VOTE] Release Spark 3.1.0 (RC1)</a> in the Spark dev mailing list.</p>
 
-<p>You can download Spark 0.5.2 as a <a href="https://github.com/downloads/mesos/spark/spark-0.5.2-sources.tgz">tar.gz file</a> (2 MB).</p>
+<p>In short, Spark 3.1.0 RC1 was <a href="https://repo1.maven.org/maven2/org/apache/spark/spark-core_2.12/3.1.0/">unexpectedly published into Maven as Spark 3.1.0</a>
+while it is not officially released to Apache mirrors. We plan to skip this release
+and choose 3.1.1 as the next release to prevent the potential problems to the end
+users.</p>
+
+<p>Therefore, Spark 3.1.1 will supersede the unofficial Spark 3.1.0 unexpectedly
+published to Maven. We discourage to use this Spark 3.1.0 for any purpose, and there
+are no guarantees on using it such as binary compatibility.</p>
+
 
 
 <p>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/plan-for-dropping-python-2-support.html
+++ b/site/news/plan-for-dropping-python-2-support.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-3-released.html
+++ b/site/news/spark-2-1-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-2-released.html
+++ b/site/news/spark-2-2-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-1-released.html
+++ b/site/news/spark-2-3-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-2-released.html
+++ b/site/news/spark-2-3-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-3-released.html
+++ b/site/news/spark-2-3-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-4-released.html
+++ b/site/news/spark-2-3-4-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-0-released.html
+++ b/site/news/spark-2-4-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-1-released.html
+++ b/site/news/spark-2-4-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-2-released.html
+++ b/site/news/spark-2-4-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-3-released.html
+++ b/site/news/spark-2-4-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-4-released.html
+++ b/site/news/spark-2-4-4-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-5-released.html
+++ b/site/news/spark-2-4-5-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-6.html
+++ b/site/news/spark-2-4-6.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-7-released.html
+++ b/site/news/spark-2-4-7-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-0-released.html
+++ b/site/news/spark-3-0-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-1-released.html
+++ b/site/news/spark-3-0-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview.html
+++ b/site/news/spark-3.0.0-preview.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview2.html
+++ b/site/news/spark-3.0.0-preview2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-apr-2019-agenda-posted.html
+++ b/site/news/spark-ai-summit-apr-2019-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-june-2020-agenda-posted.html
+++ b/site/news/spark-ai-summit-june-2020-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-release-2-2-3.html
+++ b/site/news/spark-release-2-2-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted.html
+++ b/site/news/spark-summit-east-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-oct-2018-agenda-posted.html
+++ b/site/news/spark-summit-oct-2018-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-3.html
+++ b/site/releases/spark-release-2-1-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-2.html
+++ b/site/releases/spark-release-2-2-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-3.html
+++ b/site/releases/spark-release-2-2-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-1.html
+++ b/site/releases/spark-release-2-3-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-2.html
+++ b/site/releases/spark-release-2-3-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-3.html
+++ b/site/releases/spark-release-2-3-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-4.html
+++ b/site/releases/spark-release-2-3-4.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-0.html
+++ b/site/releases/spark-release-2-4-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-1.html
+++ b/site/releases/spark-release-2-4-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-2.html
+++ b/site/releases/spark-release-2-4-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-3.html
+++ b/site/releases/spark-release-2-4-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-4.html
+++ b/site/releases/spark-release-2-4-4.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-5.html
+++ b/site/releases/spark-release-2-4-5.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-6.html
+++ b/site/releases/spark-release-2-4-6.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-7.html
+++ b/site/releases/spark-release-2-4-7.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-0.html
+++ b/site/releases/spark-release-3-0-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-1.html
+++ b/site/releases/spark-release-3-0-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/research.html
+++ b/site/research.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/security.html
+++ b/site/security.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -139,6 +139,10 @@
 </url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
+  <loc>https://spark.apache.org/news/next-official-release-spark-3.1.1.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/releases/spark-release-2-4-7.html</loc>
   <changefreq>weekly</changefreq>
 </url>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
           <span class="small">(Jun 18, 2020)</span></li>
-        
-          <li><a href="/news/spark-ai-summit-june-2020-agenda-posted.html">Spark+AI Summit (June 22-25th, 2020, VIRTUAL) agenda posted</a>
-          <span class="small">(Jun 15, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>


### PR DESCRIPTION
This PR adds news about the next release as Spark 3.1.1:

![Screen Shot 2021-01-08 at 9 48 33 AM](https://user-images.githubusercontent.com/6477701/103960918-b2b3bc80-5196-11eb-9052-39d57cb9f4bb.png)

Note that we should still wait for the response from the infra team to confirm that the removal is impossible. This PR is blocked by it.

I manually generated via `jekyll build` and excluded unrelated changes in HTMLs.