### PR TITLE
Add a SQL Metrics section to the sql documentation.

### DIFF
--- a/site/docs/3.0.2/monitoring.html
+++ b/site/docs/3.0.2/monitoring.html
@@ -1141,6 +1141,8 @@ parameter <code class="highlighter-rouge">spark.metrics.conf.[component_name].so
 JVM source is the only available optional source. For example the following configuration parameter
 activates the JVM source:
 <code class="highlighter-rouge">"spark.metrics.conf.*.source.jvm.class"="org.apache.spark.metrics.source.JvmSource"</code></p>
+<br /><br />
+Please refer to <a href="sql-metrics.html">SQL Metrics</a> for some notes on Metrics available in Spark SQL.
 
 <h2 id="list-of-available-metrics-providers">List of available metrics providers</h2>
 

--- a/site/docs/3.0.2/sql-data-sources-avro.html
+++ b/site/docs/3.0.2/sql-data-sources-avro.html
@@ -293,8 +293,18 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+
+            SQL Metrics
+
+        </a>
+    </li>
+
+
 
     <li>
         <a href="sql-ref.html">

--- a/site/docs/3.0.2/sql-data-sources-binaryFile.html
+++ b/site/docs/3.0.2/sql-data-sources-binaryFile.html
@@ -293,8 +293,18 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+
+            SQL Metrics
+
+        </a>
+    </li>
+
+
 
     <li>
         <a href="sql-ref.html">

--- a/site/docs/3.0.2/sql-data-sources-generic-options.html
+++ b/site/docs/3.0.2/sql-data-sources-generic-options.html
@@ -293,8 +293,16 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+
+            SQL Metrics
+
+        </a>
+    </li>
 
     <li>
         <a href="sql-ref.html">

--- a/site/docs/3.0.2/sql-data-sources-hive-tables.html
+++ b/site/docs/3.0.2/sql-data-sources-hive-tables.html
@@ -293,8 +293,18 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+
+            SQL Metrics
+
+        </a>
+    </li>
+
+
 
     <li>
         <a href="sql-ref.html">

--- a/site/docs/3.0.2/sql-data-sources-jdbc.html
+++ b/site/docs/3.0.2/sql-data-sources-jdbc.html
@@ -293,8 +293,18 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+
+            SQL Metrics
+
+        </a>
+    </li>
+
+
 
     <li>
         <a href="sql-ref.html">

--- a/site/docs/3.0.2/sql-data-sources-json.html
+++ b/site/docs/3.0.2/sql-data-sources-json.html
@@ -293,8 +293,18 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+
+            SQL Metrics
+
+        </a>
+    </li>
+
+
 
     <li>
         <a href="sql-ref.html">

--- a/site/docs/3.0.2/sql-data-sources-load-save-functions.html
+++ b/site/docs/3.0.2/sql-data-sources-load-save-functions.html
@@ -293,8 +293,18 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+
+            SQL Metrics
+
+        </a>
+    </li>
+
+
 
     <li>
         <a href="sql-ref.html">

--- a/site/docs/3.0.2/sql-data-sources-orc.html
+++ b/site/docs/3.0.2/sql-data-sources-orc.html
@@ -293,8 +293,18 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+
+            SQL Metrics
+
+        </a>
+    </li>
+
+
 
     <li>
         <a href="sql-ref.html">

--- a/site/docs/3.0.2/sql-data-sources-parquet.html
+++ b/site/docs/3.0.2/sql-data-sources-parquet.html
@@ -293,8 +293,18 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+
+            SQL Metrics
+
+        </a>
+    </li>
+
+
 
     <li>
         <a href="sql-ref.html">

--- a/site/docs/3.0.2/sql-data-sources-troubleshooting.html
+++ b/site/docs/3.0.2/sql-data-sources-troubleshooting.html
@@ -293,8 +293,18 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+
+            SQL Metrics
+
+        </a>
+    </li>
+
+
 
     <li>
         <a href="sql-ref.html">

--- a/site/docs/3.0.2/sql-data-sources.html
+++ b/site/docs/3.0.2/sql-data-sources.html
@@ -283,8 +283,8 @@
             
         </a>
     </li>
