### PR TITLE
Lock Jekyll version to 3.6.3

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: ".local_ruby_bundle"

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ target/
 .DS_Store
 .jekyll-cache/
 .jekyll-metadata
-Gemfile.lock
+.local_ruby_bundle

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .DS_Store
 .jekyll-cache/
 .jekyll-metadata
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem 'jekyll', '3.6.3'
-gem 'rouge', '2.2.1'
+gem "jekyll", "3.6.3"
+gem "rouge", "2.2.1"

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem 'jekyll', '3.6.3'
+gem 'rouge', '2.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,52 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    colorator (1.1.0)
+    ffi (1.14.2)
+    forwardable-extended (2.6.0)
+    jekyll (3.6.3)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.14)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (>= 1.7, < 3)
+      safe_yaml (~> 1.0)
+    jekyll-sass-converter (1.5.2)
+      sass (~> 3.4)
+    jekyll-watch (1.5.1)
+      listen (~> 3.0)
+    kramdown (1.17.0)
+    liquid (4.0.3)
+    listen (3.4.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.3.6)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (4.0.6)
+    rb-fsevent (0.10.4)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rouge (2.2.1)
+    safe_yaml (1.0.5)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll (= 3.6.3)
+  rouge (= 2.2.1)
+
+BUNDLED WITH
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 In this directory you will find text files formatted using Markdown, with an `.md` suffix.
 
