### PR TITLE
Remove not working link from third-party projects

### DIFF
--- a/site/news/index.html
+++ b/site/news/index.html
@@ -208,8 +208,9 @@
       <div class="entry-date">January 7, 2021</div>
     </header>
     <div class="entry-content"><p>The next official Spark release is Spark 3.1.1 instead of Spark 3.1.0.
-There was an accident during Spark 3.1.0 RC1 preparation,
-see <a href="http://apache-spark-developers-list.1001551.n3.nabble.com/VOTE-Release-Spark-3-1-0-RC1-td30524.html">[VOTE] Release Spark 3.1.0 (RC1)</a> in the Spark dev mailing list.</p>
+There was a technical issue during Spark 3.1.0 RC1 preparation,
+see <a href="https://www.mail-archive.com/dev@spark.apache.org/msg27133.html">[VOTE] Release Spark 3.1.0 (RC1)</a> in the Spark dev mailing list.</p>
+
 </div>
   </article>
 

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -220,9 +220,7 @@ Apache Spark. You can add a package as long as you have a GitHub repository.</p>
 
 <ul>
   <li><a href="https://github.com/spark-jobserver/spark-jobserver">REST Job Server for Apache Spark</a> - 
-REST interface for managing and submitting Spark jobs on the same cluster 
-(see <a href="http://engineering.ooyala.com/blog/open-sourcing-our-spark-job-server">blog post</a> 
-for details)</li>
+REST interface for managing and submitting Spark jobs on the same cluster.</li>
   <li><a href="http://mlbase.org/">MLbase</a> - Machine Learning research project on top of Spark</li>
   <li><a href="https://mesos.apache.org/">Apache Mesos</a> - Cluster management system that supports 
 running Spark</li>

--- a/third-party-projects.md
+++ b/third-party-projects.md
@@ -26,9 +26,7 @@ Apache Spark. You can add a package as long as you have a GitHub repository.
 <h2>Infrastructure Projects</h2>
 
 - <a href="https://github.com/spark-jobserver/spark-jobserver">REST Job Server for Apache Spark</a> - 
-REST interface for managing and submitting Spark jobs on the same cluster 
-(see <a href="http://engineering.ooyala.com/blog/open-sourcing-our-spark-job-server">blog post</a> 
-for details)
+REST interface for managing and submitting Spark jobs on the same cluster.
 - <a href="http://mlbase.org/">MLbase</a> - Machine Learning research project on top of Spark
 - <a href="https://mesos.apache.org/">Apache Mesos</a> - Cluster management system that supports 
 running Spark


### PR DESCRIPTION
The referenced website with a blog post is not anymore available. Some other blog posts could replace this link, but I think the best solution might be to reference the git project, where the documentation is up to date.