-    
-    
+
+
 
     <li>
         <a href="sql-migration-old.html">
@@ -293,8 +293,18 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+
+            SQL Metrics
+
+        </a>
+    </li>
+
+
 
     <li>
         <a href="sql-ref.html">

--- a/site/docs/3.0.2/sql-distributed-sql-engine.html
+++ b/site/docs/3.0.2/sql-distributed-sql-engine.html
@@ -203,7 +203,7 @@
             
         </a>
     </li>
-    
+
     
 
     <li>
@@ -213,8 +213,18 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+
+            SQL Metrics
+
+        </a>
+    </li>
+
+
 
     <li>
         <a href="sql-ref.html">

--- a/site/docs/3.0.2/sql-getting-started.html
+++ b/site/docs/3.0.2/sql-getting-started.html
@@ -274,7 +274,7 @@
         </a>
     </li>
     
-    
+
 
     <li>
         <a href="sql-migration-old.html">
@@ -283,8 +283,18 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+
+            SQL Metrics
+
+        </a>
+    </li>
+
+
 
     <li>
         <a href="sql-ref.html">

--- a/site/docs/3.0.2/sql-metrics.html
+++ b/site/docs/3.0.2/sql-metrics.html
@@ -1,0 +1,273 @@
+
+<!DOCTYPE html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title>SQL Metrics</title>
+
+
+
+
+  <link rel="stylesheet" href="css/bootstrap.min.css">
+  <style>
+            body {
+                padding-top: 60px;
+                padding-bottom: 40px;
+            }
+        </style>
+  <meta name="viewport" content="width=device-width">
+  <link rel="stylesheet" href="css/bootstrap-responsive.min.css">
+  <link rel="stylesheet" href="css/main.css">
+
+  <script src="js/vendor/modernizr-2.6.1-respond-1.1.0.min.js"></script>
+
+  <link rel="stylesheet" href="css/pygments-default.css">
+
+
+  <!-- Google analytics script -->
+  <script type="text/javascript">
+          var _gaq = _gaq || [];
+          _gaq.push(['_setAccount', 'UA-32518208-2']);
+          _gaq.push(['_trackPageview']);
+
+          (function() {
+            var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+            ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+            var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+          })();
+        </script>
+
+
+</head>
+<body>
+<!--[if lt IE 7]>
+<p class="chromeframe">You are using an outdated browser. <a href="https://browsehappy.com/">Upgrade your browser today</a> or <a href="http://www.google.com/chromeframe/?redirect=true">install Google Chrome Frame</a> to better experience this site.</p>
+<![endif]-->
+
+<!-- This code is taken from http://twitter.github.com/bootstrap/examples/hero.html -->
+
+<div class="navbar navbar-fixed-top" id="topbar">
+  <div class="navbar-inner">
+    <div class="container">
+      <div class="brand"><a href="index.html">
+        <img src="img/spark-logo-hd.png" style="height:50px;"/></a><span class="version">3.0.2</span>
+      </div>
+      <ul class="nav">
+        <!--TODO(andyk): Add class="active" attribute to li some how.-->
+        <li><a href="index.html">Overview</a></li>
+
+        <li class="dropdown">
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown">Programming Guides<b class="caret"></b></a>
+          <ul class="dropdown-menu">
+            <li><a href="quick-start.html">Quick Start</a></li>
+            <li><a href="rdd-programming-guide.html">RDDs, Accumulators, Broadcasts Vars</a></li>
+            <li><a href="sql-programming-guide.html">SQL, DataFrames, and Datasets</a></li>
+            <li><a href="structured-streaming-programming-guide.html">Structured Streaming</a></li>
+            <li><a href="streaming-programming-guide.html">Spark Streaming (DStreams)</a></li>
+            <li><a href="ml-guide.html">MLlib (Machine Learning)</a></li>
+            <li><a href="graphx-programming-guide.html">GraphX (Graph Processing)</a></li>
+            <li><a href="sparkr.html">SparkR (R on Spark)</a></li>
+          </ul>
+        </li>
+
+        <li class="dropdown">
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown">API Docs<b class="caret"></b></a>
+          <ul class="dropdown-menu">
+            <li><a href="api/scala/org/apache/spark/index.html">Scala</a></li>
+            <li><a href="api/java/index.html">Java</a></li>
+            <li><a href="api/python/index.html">Python</a></li>
+            <li><a href="api/R/index.html">R</a></li>
+            <li><a href="api/sql/index.html">SQL, Built-in Functions</a></li>
+          </ul>
+        </li>
+
+        <li class="dropdown">
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown">Deploying<b class="caret"></b></a>
+          <ul class="dropdown-menu">
+            <li><a href="cluster-overview.html">Overview</a></li>
+            <li><a href="submitting-applications.html">Submitting Applications</a></li>
+            <li class="divider"></li>
+            <li><a href="spark-standalone.html">Spark Standalone</a></li>
+            <li><a href="running-on-mesos.html">Mesos</a></li>
+            <li><a href="running-on-yarn.html">YARN</a></li>
+            <li><a href="running-on-kubernetes.html">Kubernetes</a></li>
+          </ul>
+        </li>
+
+        <li class="dropdown">
+          <a href="api.html" class="dropdown-toggle" data-toggle="dropdown">More<b class="caret"></b></a>
+          <ul class="dropdown-menu">
+            <li><a href="configuration.html">Configuration</a></li>
+            <li><a href="monitoring.html">Monitoring</a></li>
+            <li><a href="tuning.html">Tuning Guide</a></li>
+            <li><a href="job-scheduling.html">Job Scheduling</a></li>
+            <li><a href="security.html">Security</a></li>
+            <li><a href="hardware-provisioning.html">Hardware Provisioning</a></li>
+            <li><a href="migration-guide.html">Migration Guide</a></li>
+            <li class="divider"></li>
+            <li><a href="building-spark.html">Building Spark</a></li>
+            <li><a href="https://spark.apache.org/contributing.html">Contributing to Spark</a></li>
+            <li><a href="https://spark.apache.org/third-party-projects.html">Third Party Projects</a></li>
+          </ul>
+        </li>
+      </ul>
+      <!--<p class="navbar-text pull-right"><span class="version-text">v3.0.2</span></p>-->
+    </div>
+  </div>
+</div>
+
+<div class="container-wrapper">
+
+
+
+  <div class="left-menu-wrapper">
+    <div class="left-menu">
+      <h3><a href="sql-programming-guide.html">Spark SQL Guide</a></h3>
+
+      <ul>
+
+        <li>
+          <a href="sql-getting-started.html">
+
+            Getting Started
+
+          </a>
+        </li>
+
+
+
+        <li>
+          <a href="sql-data-sources.html">
+
+            Data Sources
+
+          </a>
+        </li>
+
+
+
+        <li>
+          <a href="sql-performance-tuning.html">
+
+            Performance Tuning
+
+          </a>
+        </li>
+
+
+
+        <li>
+          <a href="sql-distributed-sql-engine.html">
+
+            Distributed SQL Engine
+
+          </a>
+        </li>
+
+
+
+        <li>
+          <a href="sql-pyspark-pandas-with-arrow.html">
+
+            PySpark Usage Guide for Pandas with Apache Arrow
+
+          </a>
+        </li>
+
+
+
+        <li>
+          <a href="sql-migration-old.html">
+
+            Migration Guide
+
+          </a>
+        </li>
+
+
+
+        <li>
+          <a href="sql-metrics.html">
+            <b>
+
+              SQL Metrics
+
+            </b>
+          </a>
+        </li>
+
+
+
+        <li>
+          <a href="sql-ref.html">
+
+            SQL Reference
+
+          </a>
+        </li>
+
+
+
+      </ul>
+
+    </div>
+  </div>
+
+  <input id="nav-trigger" class="nav-trigger" checked type="checkbox">
+  <label for="nav-trigger"></label>
+  <div class="content-with-sidebar" id="content">
+
+    <h1 class="title">SQL Metrics</h1>
+    <h2>Number of output rows</h2>
+    <p>This metric represents the number of rows that are outputted by each operator.
+      This metric can be typically seen for most operators in the Spark UI under the SQL TAB</p>
+    <h2>Number of matched rows</h2>
+    <p>This metric represents the number of rows that matched between the left side and right
+      side of a join. This metric is typically seen for join operators in the Spark UI under the
+      SQL TAB. </p>
+
+  </div>
+
+  <!-- /container -->
+</div>
+
+<script src="js/vendor/jquery-3.4.1.min.js"></script>
+<script src="js/vendor/bootstrap.min.js"></script>
+<script src="js/vendor/anchor.min.js"></script>
+<script src="js/main.js"></script>
+
+<!-- MathJax Section -->
+<script type="text/x-mathjax-config">
+            MathJax.Hub.Config({
+                TeX: { equationNumbers: { autoNumber: "AMS" } }
+            });
+        </script>
+<script>
+            // Note that we load MathJax this way to work with local file (file://), HTTP and HTTPS.
+            // We could use "//cdn.mathjax...", but that won't support "file://".
+            (function(d, script) {
+                script = d.createElement('script');
+                script.type = 'text/javascript';
+                script.async = true;
+                script.onload = function(){
+                    MathJax.Hub.Config({
+                        tex2jax: {
+                            inlineMath: [ ["$", "$"], ["\\\\(","\\\\)"] ],
+                            displayMath: [ ["$$","$$"], ["\\[", "\\]"] ],
+                            processEscapes: true,
+                            skipTags: ['script', 'noscript', 'style', 'textarea', 'pre']
+                        }
+                    });
+                };
+                script.src = ('https:' == document.location.protocol ? 'https://' : 'http://') +
+                    'cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js' +
+                    '?config=TeX-AMS-MML_HTMLorMML';
+                d.getElementsByTagName('head')[0].appendChild(script);
+            }(document));
+        </script>
+</body>
+</html>