-Building the site requires [Jekyll](http://jekyllrb.com/docs) 3.6.3 and
-[Rouge](https://github.com/rouge-ruby/rouge) 2.2.1 which is specified in the `Gemfile`.
-The easiest way to install the right version of these tools is running `bundle install`
-in this directory.
+Building the site requires [Jekyll](http://jekyllrb.com/docs)
+[Rouge](https://github.com/rouge-ruby/rouge).
+The easiest way to install the right version of these tools is using the
+[Bundler](https://bundler.io/) and running `bundle install` in this directory.
 
 See also https://github.com/apache/spark/blob/master/docs/README.md
 
@@ -20,6 +20,14 @@ the web server on port 4000, then visit the site at http://localhost:4000.
 
 Please make sure you always run `bundle exec jekyll build` after testing your changes with
 `bundle exec jekyll serve`, otherwise you end up with broken links in a few places.
+
+## Updating Jekyll version
+
+To update `Jekyll` or any other gem please follow these steps:
+
+1. Update the version in the `Gemfile`
+1. Run `bundle update` which updates the `Gemfile.lock`
+1. Commit both files
 
 ## Docs sub-dir
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,24 @@
 
 In this directory you will find text files formatted using Markdown, with an `.md` suffix.
 
-Building the site requires [Jekyll](http://jekyllrb.com/docs) 3.3.0 or newer. 
-The easiest way to install jekyll is via a Ruby Gem. This will create a directory called `site` 
-containing `index.html` as well as the rest of the compiled directories and files.
+Building the site requires [Jekyll](http://jekyllrb.com/docs) 3.6.3 and
+[Rouge](https://github.com/rouge-ruby/rouge) 2.2.1 which is specified in the `Gemfile`.
+The easiest way to install the right version of these tools is running `bundle install`
+in this directory.
 
-To install Jekyll and its required dependencies, execute `sudo gem install jekyll rouge`.
 See also https://github.com/apache/spark/blob/master/docs/README.md
 
-You can generate the html website by running `jekyll build` in this directory. Use the `--watch` 
-flag to have jekyll recompile your files as you save changes.
+A site build will update the directories and files in the `site` directory with the generated files.
+Using Jekyll via `bundle exec jekyll` locks it to the right version.
+So after this you can generate the html website by running `bundle exec jekyll build` in this
+directory. Use the `--watch` flag to have jekyll recompile your files as you save changes.
 
-In addition to generating the site as HTML from the markdown files, jekyll can serve the site via 
-a web server. To build the site and run a web server use the command `jekyll serve` which runs 
+In addition to generating the site as HTML from the markdown files, jekyll can serve the site via
+a web server. To build the site and run a web server use the command `bundle exec jekyll serve` which runs
 the web server on port 4000, then visit the site at http://localhost:4000.
 
-Please make sure you always run `jekyll build` after testing your changes with `jekyll serve`,
-otherwise you end up with broken links in a few places.
+Please make sure you always run `bundle exec jekyll build` after testing your changes with
+`bundle exec jekyll serve`, otherwise you end up with broken links in a few places.
 
 ## Docs sub-dir
 

--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,6 @@ kramdown:
   entity_output: symbol
 permalink: none
 destination: site
-exclude: ['README.md','content', 'LICENSE', 'merge_pr.py']
+exclude: ['README.md','content', 'LICENSE', 'merge_pr.py', 'Gemfile', 'Gemfile.lock']
 keep_files: ['docs']
 url: https://spark.apache.org

--- a/release-process.md
+++ b/release-process.md
@@ -229,7 +229,7 @@ spark-website directly, otherwise you need to re-build the docs.
 # Build the latest docs
 $ git checkout v1.1.1
 $ cd docs
-$ PRODUCTION=1 jekyll build
+$ PRODUCTION=1 bundle exec jekyll build
 
 # Copy the new documentation to Apache
 $ git clone https://github.com/apache/spark-website
@@ -262,7 +262,7 @@ pick the release version from the list, then click on "Release Notes". Copy this
 `spark-2.1.2`. Create a new release post under `releases/_posts` to include this short URL. The date of the post should
 be the date you create it.
 
-Then run `jekyll build` to update the `site` directory.
+Then run `bundle exec jekyll build` to update the `site` directory.
 
 After merging the change into the `asf-site` branch, you may need to create a follow-up empty
 commit to force synchronization between ASF's git and the web site, and also the GitHub mirror.
@@ -330,6 +330,6 @@ when the branch is no longer maintained. "2.3.2" will become "2.3.3" when "2.3.3
 
 Once everything is working (website docs, website changes) create an announcement on the website
 and then send an e-mail to the mailing list. To create an announcement, create a post under
-`news/_posts` and then run `jekyll build`.
+`news/_posts` and then run `bundle exec jekyll build`.
 
 Enjoy an adult beverage of your choice, and congratulations on making a Spark release.

--- a/site/community.html
+++ b/site/community.html
@@ -349,7 +349,7 @@ vulnerabilities, and for information on known security issues.</p>
   </li>
   <li>
     <a href="https://www.meetup.com/Boston-Apache-Spark-User-Group/">Boston Spark Meetup</a>
-  </li>
+  </li>  
   <li>
     <a href="https://www.meetup.com/Boulder-Denver-Spark-Meetup/">Boulder/Denver Spark Meetup</a>
   </li>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -421,7 +421,7 @@ spark-website directly, otherwise you need to re-build the docs.</p>
 <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code># Build the latest docs
 $ git checkout v1.1.1
 $ cd docs
-$ PRODUCTION=1 jekyll build
+$ PRODUCTION=1 bundle exec jekyll build
 
 # Copy the new documentation to Apache
 $ git clone https://github.com/apache/spark-website
@@ -455,7 +455,7 @@ pick the release version from the list, then click on &#8220;Release Notes&#8221
 <code class="highlighter-rouge">spark-2.1.2</code>. Create a new release post under <code class="highlighter-rouge">releases/_posts</code> to include this short URL. The date of the post should
 be the date you create it.</p>
 
-<p>Then run <code class="highlighter-rouge">jekyll build</code> to update the <code class="highlighter-rouge">site</code> directory.</p>
+<p>Then run <code class="highlighter-rouge">bundle exec jekyll build</code> to update the <code class="highlighter-rouge">site</code> directory.</p>
 
 <p>After merging the change into the <code class="highlighter-rouge">asf-site</code> branch, you may need to create a follow-up empty
 commit to force synchronization between ASF&#8217;s git and the web site, and also the GitHub mirror.
@@ -521,7 +521,7 @@ when the branch is no longer maintained. &#8220;2.3.2&#8221; will become &#8220;
 
 <p>Once everything is working (website docs, website changes) create an announcement on the website
 and then send an e-mail to the mailing list. To create an announcement, create a post under
-<code class="highlighter-rouge">news/_posts</code> and then run <code class="highlighter-rouge">jekyll build</code>.</p>
+<code class="highlighter-rouge">news/_posts</code> and then run <code class="highlighter-rouge">bundle exec jekyll build</code>.</p>
 
 <p>Enjoy an adult beverage of your choice, and congratulations on making a Spark release.</p>
 

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -852,19 +852,15 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/mllib/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
   <loc>https://spark.apache.org/graphx/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/sql/</loc>
+  <loc>https://spark.apache.org/mllib/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/screencasts/</loc>
+  <loc>https://spark.apache.org/streaming/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
@@ -872,7 +868,11 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/streaming/</loc>
+  <loc>https://spark.apache.org/screencasts/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/sql/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>


### PR DESCRIPTION
Pin Jekyll to version 3.6.3.

As this version is where the diff is minimal, checked by the script:
```
#!/bin/zsh

versions=('3.7.3' '3.7.2' '3.7.0' '3.6.3' '3.6.2' '3.6.1' '3.6.0' '3.5.2'
'3.5.1' '3.5.0' '3.4.5' '3.4.4' '3.4.3' '3.4.2' '3.4.1' '3.4.0')

for i in $versions; do
  gem uninstall -a -x jekyll rouge
  gem install jekyll --version $i
  jekyll build
  git diff --stat
  git reset --hard HEAD
done
```

The first commit contains those minimal changes which was by running `jekyll build` with version 3.6.3:
- reordering in the sitemap.xml
- some extra space at the end of line in community.html

The 2nd commit updates the README.md and introduces the Gemfile to pin Jekyll to 3.6.3.
