### PR TITLE
[SPARK-34539][DOC] Cleanup Zinc security issue

### DIFF
--- a/security.md
+++ b/security.md
@@ -135,38 +135,6 @@ Credit:
 - Andre Protas, Apple Information Security
 
 
-<h3 id="CVE-2018-11804">CVE-2018-11804: Apache Spark build/mvn runs zinc, and can expose information from build machines</h3>
-
-Severity: Low
-
-Vendor: The Apache Software Foundation
-
-Versions Affected
-
-- 1.3.x release branch and later
-
-Description:
-
-Spark's Apache Maven-based build includes a convenience script, 'build/mvn',
-that downloads and runs a zinc server to speed up compilation. This server
-will accept connections from external hosts by default. A specially-crafted
-request to the zinc server could cause it to reveal information in files
-readable to the developer account running the build. Note that this issue
-does not affect end users of Spark, only developers building Spark from
-source code.
-
-Mitigation:
-
-- Spark users are not affected, as zinc is only a part of the build process.
-- Spark developers may simply use a local Maven installation's 'mvn' command to build, and avoid running build/mvn and zinc.
-- Spark developers building actively-developed branches (2.2.x, 2.3.x, 2.4.x, master) may update their branches to receive mitigations already patched onto the build/mvn script
-- Spark developers running zinc separately may include "-server 127.0.0.1" in its command line, and consider additional flags like "-idle-timeout 30m" to achieve similar mitigation.
-
-Credit:
-
-- Andre Protas, Apple Information Security
-
-
 <h3 id="CVE-2018-11770">CVE-2018-11770: Apache Spark standalone master, Mesos REST APIs not controlled by authentication</h3>
 
 Severity: Medium

--- a/site/security.html
+++ b/site/security.html
@@ -343,43 +343,6 @@ and related security properties described at https://spark.apache.org/docs/lates
   <li>Andre Protas, Apple Information Security</li>
 </ul>
 
-<h3 id="CVE-2018-11804">CVE-2018-11804: Apache Spark build/mvn runs zinc, and can expose information from build machines</h3>
-
-<p>Severity: Low</p>
-
-<p>Vendor: The Apache Software Foundation</p>
-
-<p>Versions Affected</p>
-
-<ul>
-  <li>1.3.x release branch and later</li>
-</ul>
-
-<p>Description:</p>
-
-<p>Spark&#8217;s Apache Maven-based build includes a convenience script, &#8216;build/mvn&#8217;,
-that downloads and runs a zinc server to speed up compilation. This server
-will accept connections from external hosts by default. A specially-crafted
-request to the zinc server could cause it to reveal information in files
-readable to the developer account running the build. Note that this issue
-does not affect end users of Spark, only developers building Spark from
-source code.</p>
-
-<p>Mitigation:</p>
-
-<ul>
-  <li>Spark users are not affected, as zinc is only a part of the build process.</li>
-  <li>Spark developers may simply use a local Maven installation&#8217;s &#8216;mvn&#8217; command to build, and avoid running build/mvn and zinc.</li>
-  <li>Spark developers building actively-developed branches (2.2.x, 2.3.x, 2.4.x, master) may update their branches to receive mitigations already patched onto the build/mvn script</li>
-  <li>Spark developers running zinc separately may include &#8220;-server 127.0.0.1&#8221; in its command line, and consider additional flags like &#8220;-idle-timeout 30m&#8221; to achieve similar mitigation.</li>
-</ul>
-
-<p>Credit:</p>
-
-<ul>
-  <li>Andre Protas, Apple Information Security</li>
-</ul>
-
 <h3 id="CVE-2018-11770">CVE-2018-11770: Apache Spark standalone master, Mesos REST APIs not controlled by authentication</h3>
 
 <p>Severity: Medium</p>


### PR DESCRIPTION
Zinc Server realted code has been cleanup [1], this patch
removes the Zinc Server related security issue.

[1] https://github.com/apache/spark/pull/31647
