### PR TITLE
Fix a sbt example for generating dependency graphs

### DIFF
--- a/developer-tools.md
+++ b/developer-tools.md
@@ -374,7 +374,7 @@ $ git checkout origin/pr/112 -b new-branch
 
 ```
 $ # sbt
-$ build/sbt dependency-tree
+$ build/sbt dependencyTree
  
 $ # Maven
 $ build/mvn -DskipTests install

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -547,7 +547,7 @@ $ git checkout origin/pr/112 -b new-branch
 <h3>Generating Dependency Graphs</h3>
 
 <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>$ # sbt
-$ build/sbt dependency-tree
+$ build/sbt dependencyTree
  
 $ # Maven
 $ build/mvn -DskipTests install


### PR DESCRIPTION
This PR intends to fix an error below;
```
$./build/sbt dependency-tree
[error] Not a valid command: dependency-tree
[error] Not a valid project ID: dependency-tree
[error] Expected ':'
[error] Not a valid key: dependency-tree (similar: dependencyTree, dependencyOverrides, sbtDependency)
[error] dependency-tree
[error]                ^
```
