### PR TITLE
Add 3.0.2 release note and news and update links

### DIFF
--- a/_layouts/global.html
+++ b/_layouts/global.html
@@ -121,7 +121,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="{{site.baseurl}}/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="{{site.baseurl}}/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="{{site.baseurl}}/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="{{site.baseurl}}/faq.html">Frequently Asked Questions</a></li>
         </ul>

--- a/documentation.md
+++ b/documentation.md
@@ -12,6 +12,7 @@ navigation:
 <p>Setup instructions, programming guides, and other documentation are available for each stable version of Spark below:</p>
 
 <ul>
+  <li><a href="{{site.baseurl}}/docs/3.0.2/">Spark 3.0.2</a></li>
   <li><a href="{{site.baseurl}}/docs/3.0.1/">Spark 3.0.1</a></li>
   <li><a href="{{site.baseurl}}/docs/3.0.0/">Spark 3.0.0</a></li>
   <li><a href="{{site.baseurl}}/docs/2.4.7/">Spark 2.4.7</a></li>

--- a/downloads.md
+++ b/downloads.md
@@ -41,7 +41,7 @@ Spark artifacts are [hosted in Maven Central](https://search.maven.org/search?q=
 
     groupId: org.apache.spark
     artifactId: spark-core_2.12
-    version: 3.0.1
+    version: 3.0.2
 
 ### Installing with PyPi
 <a href="https://pypi.org/project/pyspark/">PySpark</a> is now available in pypi. To install just run `pip install pyspark`.

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -23,7 +23,7 @@ var packagesV9 = [hadoop2p7, hadoop2p6, hadoopFree, scala2p12_hadoopFree, source
 // 3.0.0+
 var packagesV10 = [hadoop2p7, hadoop3p2, hadoopFree, sources];
 
-addRelease("3.0.1", new Date("09/02/2020"), packagesV10, true);
+addRelease("3.0.2", new Date("02/19/2021"), packagesV10, true);
 addRelease("2.4.7", new Date("09/12/2020"), packagesV9, true);
 
 function append(el, contents) {

--- a/news/_posts/2021-02-19-spark-3-0-2-released.md
+++ b/news/_posts/2021-02-19-spark-3-0-2-released.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: Spark 3.0.2 released
+categories:
+- News
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+We are happy to announce the availability of <a href="{{site.baseurl}}/releases/spark-release-3-0-2.html" title="Spark Release 3.0.2">Spark 3.0.2</a>! Visit the <a href="{{site.baseurl}}/releases/spark-release-3-0-2.html" title="Spark Release 3.0.2">release notes</a> to read about the new features, or <a href="{{site.baseurl}}/downloads.html">download</a> the release today.

--- a/releases/_posts/2021-02-19-spark-release-3-0-2.md
+++ b/releases/_posts/2021-02-19-spark-release-3-0-2.md
@@ -1,0 +1,59 @@
+---
+layout: post
+title: Spark Release 3.0.2
+categories: []
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+
+Spark 3.0.2 is a maintenance release containing stability fixes. This release is based on the branch-3.0 maintenance branch of Spark. We strongly recommend all 3.0 users to upgrade to this stable release.
+
+### Notable changes
+
+  - [[SPARK-31511]](https://issues.apache.org/jira/browse/SPARK-31511): Make BytesToBytesMap iterator() thread-safe
+  - [[SPARK-32635]](https://issues.apache.org/jira/browse/SPARK-32635): When pyspark.sql.functions.lit() function is used with dataframe cache, it returns wrong result
+  - [[SPARK-32753]](https://issues.apache.org/jira/browse/SPARK-32753): Deduplicating and repartitioning the same column create duplicate rows with AQE
+  - [[SPARK-32764]](https://issues.apache.org/jira/browse/SPARK-32764): compare of -0.0 < 0.0 return true
+  - [[SPARK-32840]](https://issues.apache.org/jira/browse/SPARK-32840): Invalid interval value can happen to be just adhesive with the unit
+  - [[SPARK-32908]](https://issues.apache.org/jira/browse/SPARK-32908): percentile_approx() returns incorrect results
+  - [[SPARK-33019]](https://issues.apache.org/jira/browse/SPARK-33019): Use spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1 by default
+  - [[SPARK-33183]](https://issues.apache.org/jira/browse/SPARK-33183): Bug in optimizer rule EliminateSorts
+  - [[SPARK-33260]](https://issues.apache.org/jira/browse/SPARK-33260): SortExec produces incorrect results if sortOrder is a Stream
+  - [[SPARK-33290]](https://issues.apache.org/jira/browse/SPARK-33290): SPARK-33507 REFRESH TABLE should invalidate cache even though the table itself may not be cached
+  - [[SPARK-33358]](https://issues.apache.org/jira/browse/SPARK-33358): Spark SQL CLI command processing loop can't exit while one comand fail
+  - [[SPARK-33404]](https://issues.apache.org/jira/browse/SPARK-33404): "date_trunc" expression returns incorrect results
+  - [[SPARK-33435]](https://issues.apache.org/jira/browse/SPARK-33435): SPARK-33507 DSv2: REFRESH TABLE should invalidate caches
+  - [[SPARK-33591]](https://issues.apache.org/jira/browse/SPARK-33591): NULL is recognized as the "null" string in partition specs
+  - [[SPARK-33593]](https://issues.apache.org/jira/browse/SPARK-33593): Vector reader got incorrect data with binary partition value
+  - [[SPARK-33726]](https://issues.apache.org/jira/browse/SPARK-33726): Duplicate field names causes wrong answers during aggregation
+  - [[SPARK-33819]](https://issues.apache.org/jira/browse/SPARK-33819): SingleFileEventLogFileReader/RollingEventLogFilesFileReader should be `package private`
+  - [[SPARK-33950]](https://issues.apache.org/jira/browse/SPARK-33950): ALTER TABLE .. DROP PARTITION doesn't refresh cache
+  - [[SPARK-34011]](https://issues.apache.org/jira/browse/SPARK-34011): ALTER TABLE .. RENAME TO PARTITION doesn't refresh cache
+  - [[SPARK-34027]](https://issues.apache.org/jira/browse/SPARK-34027): ALTER TABLE .. RECOVER PARTITIONS doesn't refresh cache
+  - [[SPARK-34055]](https://issues.apache.org/jira/browse/SPARK-34055): ALTER TABLE .. ADD PARTITION doesn't refresh cache
+  - [[SPARK-34187]](https://issues.apache.org/jira/browse/SPARK-34187): Use available offset range obtained during polling when checking offset validation
+  - [[SPARK-34212]](https://issues.apache.org/jira/browse/SPARK-34212): For parquet table, after changing the precision and scale of decimal type in hive, spark reads incorrect value
+  - [[SPARK-34213]](https://issues.apache.org/jira/browse/SPARK-34213): LOAD DATA doesn't refresh v1 table cache
+  - [[SPARK-34229]](https://issues.apache.org/jira/browse/SPARK-34229): Avro should read decimal values with the file schema
+  - [[SPARK-34262]](https://issues.apache.org/jira/browse/SPARK-34262): ALTER TABLE .. SET LOCATION doesn't refresh v1 table cache
+
+### Dependency Changes
+
+While being a maintence release we did still upgrade some dependencies in this release they are:
+
+  - [[SPARK-32691]](https://issues.apache.org/jira/browse/SPARK-32691): Bump commons-crypto to v1.1.0
+  - [[SPARK-33831]](https://issues.apache.org/jira/browse/SPARK-33831): Update Jetty to 9.4.34
+  - [[SPARK-33725]](https://issues.apache.org/jira/browse/SPARK-33725): Upgrade snappy-java to 1.1.8.2
+  - [[SPARK-33405]](https://issues.apache.org/jira/browse/SPARK-33405): Upgrade commons-compress to 1.20
+
+### Known issues
+  - [[SPARK-34449]](https://issues.apache.org/jira/browse/SPARK-34449): Upgrade Jetty to 9.4.36
+
+You can consult JIRA for the [detailed changes](https://s.apache.org/spark-3.0.2).
+
+We would like to acknowledge all community members for contributing patches to this release.

--- a/site/committers.html
+++ b/site/committers.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/community.html
+++ b/site/community.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
@@ -205,6 +205,7 @@
 <p>Setup instructions, programming guides, and other documentation are available for each stable version of Spark below:</p>
 
 <ul>
+  <li><a href="/docs/3.0.2/">Spark 3.0.2</a></li>
   <li><a href="/docs/3.0.1/">Spark 3.0.1</a></li>
   <li><a href="/docs/3.0.0/">Spark 3.0.0</a></li>
   <li><a href="/docs/2.4.7/">Spark 2.4.7</a></li>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
@@ -241,7 +241,7 @@ The latest preview release is Spark 3.0.0-preview2, published on Dec 23, 2019.</
 
 <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>groupId: org.apache.spark
 artifactId: spark-core_2.12
-version: 3.0.1
+version: 3.0.2
 </code></pre></div></div>
 
 <h3 id="installing-with-pypi">Installing with PyPi</h3>

--- a/site/examples.html
+++ b/site/examples.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/faq.html
+++ b/site/faq.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -109,7 +109,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/history.html
+++ b/site/history.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/index.html
+++ b/site/index.html
@@ -108,7 +108,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -164,6 +164,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -172,9 +175,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -23,7 +23,7 @@ var packagesV9 = [hadoop2p7, hadoop2p6, hadoopFree, scala2p12_hadoopFree, source
 // 3.0.0+
 var packagesV10 = [hadoop2p7, hadoop3p2, hadoopFree, sources];
 
-addRelease("3.0.1", new Date("09/02/2020"), packagesV10, true);
+addRelease("3.0.2", new Date("02/19/2021"), packagesV10, true);
 addRelease("2.4.7", new Date("09/12/2020"), packagesV9, true);
 
 function append(el, contents) {

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -109,7 +109,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -109,7 +109,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
@@ -201,6 +201,15 @@
 
   <div class="col-md-9 col-md-pull-3">
     <h2 id="spark-news">Spark News</h2>
+
+<article class="hentry">
+    <header class="entry-header">
+      <h3 class="entry-title"><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a></h3>
+      <div class="entry-date">February 19, 2021</div>
+    </header>
+    <div class="entry-content"><p>We are happy to announce the availability of <a href="/releases/spark-release-3-0-2.html" title="Spark Release 3.0.2">Spark 3.0.2</a>! Visit the <a href="/releases/spark-release-3-0-2.html" title="Spark Release 3.0.2">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+</div>
+  </article>
 
 <article class="hentry">
     <header class="entry-header">

--- a/site/news/next-official-release-spark-3.1.1.html
+++ b/site/news/next-official-release-spark-3.1.1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/plan-for-dropping-python-2-support.html
+++ b/site/news/plan-for-dropping-python-2-support.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-3-released.html
+++ b/site/news/spark-2-1-3-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-2-released.html
+++ b/site/news/spark-2-2-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-1-released.html
+++ b/site/news/spark-2-3-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-2-released.html
+++ b/site/news/spark-2-3-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-3-released.html
+++ b/site/news/spark-2-3-3-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-4-released.html
+++ b/site/news/spark-2-3-4-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-0-released.html
+++ b/site/news/spark-2-4-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-1-released.html
+++ b/site/news/spark-2-4-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-2-released.html
+++ b/site/news/spark-2-4-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-3-released.html
+++ b/site/news/spark-2-4-3-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-4-released.html
+++ b/site/news/spark-2-4-4-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-5-released.html
+++ b/site/news/spark-2-4-5-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-6.html
+++ b/site/news/spark-2-4-6.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-7-released.html
+++ b/site/news/spark-2-4-7-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-0-released.html
+++ b/site/news/spark-3-0-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-1-released.html
+++ b/site/news/spark-3-0-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-2-released.html
+++ b/site/news/spark-3-0-2-released.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark Release 1.5.1 | Apache Spark
+     Spark 3.0.2 released | Apache Spark
     
   </title>
 
@@ -200,15 +200,10 @@
   </div>
 
   <div class="col-md-9 col-md-pull-3">
-    <h2>Spark Release 1.5.1</h2>
+    <h2>Spark 3.0.2 released</h2>
 
 
-<p>Spark 1.5.1 is a maintenance release containing stability fixes. This release is based on the branch-1.5 maintenance branch of Spark. We strongly recommend all 1.5.0 users to upgrade to this stable release.</p>
-
-<p>You can consult JIRA for the <a href="http://s.apache.org/spark-1.5.1">detailed changes</a>.</p>
-
-<p>We would like to acknowledge the following community members for contributing patches to this release: Ahir Reddy, Akash Mishra, Alexey Grishchenko, Andrew Or, Cheng Hao, Cheng Lian, Daniel Imfeld, Davies Liu, Felix Bechstein, Felix Cheung, Forest Fang, Holden Karau, Hossein Falaki, Iulian Dragos, Jacek Laskowski, Josh Rosen, Josiah Samuel, Justin Uang, Kousuke Saruta, Liang-Chi Hsieh, Luciano Resende, Marcelo Vanzin, Matt Hagen, Michael Armbrust, Mingyu Kim, Navis Ryu, Nick Pritchard, Nithin Asokan, Noel Smith, Pete Robbins, Reynold Xin, Rohit Agarwal, Sean Owen, Sean Paradiso, Shixiong Zhu, Stephen Hopper, Tathagata Das, Tathagata Das, Tom Graves, Weizhong Lin, Wenchen Fan, XuTingjun, Yanbo Liang, Yangping Wu, Yijie Shen, Yin Huai, Zhichao Li.</p>
-
+<p>We are happy to announce the availability of <a href="/releases/spark-release-3-0-2.html" title="Spark Release 3.0.2">Spark 3.0.2</a>! Visit the <a href="/releases/spark-release-3-0-2.html" title="Spark Release 3.0.2">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
 
 
 <p>

--- a/site/news/spark-3.0.0-preview.html
+++ b/site/news/spark-3.0.0-preview.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview2.html
+++ b/site/news/spark-3.0.0-preview2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-apr-2019-agenda-posted.html
+++ b/site/news/spark-ai-summit-apr-2019-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-june-2020-agenda-posted.html
+++ b/site/news/spark-ai-summit-june-2020-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-release-2-2-3.html
+++ b/site/news/spark-release-2-2-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted.html
+++ b/site/news/spark-summit-east-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-oct-2018-agenda-posted.html
+++ b/site/news/spark-summit-oct-2018-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-3.html
+++ b/site/releases/spark-release-2-1-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-2.html
+++ b/site/releases/spark-release-2-2-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-3.html
+++ b/site/releases/spark-release-2-2-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-1.html
+++ b/site/releases/spark-release-2-3-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-2.html
+++ b/site/releases/spark-release-2-3-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-3.html
+++ b/site/releases/spark-release-2-3-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-4.html
+++ b/site/releases/spark-release-2-3-4.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-0.html
+++ b/site/releases/spark-release-2-4-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-1.html
+++ b/site/releases/spark-release-2-4-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-2.html
+++ b/site/releases/spark-release-2-4-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-3.html
+++ b/site/releases/spark-release-2-4-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-4.html
+++ b/site/releases/spark-release-2-4-4.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-5.html
+++ b/site/releases/spark-release-2-4-5.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-6.html
+++ b/site/releases/spark-release-2-4-6.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-7.html
+++ b/site/releases/spark-release-2-4-7.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-0.html
+++ b/site/releases/spark-release-3-0-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-1.html
+++ b/site/releases/spark-release-3-0-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-2.html
+++ b/site/releases/spark-release-3-0-2.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark Release 1.5.1 | Apache Spark
+     Spark Release 3.0.2 | Apache Spark
     
   </title>
 
@@ -200,15 +200,61 @@
   </div>
 
   <div class="col-md-9 col-md-pull-3">
-    <h2>Spark Release 1.5.1</h2>
+    <h2>Spark Release 3.0.2</h2>
 
 
-<p>Spark 1.5.1 is a maintenance release containing stability fixes. This release is based on the branch-1.5 maintenance branch of Spark. We strongly recommend all 1.5.0 users to upgrade to this stable release.</p>
+<p>Spark 3.0.2 is a maintenance release containing stability fixes. This release is based on the branch-3.0 maintenance branch of Spark. We strongly recommend all 3.0 users to upgrade to this stable release.</p>
 
-<p>You can consult JIRA for the <a href="http://s.apache.org/spark-1.5.1">detailed changes</a>.</p>
+<h3 id="notable-changes">Notable changes</h3>
 
-<p>We would like to acknowledge the following community members for contributing patches to this release: Ahir Reddy, Akash Mishra, Alexey Grishchenko, Andrew Or, Cheng Hao, Cheng Lian, Daniel Imfeld, Davies Liu, Felix Bechstein, Felix Cheung, Forest Fang, Holden Karau, Hossein Falaki, Iulian Dragos, Jacek Laskowski, Josh Rosen, Josiah Samuel, Justin Uang, Kousuke Saruta, Liang-Chi Hsieh, Luciano Resende, Marcelo Vanzin, Matt Hagen, Michael Armbrust, Mingyu Kim, Navis Ryu, Nick Pritchard, Nithin Asokan, Noel Smith, Pete Robbins, Reynold Xin, Rohit Agarwal, Sean Owen, Sean Paradiso, Shixiong Zhu, Stephen Hopper, Tathagata Das, Tathagata Das, Tom Graves, Weizhong Lin, Wenchen Fan, XuTingjun, Yanbo Liang, Yangping Wu, Yijie Shen, Yin Huai, Zhichao Li.</p>
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-31511">[SPARK-31511]</a>: Make BytesToBytesMap iterator() thread-safe</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32635">[SPARK-32635]</a>: When pyspark.sql.functions.lit() function is used with dataframe cache, it returns wrong result</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32753">[SPARK-32753]</a>: Deduplicating and repartitioning the same column create duplicate rows with AQE</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32764">[SPARK-32764]</a>: compare of -0.0 &lt; 0.0 return true</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32840">[SPARK-32840]</a>: Invalid interval value can happen to be just adhesive with the unit</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32908">[SPARK-32908]</a>: percentile_approx() returns incorrect results</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33019">[SPARK-33019]</a>: Use spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1 by default</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33183">[SPARK-33183]</a>: Bug in optimizer rule EliminateSorts</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33260">[SPARK-33260]</a>: SortExec produces incorrect results if sortOrder is a Stream</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33290">[SPARK-33290]</a>: SPARK-33507 REFRESH TABLE should invalidate cache even though the table itself may not be cached</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33358">[SPARK-33358]</a>: Spark SQL CLI command processing loop can&#8217;t exit while one comand fail</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33404">[SPARK-33404]</a>: &#8220;date_trunc&#8221; expression returns incorrect results</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33435">[SPARK-33435]</a>: SPARK-33507 DSv2: REFRESH TABLE should invalidate caches</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33591">[SPARK-33591]</a>: NULL is recognized as the &#8220;null&#8221; string in partition specs</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33593">[SPARK-33593]</a>: Vector reader got incorrect data with binary partition value</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33726">[SPARK-33726]</a>: Duplicate field names causes wrong answers during aggregation</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33819">[SPARK-33819]</a>: SingleFileEventLogFileReader/RollingEventLogFilesFileReader should be <code class="highlighter-rouge"><span class="k">package</span> <span class="n">private</span></code></li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33950">[SPARK-33950]</a>: ALTER TABLE .. DROP PARTITION doesn&#8217;t refresh cache</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34011">[SPARK-34011]</a>: ALTER TABLE .. RENAME TO PARTITION doesn&#8217;t refresh cache</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34027">[SPARK-34027]</a>: ALTER TABLE .. RECOVER PARTITIONS doesn&#8217;t refresh cache</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34055">[SPARK-34055]</a>: ALTER TABLE .. ADD PARTITION doesn&#8217;t refresh cache</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34187">[SPARK-34187]</a>: Use available offset range obtained during polling when checking offset validation</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34212">[SPARK-34212]</a>: For parquet table, after changing the precision and scale of decimal type in hive, spark reads incorrect value</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34213">[SPARK-34213]</a>: LOAD DATA doesn&#8217;t refresh v1 table cache</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34229">[SPARK-34229]</a>: Avro should read decimal values with the file schema</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34262">[SPARK-34262]</a>: ALTER TABLE .. SET LOCATION doesn&#8217;t refresh v1 table cache</li>
+</ul>
 
+<h3 id="dependency-changes">Dependency Changes</h3>
+
+<p>While being a maintence release we did still upgrade some dependencies in this release they are:</p>
+
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32691">[SPARK-32691]</a>: Bump commons-crypto to v1.1.0</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33831">[SPARK-33831]</a>: Update Jetty to 9.4.34</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33725">[SPARK-33725]</a>: Upgrade snappy-java to 1.1.8.2</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33405">[SPARK-33405]</a>: Upgrade commons-compress to 1.20</li>
+</ul>
+
+<h3 id="known-issues">Known issues</h3>
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34449">[SPARK-34449]</a>: Upgrade Jetty to 9.4.36</li>
+</ul>
+
+<p>You can consult JIRA for the <a href="https://s.apache.org/spark-3.0.2">detailed changes</a>.</p>
+
+<p>We would like to acknowledge all community members for contributing patches to this release.</p>
 
 
 <p>

--- a/site/research.html
+++ b/site/research.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/security.html
+++ b/site/security.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -139,6 +139,14 @@
 </url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
+  <loc>https://spark.apache.org/releases/spark-release-3-0-2.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/news/spark-3-0-2-released.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/news/next-official-release-spark-3.1.1.html</loc>
   <changefreq>weekly</changefreq>
 </url>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -109,7 +109,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -109,7 +109,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
           <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
           <span class="small">(Jan 07, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
           <span class="small">(Sep 08, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-0-released.html">Spark 3.0.0 released</a>
-          <span class="small">(Jun 18, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>


### PR DESCRIPTION
This PR aims to update our website. I checked the followings are available as of now.
- https://spark.apache.org/docs/3.0.2/
- https://dist.apache.org/repos/dist/release/spark/spark-3.0.2/
- https://repo1.maven.org/maven2/org/apache/spark/spark-core_2.12/3.0.2/
- https://pypi.org/project/pyspark/3.0.2/