### PR TITLE
Add github workflow for checking all doc is generated with the right Jekyll version

### DIFF
--- a/.github/workflows/doc_gen.yml
+++ b/.github/workflows/doc_gen.yml
@@ -1,0 +1,39 @@
+name: Check document generation
+
+on:
+  push:
+    branches:
+    - asf-site
+  pull_request:
+    branches:
+    - asf-site
+
+jobs:
+  lint:
+    name: check wether all documentation was generated with the right Jekyll version
+    runs-on: ubuntu-20.04
+    container:
+      image: dongjoon/apache-spark-github-action-image:20201025
+    steps:
+    - name: Checkout Spark Website repository
+      uses: actions/checkout@v2
+    - name: Install dependencies for documentation generation
+      run: |
+        apt-get update -y
+        apt-get install -y ruby ruby-dev
+        gem install bundler --version 1.17.2
+        bundle install
+    - name: Run documentation build
+      run: |
+        export LC_ALL=C.UTF-8
+        export LANG=C.UTF-8
+        bundle exec jekyll build
+        CHANGED_FILE=( $(git ls-files --modified --other --exclude-standard --directory | grep -v sitemap.xml) )
+        if [ ${#CHANGED_FILE[@]} -ne 0 ]; then
+          echo "Not all documention was generated and/or not the right Jekyll version was used! Modified / untracked files (excluding sitemap.xml):"
+          echo ${CHANGED_FILE[*]}
+          echo "Git diff (excluding sitemap.xml):"
+          git diff -- . ':(exclude)site/sitemap.xml'
+          exit 1
+        fi
+      shell: /bin/bash {0}

--- a/.github/workflows/doc_gen.yml
+++ b/.github/workflows/doc_gen.yml
@@ -30,7 +30,7 @@ jobs:
         bundle exec jekyll build
         CHANGED_FILE=( $(git ls-files --modified --other --exclude-standard --directory | grep -v sitemap.xml) )
         if [ ${#CHANGED_FILE[@]} -ne 0 ]; then
-          echo "Not all documention was generated and/or not the right Jekyll version was used! Modified / untracked files (excluding sitemap.xml):"
+          echo "Not all documentation was generated and/or not the right Jekyll version was used! Modified / untracked files (excluding sitemap.xml):"
           echo ${CHANGED_FILE[*]}
           echo "Git diff (excluding sitemap.xml):"
           git diff -- . ':(exclude)site/sitemap.xml'


### PR DESCRIPTION
After https://github.com/apache/spark-website/commit/1bb4e571b6a575d1be55552569da46e843beccc4 the next logical step is automate the checking of the documentation generation:
- checking whether the generation was complete (contains all the generated HTMLs for the last versions of the markdown files)
- checking whether the right version of Jekyll was used

This can be done with a github workflow by rebuilding the documentation and checking whether there are any unstaged changes.

For testing there is a temporary extra commit which adds a new file and modifies an existing one and committing them without the corresponding HTMLs:

```
$ git show --stat
commit c67186399fa3b444dbdaf0e09226eb954ef1e947 (HEAD -> add-workflow)
Author: attilapiros <piros.attila.zsolt@gmail.com>
Date:   Sat Feb 20 14:21:07 2021 +0100

    temporary commit

 community.md |  2 +-
 new_file.md  | 10 ++++++++++
 2 files changed, 11 insertions(+), 1 deletion(-)
```