### PR TITLE
[SPARK-34539][DOC] Cleanup Zinc description in developer-tools

### DIFF
--- a/developer-tools.md
+++ b/developer-tools.md
@@ -34,20 +34,6 @@ $ ./bin/spark-shell
 $ build/sbt ~compile
 ```
 
-<h4>Maven: Speeding up Compilation with Zinc</h4>
-
-[Zinc](https://github.com/typesafehub/zinc) is a long-running server version of SBT's incremental
-compiler. When run locally as a background process, it speeds up builds of Scala-based projects
-like Spark. Developers who regularly recompile Spark with Maven will be the most interested in
-Zinc. The project site gives instructions for building and running `zinc`; OS X users can
-install it using `brew install zinc`.
-
-If using the `build/mvn` package `zinc` will automatically be downloaded and leveraged for all
-builds. This process will auto-start after the first time `build/mvn` is called and bind to port
-3030 unless the `ZINC_PORT` environment variable is set. The `zinc` process can subsequently be
-shut down at any time by running `build/zinc-<version>/bin/zinc -shutdown` and will automatically
-restart whenever `build/mvn` is called.
-
 <h3>Building submodules individually</h3>
 
 For instance, you can build the Spark Core module using:

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -226,20 +226,6 @@ $ ./bin/spark-shell
 $ build/sbt ~compile
 </code></pre></div></div>
 
-<h4>Maven: Speeding up Compilation with Zinc</h4>
-
-<p><a href="https://github.com/typesafehub/zinc">Zinc</a> is a long-running server version of SBT&#8217;s incremental
-compiler. When run locally as a background process, it speeds up builds of Scala-based projects
-like Spark. Developers who regularly recompile Spark with Maven will be the most interested in
-Zinc. The project site gives instructions for building and running <code class="language-plaintext highlighter-rouge">zinc</code>; OS X users can
-install it using <code class="language-plaintext highlighter-rouge">brew install zinc</code>.</p>
-
-<p>If using the <code class="language-plaintext highlighter-rouge">build/mvn</code> package <code class="language-plaintext highlighter-rouge">zinc</code> will automatically be downloaded and leveraged for all
-builds. This process will auto-start after the first time <code class="language-plaintext highlighter-rouge">build/mvn</code> is called and bind to port
-3030 unless the <code class="language-plaintext highlighter-rouge">ZINC_PORT</code> environment variable is set. The <code class="language-plaintext highlighter-rouge">zinc</code> process can subsequently be
-shut down at any time by running <code class="language-plaintext highlighter-rouge">build/zinc-&lt;version&gt;/bin/zinc -shutdown</code> and will automatically
-restart whenever <code class="language-plaintext highlighter-rouge">build/mvn</code> is called.</p>
-
 <h3>Building submodules individually</h3>
 
 <p>For instance, you can build the Spark Core module using:</p>


### PR DESCRIPTION
Since Spark 3.0.0 with scala-maven-plugin v4.x, if using `build/mvn`, by default, the Zinc incremental compiler is enabled by maven plugin `scala-maven-plugin`, it will call directly with embedded Zinc APIs to speed up your compilation.

There is no longer something developers need to care about, so this patch we cleanup all Zinc related description.

Releted: https://github.com/apache/spark/pull/31647