### PR TITLE
Support Ruby 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,3 +19,5 @@ source "https://rubygems.org"
 
 gem "jekyll", "4.2.0"
 gem "rouge", "3.26.0"
+
+gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.7.0)
+    webrick (1.7.0)
 
 PLATFORMS
   ruby
@@ -63,6 +64,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (= 4.2.0)
   rouge (= 3.26.0)
+  webrick (~> 1.7)
 
 BUNDLED WITH
    1.17.2


### PR DESCRIPTION
This adds webrick as gem to support Ruby 3.

To the generated documents it has no effect.

The corresponding issue is https://github.com/jekyll/jekyll/issues/8523.