--- a/site/docs/3.0.2/sql-migration-guide.html
+++ b/site/docs/3.0.2/sql-migration-guide.html
@@ -177,8 +177,18 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+
+            SQL Metrics
+
+        </a>
+    </li>
+
+
 
     <li>
         <a href="sparkr-migration-guide.html">

--- a/site/docs/3.0.2/sql-migration-old.html
+++ b/site/docs/3.0.2/sql-migration-old.html
@@ -187,8 +187,18 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+
+            SQL Metrics
+
+        </a>
+    </li>
+
+
 
     <li>
         <a href="sql-ref.html">

--- a/site/docs/3.0.2/sql-performance-tuning.html
+++ b/site/docs/3.0.2/sql-performance-tuning.html
@@ -223,8 +223,18 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+
+            SQL Metrics
+
+        </a>
+    </li>
+
+
 
     <li>
         <a href="sql-ref.html">

--- a/site/docs/3.0.2/sql-programming-guide.html
+++ b/site/docs/3.0.2/sql-programming-guide.html
@@ -187,6 +187,16 @@
             
         </a>
     </li>
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+            
+                SQL Metrics
+            
+        </a>
+    </li>
     
     
 

--- a/site/docs/3.0.2/sql-pyspark-pandas-with-arrow.html
+++ b/site/docs/3.0.2/sql-pyspark-pandas-with-arrow.html
@@ -243,8 +243,18 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+            
+                SQL Metrics
+            
+        </a>
+    </li>
+
+
 
     <li>
         <a href="sql-ref.html">

--- a/site/docs/3.0.2/sql-ref.html
+++ b/site/docs/3.0.2/sql-ref.html
@@ -187,8 +187,17 @@
             
         </a>
     </li>
-    
-    
+
+
+
+    <li>
+        <a href="sql-metrics.html">
+
+            SQL Metrics
+        </a>
+    </li>
+
+
 
     <li>
         <a href="sql-ref.html">


### PR DESCRIPTION
This [PR](https://github.com/apache/spark/pull/31477) adds a new metric to the SQL UI named "number of matched rows". During the review process @maropu pointed out that there is no documentation explaining the metrics available in the spark UI and we should probably add that to the spark website so that user can understand what exactly does the metrics mean. This PR is an attempt to add the documentation for the some of the metrics available in the SQL Tab of the Spark UI. There might be more metrics that can be further added to this new section that I added.

![image](https://user-images.githubusercontent.com/9795421/109372039-42ebb500-785c-11eb-8536-47f717aa4a1d.png)

