### PR TITLE
Add Spark 3.1.1 release notes, news and etc.

### DIFF
--- a/_layouts/global.html
+++ b/_layouts/global.html
@@ -121,7 +121,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="{{site.baseurl}}/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="{{site.baseurl}}/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="{{site.baseurl}}/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="{{site.baseurl}}/faq.html">Frequently Asked Questions</a></li>
         </ul>

--- a/documentation.md
+++ b/documentation.md
@@ -12,6 +12,7 @@ navigation:
 <p>Setup instructions, programming guides, and other documentation are available for each stable version of Spark below:</p>
 
 <ul>
+  <li><a href="{{site.baseurl}}/docs/3.1.1/">Spark 3.1.1</a></li>
   <li><a href="{{site.baseurl}}/docs/3.0.2/">Spark 3.0.2</a></li>
   <li><a href="{{site.baseurl}}/docs/3.0.1/">Spark 3.0.1</a></li>
   <li><a href="{{site.baseurl}}/docs/3.0.0/">Spark 3.0.0</a></li>

--- a/downloads.md
+++ b/downloads.md
@@ -41,7 +41,7 @@ Spark artifacts are [hosted in Maven Central](https://search.maven.org/search?q=
 
     groupId: org.apache.spark
     artifactId: spark-core_2.12
-    version: 3.0.2
+    version: 3.1.1
 
 ### Installing with PyPi
 <a href="https://pypi.org/project/pyspark/">PySpark</a> is now available in pypi. To install just run `pip install pyspark`.

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -23,6 +23,8 @@ var packagesV9 = [hadoop2p7, hadoop2p6, hadoopFree, scala2p12_hadoopFree, source
 // 3.0.0+
 var packagesV10 = [hadoop2p7, hadoop3p2, hadoopFree, sources];
 
+
+addRelease("3.1.1", new Date("03/02/2021"), packagesV10, true);
 addRelease("3.0.2", new Date("02/19/2021"), packagesV10, true);
 addRelease("2.4.7", new Date("09/12/2020"), packagesV9, true);
 

--- a/news/_posts/2021-03-02-spark-3-1-1-released.md
+++ b/news/_posts/2021-03-02-spark-3-1-1-released.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: Spark 3.1.1 released
+categories:
+- News
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+We are happy to announce the availability of <a href="{{site.baseurl}}/releases/spark-release-3-1-1.html" title="Spark Release 3.1.1">Spark 3.1.1</a>! Visit the <a href="{{site.baseurl}}/releases/spark-release-3-1-1.html" title="Spark Release 3.1.1">release notes</a> to read about the new features, or <a href="{{site.baseurl}}/downloads.html">download</a> the release today.

--- a/releases/_posts/2021-03-02-spark-release-3-1-1.md
+++ b/releases/_posts/2021-03-02-spark-release-3-1-1.md
@@ -1,0 +1,366 @@
+---
+layout: post
+title: Spark Release 3.1.1
+categories: []
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+
+Apache Spark 3.1.1 is the second release of the 3.x line. This release adds Python type annotations and Python dependency management support as part of Project Zen. Other major updates include improved ANSI SQL compliance support, history server support in structured streaming, the general availability (GA) of Kubernetes and node decommissioning in Kubernetes and Standalone. In addition, this release continues to focus on usability, stability, and polish while resolving around 1500 tickets.
+
+To download Apache Spark 3.1.1, visit the [downloads](https://spark.apache.org/downloads.html) page. You can consult JIRA for the [detailed changes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315420&version=12349541). We have curated a list of high level changes here, grouped by major modules.
+
+* This will become a table of contents (this text will be scraped).
+{:toc}
+
+
+### Core, Spark SQL, Structured Streaming
+
+**Highlight**
+
+- Unify create table SQL syntax ([SPARK-31257](https://issues.apache.org/jira/browse/SPARK-31257))
+- Shuffled hash join improvement ([SPARK-32461](https://issues.apache.org/jira/browse/SPARK-32461))
+- Experimental node decommissioning for Kubernates and Standalone ([SPARK-20624](https://issues.apache.org/jira/browse/SPARK-20624))
+- Enhanced subexpression elimination ([SPARK-33092](https://issues.apache.org/jira/browse/SPARK-33092), [SPARK-33337](https://issues.apache.org/jira/browse/SPARK-33337), [SPARK-33427](https://issues.apache.org/jira/browse/SPARK-33427), [SPARK-33540](https://issues.apache.org/jira/browse/SPARK-33540))
+- Kubernetes GA ([SPARK-33005](https://issues.apache.org/jira/browse/SPARK-33005))
+- Use Apache Hadoop 3.2.0 by default ([SPARK-32058](https://issues.apache.org/jira/browse/SPARK-32058), [SPARK-32841](https://issues.apache.org/jira/browse/SPARK-32841))
+
+**ANSI SQL Compatibility Enhancements**
+
+- Support char/varchar data type ([SPARK-33480](https://issues.apache.org/jira/browse/SPARK-33480))
+- ANSI mode: runtime errors instead of returning null ([SPARK-33275](https://issues.apache.org/jira/browse/SPARK-33275))
+- ANSI mode: new explicit cast syntax rules ([SPARK-33354](https://issues.apache.org/jira/browse/SPARK-33354))
+- Add SQL standard command SET TIME ZONE ([SPARK-32272](https://issues.apache.org/jira/browse/SPARK-32272))
+- Unify create table SQL syntax ([SPARK-31257](https://issues.apache.org/jira/browse/SPARK-31257))
+- Unify temp view and permanent view behaviors ([SPARK-33138](https://issues.apache.org/jira/browse/SPARK-33138))
+- Support column list in INSERT statement ([SPARK-32976](https://issues.apache.org/jira/browse/SPARK-32976))
+- Support ANSI nested bracketed comments ([SPARK-28880](https://issues.apache.org/jira/browse/SPARK-28880))
+
+**Performance Enhancements**
+
+- Host-local shuffle data reading without shuffle service ([SPARK-32077](https://issues.apache.org/jira/browse/SPARK-32077))
+- Remove redundant sorts before repartition nodes ([SPARK-32276](https://issues.apache.org/jira/browse/SPARK-32276))
+- Partially push down predicates ([SPARK-32302](https://issues.apache.org/jira/browse/SPARK-32302), [SPARK-32352](https://issues.apache.org/jira/browse/SPARK-32352))
+- Push down filters through expand ([SPARK-33302](https://issues.apache.org/jira/browse/SPARK-33302))
+- Push more possible predicates through Join via CNF conversion ([SPARK-31705](https://issues.apache.org/jira/browse/SPARK-31705))
+- Remove shuffle by preserving output partitioning of broadcast hash join ([SPARK-31869](https://issues.apache.org/jira/browse/SPARK-31869))
+- Remove shuffle by improving reordering join keys ([SPARK-32282](https://issues.apache.org/jira/browse/SPARK-32282))
+- Remove shuffle by normalizing output partitioning and sortorder ([SPARK-33399](https://issues.apache.org/jira/browse/SPARK-33399))
+- Shuffled hash join improvement ([SPARK-32461](https://issues.apache.org/jira/browse/SPARK-32461))
+  - Preserve shuffled hash join build side partitioning ([SPARK-32330](https://issues.apache.org/jira/browse/SPARK-32330))
+  - Preserve hash join (BHJ and SHJ) stream side ordering ([SPARK-32383](https://issues.apache.org/jira/browse/SPARK-32383))
+  - Coalesce bucketed tables for shuffled hash join ([SPARK-32286](https://issues.apache.org/jira/browse/SPARK-32286))
+  - Add code-gen for shuffled hash join ([SPARK-32421](https://issues.apache.org/jira/browse/SPARK-32421))
+  - Support full outer join in shuffled hash join ([SPARK-32399](https://issues.apache.org/jira/browse/SPARK-32399))
+- Support subexpression elimination in project with whole-stage-codegen ([SPARK-33092](https://issues.apache.org/jira/browse/SPARK-33092))
+- Support subexpression elimination in conditional expressions ([SPARK-33337](https://issues.apache.org/jira/browse/SPARK-33337))
+- Support subexpression elimination for interpreted expression evaluation ([SPARK-33427](https://issues.apache.org/jira/browse/SPARK-33427))
+- Support subexpression elimination for interpreted predicate ([SPARK-33540](https://issues.apache.org/jira/browse/SPARK-33540))
+- Other optimizer rules
+  - Rule ExtractSingleColumnNullAwareAntiJoin ([SPARK-32290](https://issues.apache.org/jira/browse/SPARK-32290))
+  - Rule EliminateNullAwareAntiJoin ([SPARK-32573](https://issues.apache.org/jira/browse/SPARK-32573))
+  - Rule EliminateAggregateFilter ([SPARK-32540](https://issues.apache.org/jira/browse/SPARK-32540))
+  - Rule UnwrapCastInBinaryComparison ([SPARK-32858](https://issues.apache.org/jira/browse/SPARK-32858))
+  - Rule DisableUnnecessaryBucketedScan ([SPARK-32859](https://issues.apache.org/jira/browse/SPARK-32859))
+  - Rule CoalesceBucketsInJoin ([SPARK-31350](https://issues.apache.org/jira/browse/SPARK-31350))
+  - Prune unnecessary nested fields from generate without project ([SPARK-29721](https://issues.apache.org/jira/browse/SPARK-29721))
+  - Prune unnecessary nested fields from aggregate and expand ([SPARK-27217](https://issues.apache.org/jira/browse/SPARK-27217))
+  - Prune unnecessary nested fields from repartition-by-expression and join ([SPARK-31736](https://issues.apache.org/jira/browse/SPARK-31736))
+  - Prune unnecessary nested fields over cosmetic variations ([SPARK-32163](https://issues.apache.org/jira/browse/SPARK-32163))
+  - Prune unnecessary nested fields from window and sort ([SPARK-32059](https://issues.apache.org/jira/browse/SPARK-32059))
+  - Optimize size of CreateArray/CreateMap to be the size of its children ([SPARK-33544](https://issues.apache.org/jira/browse/SPARK-33544))
+
+**Extensibility Enhancements**
+
+- Stage Level Resource configuration and Scheduling ([SPARK-27495](https://issues.apache.org/jira/browse/SPARK-27495))
+  - Expose RDD APIs for Stage Level Scheduling ([SPARK-29150](https://issues.apache.org/jira/browse/SPARK-29150))
+  - Merge resource profiles within a stage ([SPARK-29153](https://issues.apache.org/jira/browse/SPARK-29153))
+  - Stage level scheduling support for Kubernetes ([SPARK-33288](https://issues.apache.org/jira/browse/SPARK-33288))
+  - Add UI support for stage level scheduling ([SPARK-29303](https://issues.apache.org/jira/browse/SPARK-29303))
+- Remote storage for persisting shuffle data ([SPARK-25299](https://issues.apache.org/jira/browse/SPARK-25299))
+  - Shuffle writer metadata APIs ([SPARK-31798](https://issues.apache.org/jira/browse/SPARK-31798))
+- Allow to use a custom shuffle manager with external shuffle service ([SPARK-33037](https://issues.apache.org/jira/browse/SPARK-33037))
+- Add SupportsPartitions APIs on DataSourceV2 ([SPARK-31694](https://issues.apache.org/jira/browse/SPARK-31694))
+- Add SupportsMetadataColumns API on DataSourceV2 ([SPARK-31255](https://issues.apache.org/jira/browse/SPARK-31255))
+- Make SQL cache serialization pluggable ([SPARK-32274](https://issues.apache.org/jira/browse/SPARK-32274))
+- Introduce the "purge" option in TableCatalog.dropTable for v2 catalog ([SPARK-33364](https://issues.apache.org/jira/browse/SPARK-33364))
+
+**Connector Enhancements**
+
+- Hive Metastore partition filter pushdown improvement ([SPARK-33537](https://issues.apache.org/jira/browse/SPARK-33537))
+  - Support contains, starts-with and ends-with filters ([SPARK-33458](https://issues.apache.org/jira/browse/SPARK-33458))
+  - Support filter by date type ([SPARK-33477](https://issues.apache.org/jira/browse/SPARK-33477))
+  - Support filter by not-equals ([SPARK-33582](https://issues.apache.org/jira/browse/SPARK-33582))
+- Parquet
+  - Allow complex type in map’s key type in Parquet ([SPARK-32639](https://issues.apache.org/jira/browse/SPARK-32639))
+  - Allow saving/loading INT96 in Parquet without rebasing ([SPARK-33160](https://issues.apache.org/jira/browse/SPARK-33160))
+- ORC
+  - Nested column predicate pushdown for ORC ([SPARK-25557](https://issues.apache.org/jira/browse/SPARK-25557))
+  - Upgrade Apache ORC to 1.5.12 ([SPARK-33050](https://issues.apache.org/jira/browse/SPARK-33050))
+- CSV
+  - Leverage SQL text data source during CSV schema inference ([SPARK-32270](https://issues.apache.org/jira/browse/SPARK-32270))
+- JSON
+  - Support filters pushdown in JSON datasource ([SPARK-30648](https://issues.apache.org/jira/browse/SPARK-30648))
+- JDBC
+  - Implement catalog APIs for JDBC ([SPARK-32375](https://issues.apache.org/jira/browse/SPARK-32375), [SPARK-32579](https://issues.apache.org/jira/browse/SPARK-32579), [SPARK-32402](https://issues.apache.org/jira/browse/SPARK-32402), [SPARK-33130](https://issues.apache.org/jira/browse/SPARK-33130))
+  - Create JDBC authentication provider developer API ([SPARK-32001](https://issues.apache.org/jira/browse/SPARK-32001))
+  - Add JDBC connection provider disable possibility ([SPARK-32047](https://issues.apache.org/jira/browse/SPARK-32047))
+- Avro
+  - Support filters pushdown in Avro datasource ([SPARK-32346](https://issues.apache.org/jira/browse/SPARK-32346))
+
+**Feature Enhancements**
+
+- Node Decommissioning ([SPARK-20624](https://issues.apache.org/jira/browse/SPARK-20624))
+  - Basic framework ([SPARK-20628](https://issues.apache.org/jira/browse/SPARK-20628))
+  - Migrate RDD blocks during decommission([SPARK-20732](https://issues.apache.org/jira/browse/SPARK-20732))
+  - Graceful decommissioning as part of dynamic scaling ([SPARK-31198](https://issues.apache.org/jira/browse/SPARK-31198))
+  - Migrate shuffle blocks during decommission ([SPARK-20629](https://issues.apache.org/jira/browse/SPARK-20629))
+  - Only exit executor when tasks and block migration are finished ([SPARK-31197](https://issues.apache.org/jira/browse/SPARK-31197))
+  - Support fallback storage during decommission ([SPARK-33545](https://issues.apache.org/jira/browse/SPARK-33545))
+- New built-in functions
+  - json_array_length ([SPARK-31008](https://issues.apache.org/jira/browse/SPARK-31008))
+  - json_object_keys ([SPARK-31009](https://issues.apache.org/jira/browse/SPARK-31009))
+  - current_catalog ([SPARK-30352](https://issues.apache.org/jira/browse/SPARK-30352))
+  - timestamp_seconds, timestamp_millis, timestamp_micros ([SPARK-31710](https://issues.apache.org/jira/browse/SPARK-31710))
+  - width_bucket ([SPARK-21117](https://issues.apache.org/jira/browse/SPARK-21117))
+  - regexp_extract_all ([SPARK-24884](https://issues.apache.org/jira/browse/SPARK-24884))
+  - nth_value ([SPARK-27951](https://issues.apache.org/jira/browse/SPARK-27951))
+  - raise_error ([SPARK-32793](https://issues.apache.org/jira/browse/SPARK-32793))
+  - unix_seconds, unix_millis and unix_micros ([SPARK-33627](https://issues.apache.org/jira/browse/SPARK-33627))
+  - date_from_unix_date and unix_date ([SPARK-33646](https://issues.apache.org/jira/browse/SPARK-33646))
+  - current_timezone ([SPARK-33469](https://issues.apache.org/jira/browse/SPARK-33469))
+- EXPLAIN command enhancement ([SPARK-32337](https://issues.apache.org/jira/browse/SPARK-32337), [SPARK-31325](https://issues.apache.org/jira/browse/SPARK-31325))
+- Provide a option to disable user supplied Hints ([SPARK-31875](https://issues.apache.org/jira/browse/SPARK-31875))
+- Support Hive style REPLACE COLUMNS syntax ([SPARK-30613](https://issues.apache.org/jira/browse/SPARK-30613))
+- Support 'LIKE ANY' and 'LIKE ALL' operators ([SPARK-30724](https://issues.apache.org/jira/browse/SPARK-30724))
+- Support unlimited MATCHED and NOT MATCHED in MERGE INTO ([SPARK-32030](https://issues.apache.org/jira/browse/SPARK-32030))
+- Support 'F'-suffixed float literals ([SPARK-32207](https://issues.apache.org/jira/browse/SPARK-32207))
+- Support RESET syntax to reset single configuration ([SPARK-32406](https://issues.apache.org/jira/browse/SPARK-32406))
+- Support filter expression allows simultaneous use of DISTINCT ([SPARK-30276](https://issues.apache.org/jira/browse/SPARK-30276))
+- Support alter table add/drop partition command for DSv2 ([SPARK-32512](https://issues.apache.org/jira/browse/SPARK-32512))
+- Support NOT IN subqueries inside nested OR conditions ([SPARK-25154](https://issues.apache.org/jira/browse/SPARK-25154))
+- Support REFRESH FUNCTION command ([SPARK-31999](https://issues.apache.org/jira/browse/SPARK-31999))
+- Add 'sameSemantics' and 'sementicHash' methods in Dataset ([SPARK-30791](https://issues.apache.org/jira/browse/SPARK-30791))
+- Support composed type of case class in UDF ([SPARK-31826](https://issues.apache.org/jira/browse/SPARK-31826))
+- Support enumeration in encoders ([SPARK-32585](https://issues.apache.org/jira/browse/SPARK-32585))
+- Support nested field APIs withField and dropFields ([SPARK-31317](https://issues.apache.org/jira/browse/SPARK-31317), [SPARK-32511](https://issues.apache.org/jira/browse/SPARK-32511))
+- Support to fill nulls for missing columns in unionByName ([SPARK-29358](https://issues.apache.org/jira/browse/SPARK-29358))
+- Support DataFrameReader.table to take the specified options ([SPARK-32592](https://issues.apache.org/jira/browse/SPARK-32592), [SPARK-32844](https://issues.apache.org/jira/browse/SPARK-32844))
+- Support HDFS location in `spark.sql.hive.metastore.jars` ([SPARK-32852](https://issues.apache.org/jira/browse/SPARK-32852))
+- Support --archives option natively ([SPARK-33530](https://issues.apache.org/jira/browse/SPARK-33530), [SPARK-33615](https://issues.apache.org/jira/browse/SPARK-33615))
+- Enhance ExecutorPlugin API to include methods for task start and end events ([SPARK-33088](https://issues.apache.org/jira/browse/SPARK-33088))
+
+**Other Notable Changes**
+
+- Provide Search Function in Spark docs site ([SPARK-33166](https://issues.apache.org/jira/browse/SPARK-33166))
+- Use Apache Hadoop 3.2.0 by default ([SPARK-32058](https://issues.apache.org/jira/browse/SPARK-32058), [SPARK-32841](https://issues.apache.org/jira/browse/SPARK-32841))
+- Upgrade Apache Arrow to 2.0.0 ([SPARK-33213](https://issues.apache.org/jira/browse/SPARK-33213))
+- Kubernetes GA ([SPARK-33005](https://issues.apache.org/jira/browse/SPARK-33005))
+  - Adds support for Kubernetes NFS volume mounts ([SPARK-31394](https://issues.apache.org/jira/browse/SPARK-31394))
+  - Support dynamic PVC creation/deletion ([SPARK-32971](https://issues.apache.org/jira/browse/SPARK-32971), [SPARK-32997](https://issues.apache.org/jira/browse/SPARK-32997))
+  - Respect environment variables and configurations for Python executables ([SPARK-33748](https://issues.apache.org/jira/browse/SPARK-33748))
+  - Support Python dependency ([SPARK-27936](https://issues.apache.org/jira/browse/SPARK-33748))
+  - Make pod allocation executor timeouts configurable and allow scheduling with pending pods ([SPARK-33231](https://issues.apache.org/jira/browse/SPARK-33231), [SPARK-33262](https://issues.apache.org/jira/browse/SPARK-33262))
+  - Respect executor idle timeout conf in ExecutorPodsAllocator ([SPARK-33099](https://issues.apache.org/jira/browse/SPARK-33099))
+  - Support JDBC Kerberos with keytab ([SPARK-12312](https://issues.apache.org/jira/browse/SPARK-12312))
+- Enable Java 8 time API in thrift server ([SPARK-31910](https://issues.apache.org/jira/browse/SPARK-31910))
+- Enable Java 8 time API in UDFs ([SPARK-32154](https://issues.apache.org/jira/browse/SPARK-32154))
+- Overflow check for aggregate sum with decimals ([SPARK-28067](https://issues.apache.org/jira/browse/SPARK-28067))
+- Fix commit collision in dynamic partition overwrite mode ([SPARK-27194](https://issues.apache.org/jira/browse/SPARK-27194), [SPARK-29302](https://issues.apache.org/jira/browse/SPARK-29302))
+- Removed references to slave, blacklist and whitelist ([SPARK-32004](https://issues.apache.org/jira/browse/SPARK-32004), [SPARK-32036](https://issues.apache.org/jira/browse/SPARK-32036), [SPARK-32037](https://issues.apache.org/jira/browse/SPARK-32037))
+- Remove task result size check for shuffle map stage ([SPARK-32470](https://issues.apache.org/jira/browse/SPARK-32470))
+- Generalize ExecutorSource to expose user-given file system schemes ([SPARK-33476](https://issues.apache.org/jira/browse/SPARK-33476))
+- Add StorageLevel.DISK_ONLY_3 ([SPARK-32517](https://issues.apache.org/jira/browse/SPARK-32517))
+- Expose executor memory metrics in the web UI for executors ([SPARK-23432](https://issues.apache.org/jira/browse/SPARK-23432))
+- Expose executor memory metrics at the stage level, in the Stages tab ([SPARK-26341](https://issues.apache.org/jira/browse/SPARK-26341))
+- Fix explicitly set of `spark.ui.port` in YARN cluster mode ([SPARK-29465](https://issues.apache.org/jira/browse/SPARK-29465))
+- Add `spark.submit.waitForCompletion` configuration to control spark-submit exit in Standalone cluster mode ([SPARK-31486](https://issues.apache.org/jira/browse/SPARK-31486))
+- Do not propagate Hadoop’s classpath for Spark distribution with built-in Hadoop ([SPARK-31960](https://issues.apache.org/jira/browse/SPARK-31960))
+- Fix jobs disappear intermittently in SHS under high load ([SPARK-33841](https://issues.apache.org/jira/browse/SPARK-33841))
+- Redact sensitive attributes of application log in SHS ([SPARK-33504](https://issues.apache.org/jira/browse/SPARK-33504))
+- Set up yarn.Client to print direct links to driver stdout/stderr ([SPARK-33185](https://issues.apache.org/jira/browse/SPARK-33185))
+- Fix memory leak when fail to store pieces of broadcast ([SPARK-32715](https://issues.apache.org/jira/browse/SPARK-32715))
+- Make BlockManagerMaster driver heartbeat timeout configurable ([SPARK-34278](https://issues.apache.org/jira/browse/SPARK-34278))
+- Unify and complete cache behaviors ([SPARK-33507](https://issues.apache.org/jira/browse/SPARK-33507))
+
+**Changes of behavior**
+
+Please read the migration guides for each component: [Spark Core](https://spark.apache.org/docs/3.1.1/core-migration-guide.html) and [Spark SQL](https://spark.apache.org/docs/3.1.1/sql-migration-guide.html).
+
+*Programming guides: [Spark RDD Programming Guide](https://spark.apache.org/docs/3.1.1/rdd-programming-guide.html) and [Spark SQL, DataFrames and Datasets Guide](https://spark.apache.org/docs/3.1.1/sql-programming-guide.html).*
+
+
+### PySpark
+
+**Project Zen**
+
+- Project Zen: Improving Python usability ([SPARK-32082](https://issues.apache.org/jira/browse/SPARK-32082))
+- PySpark type hints support ([SPARK-32681](https://issues.apache.org/jira/browse/SPARK-32681))
+- Redesign PySpark documentation ([SPARK-31851](https://issues.apache.org/jira/browse/SPARK-31851))
+- Migrate to NumPy documentation style ([SPARK-32085](https://issues.apache.org/jira/browse/SPARK-32085))
+- Installation option for PyPI Users ([SPARK-32017](https://issues.apache.org/jira/browse/SPARK-32017))
+- Un-deprecate inferring DataFrame schema from list of dict ([SPARK-32686](https://issues.apache.org/jira/browse/SPARK-32686))
+- Simplify the exception message from Python UDFs ([SPARK-33407](https://issues.apache.org/jira/browse/SPARK-33407))
+
+**Other Notable Changes**
+
+- Stage Level Scheduling APIs ([SPARK-29641](https://issues.apache.org/jira/browse/SPARK-29641))
+- Deduplicate deterministic PythonUDF calls ([SPARK-33303](https://issues.apache.org/jira/browse/SPARK-33303))
+- Support higher order functions in PySpark functions([SPARK-30681](https://issues.apache.org/jira/browse/SPARK-30681))
+- Support data source v2x write APIs ([SPARK-29157](https://issues.apache.org/jira/browse/SPARK-29157))
+- Support percentile_approx in PySpark functions([SPARK-30569](https://issues.apache.org/jira/browse/SPARK-30569))
+- Support inputFiles in PySpark DataFrame ([SPARK-31763](https://issues.apache.org/jira/browse/SPARK-31763))
+- Support withField in PySpark Column ([SPARK-32835](https://issues.apache.org/jira/browse/SPARK-32835))
+- Support dropFields in PySpark Column ([SPARK-32511](https://issues.apache.org/jira/browse/SPARK-32511))
+- Support nth_value in PySpark functions ([SPARK-33020](https://issues.apache.org/jira/browse/SPARK-33020))
+- Support acosh, asinh and atanh ([SPARK-33563](https://issues.apache.org/jira/browse/SPARK-33563))
+- Support getCheckpointDir method in PySpark SparkContext ([SPARK-33017](https://issues.apache.org/jira/browse/SPARK-33017))
+- Support to fill nulls for missing columns in unionByName ([SPARK-32798](https://issues.apache.org/jira/browse/SPARK-32798))
+- Update cloudpickle to v1.5.0 ([SPARK-32094](https://issues.apache.org/jira/browse/SPARK-32094))
+- Add MapType support for PySpark with Arrow ([SPARK-24554](https://issues.apache.org/jira/browse/SPARK-33748))
+- DataStreamReader.table and DataStreamWriter.toTable ([SPARK-33836](https://issues.apache.org/jira/browse/SPARK-33836))
+
+**Changes of behavior**
+
+Please read the migration guides for [PySpark](https://spark.apache.org/docs/3.1.1/api/python/migration_guide/index.html).
+
+*Programming guides: [PySpark Getting Started](https://spark.apache.org/docs/3.1.1/api/python/getting_started/index.html) and [PySpark User Guide](https://spark.apache.org/docs/3.1.1/api/python/user_guide/index.html).*
+
+
+### Structured Streaming
+
+**Performance Enhancements**
+
+- Cache fetched list of files beyond maxFilesPerTrigger as unread file ([SPARK-30866](https://issues.apache.org/jira/browse/SPARK-30866))
+- Streamline the logic on file stream source and sink metadata log ([SPARK-30462](https://issues.apache.org/jira/browse/SPARK-30462))
+- Avoid reading compact metadata log twice if the query restarts from compact batch ([SPARK-30900](https://issues.apache.org/jira/browse/SPARK-30900))
+
+**Feature Enhancements**
+
+- Add DataStreamReader.table API ([SPARK-32885](https://issues.apache.org/jira/browse/SPARK-32885))
+- Add DataStreamWriter.toTable API ([SPARK-32896](https://issues.apache.org/jira/browse/SPARK-32896))
+- Left semi stream-stream join ([SPARK-32862](https://issues.apache.org/jira/browse/SPARK-32862))
+- Full outer stream-stream join ([SPARK-32863](https://issues.apache.org/jira/browse/SPARK-32863))
+- Provide a new option to have retention on output files ([SPARK-27188](https://issues.apache.org/jira/browse/SPARK-27188))
+- Add Spark Structured Streaming History Server Support ([SPARK-31953](https://issues.apache.org/jira/browse/SPARK-31953))
+- Introduce State schema validation among query restart ([SPARK-27237](https://issues.apache.org/jira/browse/SPARK-27237))
+
+**Other Notable Changes**
+
+- Introduce schema validation for streaming state store ([SPARK-31894](https://issues.apache.org/jira/browse/SPARK-31894))
+- Support to use a different compression codec in state store ([SPARK-33263](https://issues.apache.org/jira/browse/SPARK-33263))
+- Kafka connector infinite wait because metadata never updated ([SPARK-28367](https://issues.apache.org/jira/browse/SPARK-28367))
+- Upgrade Kafka to 2.6.0 ([SPARK-32568](https://issues.apache.org/jira/browse/SPARK-32568))
+- Pagination support for Structured Streaming UI pages ([SPARK-31642](https://issues.apache.org/jira/browse/SPARK-31642), [SPARK-30119](https://issues.apache.org/jira/browse/SPARK-30119))
+- State information in Structured Streaming UI ([SPARK-33223](https://issues.apache.org/jira/browse/SPARK-33223))
+- Watermark gap information in Structured Streaming UI ([SPARK-33224](https://issues.apache.org/jira/browse/SPARK-33224))
+- Expose state custom metrics information on SS UI ([SPARK-33287](https://issues.apache.org/jira/browse/SPARK-33287))
+- Add a new metric regarding number of rows later than watermark ([SPARK-24634](https://issues.apache.org/jira/browse/SPARK-24634))
+
+**Changes of behavior**
+
+Please read the migration guides for [Structured Streaming](https://spark.apache.org/docs/3.1.1/ss-migration-guide.html).
+
+*Programming guides: [Structured Streaming Programming Guide](https://spark.apache.org/docs/3.1.1/structured-streaming-programming-guide.html).*
+
+
+### MLlib
+
+**Highlight**
+
+- LinearSVC blockify input vectors ([SPARK-30642](https://issues.apache.org/jira/browse/SPARK-30642))
+- LogisticRegression blockify input vectors ([SPARK-30659](https://issues.apache.org/jira/browse/SPARK-30659))
+- LinearRegression blockify input vectors ([SPARK-30660](https://issues.apache.org/jira/browse/SPARK-30660))
+- AFT blockify input vectors ([SPARK-31656](https://issues.apache.org/jira/browse/SPARK-31656))
+- Add support for association rules in ML ([SPARK-19939](https://issues.apache.org/jira/browse/SPARK-19939))
+- Add training summary for LinearSVCModel ([SPARK-20249](https://issues.apache.org/jira/browse/SPARK-20249))
+- Add summary to RandomForestClassificationModel ([SPARK-23631](https://issues.apache.org/jira/browse/SPARK-23631))
+- Add training summary to FMClassificationModel ([SPARK-32140](https://issues.apache.org/jira/browse/SPARK-32140))
+- Add summary to MultilayerPerceptronClassificationModel ([SPARK-32449](https://issues.apache.org/jira/browse/SPARK-32449))
+- Add FMClassifier to SparkR ([SPARK-30820](https://issues.apache.org/jira/browse/SPARK-30820))
+- Add SparkR LinearRegression wrapper ([SPARK-30818](https://issues.apache.org/jira/browse/SPARK-30818))
+- Add FMRegressor wrapper to SparkR ([SPARK-30819](https://issues.apache.org/jira/browse/SPARK-30819))
+- Add SparkR wrapper for vector_to_array ([SPARK-33040](https://issues.apache.org/jira/browse/SPARK-33040))
+- adaptively blockify instances - LinearSVC ([SPARK-32907](https://issues.apache.org/jira/browse/SPARK-32907))
+- make CrossValidator/TrainValidateSplit/OneVsRest Reader/Writer support Python backend estimator/evaluator ([SPARK-33520](https://issues.apache.org/jira/browse/SPARK-33520))
+- Improve performance of ML ALS recommendForAll by GEMV ([SPARK-33518](https://issues.apache.org/jira/browse/SPARK-33520))
+- Add UnivariateFeatureSelector ([SPARK-34080](https://issues.apache.org/jira/browse/SPARK-34080))
+
+**Other Notable Changes**
+
+- GMM compute summary and update distributions in one job ([SPARK-31032](https://issues.apache.org/jira/browse/SPARK-31032))
+- Remove ChiSqSelector dependency on mllib.ChiSqSelectorModel ([SPARK-31077](https://issues.apache.org/jira/browse/SPARK-31077))
+- Flatten the result dataframe of tests in testChiSquare ([SPARK-31301](https://issues.apache.org/jira/browse/SPARK-31301))
+- MinHash keyDistance optimization ([SPARK-31436](https://issues.apache.org/jira/browse/SPARK-31436))
+- KMeans optimization based on triangle-inequality ([SPARK-31007](https://issues.apache.org/jira/browse/SPARK-31007))
+- Add weight support in ClusteringEvaluator ([SPARK-31734](https://issues.apache.org/jira/browse/SPARK-31734))
+- Add getMetrics in Evaluators ([SPARK-31768](https://issues.apache.org/jira/browse/SPARK-31768))
+- Add instance weight support in LinearRegressionSummary ([SPARK-31944](https://issues.apache.org/jira/browse/SPARK-31944))
+- Add user-specified fold column to CrossValidator ([SPARK-31777](https://issues.apache.org/jira/browse/SPARK-31777))
+- ML params default value parity in feature and tuning ([SPARK-32310](https://issues.apache.org/jira/browse/SPARK-32310))
+- Fix double caching in KMeans/BiKMeans ([SPARK-32676](https://issues.apache.org/jira/browse/SPARK-32676))
+- aft transform optimization ([SPARK-33111](https://issues.apache.org/jira/browse/SPARK-33111))
+- FeatureHasher transform optimization ([SPARK-32974](https://issues.apache.org/jira/browse/SPARK-32974))
+- Add array_to_vector function for dataframe column ([SPARK-33556](https://issues.apache.org/jira/browse/SPARK-33556))
+- ML params default value parity in classification, regression, clustering and fpm ([SPARK-32310](https://issues.apache.org/jira/browse/SPARK-32310))
+- Summary.totalIterations greater than maxIters ([SPARK-31925](https://issues.apache.org/jira/browse/SPARK-31925))
+- tree models prediction optimization ([SPARK-32298](https://issues.apache.org/jira/browse/SPARK-32298))
+
+**Changes of behavior**
+
+Please read the migration guides for [MLlib](https://spark.apache.org/docs/3.1.1/ml-migration-guide.html).
+
+*Programming guide: [Machine Learning Library (MLlib) Guide](https://spark.apache.org/docs/3.1.1/ml-guide.html).*
+
+
+### SparkR
+
+- Add SparkR interface for higher order functions ([SPARK-30682](https://issues.apache.org/jira/browse/SPARK-30682))
+- Support to fill nulls for missing columns in unionByName ([SPARK-32798](https://issues.apache.org/jira/browse/SPARK-32798))
+- Support withColumn in SparkR functions ([SPARK-32946](https://issues.apache.org/jira/browse/SPARK-32946))
+- Support timestamp_seconds in SparkR functions ([SPARK-32949](https://issues.apache.org/jira/browse/SPARK-32949))
+- Support nth_value in SparkR functions ([SPARK-33030](https://issues.apache.org/jira/browse/SPARK-33030))
+- Minimum Arrow version bumped up to 1.0.0 ([SPARK-32452](https://issues.apache.org/jira/browse/SPARK-32452))
+- Support array_to_vector in SparkR functions ([SPARK-33622](https://issues.apache.org/jira/browse/SPARK-33622))
+- Support acosh, asinh and atanh ([SPARK-33563](https://issues.apache.org/jira/browse/SPARK-33563))
+- Support from_avro and to_avro ([SPARK-33304](https://issues.apache.org/jira/browse/SPARK-33304))
+
+**Changes of behavior**
+
+Please read the [migration guide](https://spark.apache.org/docs/3.1.1/sparkr-migration-guide.html) for details.
+
+*Programming guide: [SparkR (R on Spark)](https://spark.apache.org/docs/3.1.1/sparkr.html).*
+
+
+### GraphX
+
+*Programming guide: [GraphX Programming Guide](https://spark.apache.org/docs/3.1.1/graphx-programming-guide.html).*
+
+
+### Deprecations and Removals
+
+- Drop Python 2.7, 3.4 and 3.5 ([SPARK-32138](https://issues.apache.org/jira/browse/SPARK-32138))
+- Drop R &lt; 3.5 support ([SPARK-32073](https://issues.apache.org/jira/browse/SPARK-32073))
+- Remove hive-1.2 distribution ([SPARK-32981](https://issues.apache.org/jira/browse/SPARK-32981))
+- Remove references to org.spark-project.hive ([SPARK-20202](https://issues.apache.org/jira/browse/SPARK-20202))
+- Deprecate support of multiple workers on the same host in Standalone ([SPARK-31018](https://issues.apache.org/jira/browse/SPARK-31018))
+
+
+## Known Issues
+
+- [[SPARK-33392](https://issues.apache.org/jira/browse/SPARK-34543)] Respect case sensitivity in V1 ALTER TABLE .. SET LOCATION
+- [[SPARK-34531](https://issues.apache.org/jira/browse/SPARK-34531)] Remove Experimental API tag in PrometheusServlet
+- [[SPARK-34515](https://issues.apache.org/jira/browse/SPARK-34515)] Fix NPE if InSet contains null value during getPartitionsByFilter
+- [[SPARK-34497](https://issues.apache.org/jira/browse/SPARK-34497)] JDBC connection provider is not removing kerberos credentials from JVM security context
+- [[SPARK-34490](https://issues.apache.org/jira/browse/SPARK-34490)] table maybe resolved as a view if the table is dropped
+- [[SPARK-34473](https://issues.apache.org/jira/browse/SPARK-34473)] avoid NPE in DataFrameReader.schema(StructType)
+- [[SPARK-34436](https://issues.apache.org/jira/browse/SPARK-34436)] DPP support LIKE ANY/ALL
+
+## Credits
+
+Last but not least, this release would not have been possible without the following contributors: Abhishek Dixit, Adam Binford, Ajith S, Akshat Bordia, Alessandro Patti, Alex Favaro, Ali Afroozeh, Ali Smesseim, Allison Wang, Ankit Srivastava, Anton Okolnychyi, Antonin Delpeuch, Artsiom Yudovin, Arwin Tio, Attila Zsolt Piros, Baohe Zhang, Bo Yang, Bo Zhang, Brandon Jiang, Bruce Robbins, Bryan Cutler, CC Highman, Chandni Singh, Chao Sun, Chen Zhang, Cheng Su, Chuliang Xiao, DB Tsai, Dale Clarke, Daniel Himmelstein, Daniel Moore, David Toneian, Denis Pyshev, Devesh Agrawal, Dilip Biswal, Dmitry Sabanin, Dongjoon Hyun, Du Ripeng, Emilian Bold, Eren Avsarogullari, Eric Lemmon, Eric Wu, Erik Krogen, Fabian Höring, Farhan Khan, Farooq Qaiser, Fei Wang, Fokko Driesprong, Frank Yin, Fuwang Hu, Gabor Somogyi, Gengliang Wang, Gera Shegalov, German Schiavon Matteo, Goki Mori, Guangxin Wang, Gustavo Martin Morcuende, Herman Van Hovell, Holden Karau, Huang Yi, Haejoon Lee, Huaxin Gao, Hyukjin Kwon, Izek Greenfield, Jackey Lee, Jacob Kim, Jalpan Randeri, Jatin Puri, Jiaan Geng, Jinxin Tang, Josh Soref, Jonathan Lafleche, Jungtaek Lim, Karen Feng, Karol Chmist, Kaxil Naik, Kazuaki Ishizaki, Ke Jia, Keiji Yoshida, Kent Yao, Kevin Su, Kevin Wang, Koert Kuipers, Kousuke Saruta, Kyle Bendickson, Lantao Jin, Leanken Lin, Liang Zhang, Liang-Chi Hsieh, Linhong Liu, Lipeng Zhu, Lu Lu, Luca Canali, Maciej Szymkiewicz, Manu Zhang, Marcelo Vanzin, Maryann Xue, Matthew Cheah, Maxim Gekk, Michael Chirico, Michael Munday, Michał Wieleba, Min Shen, Nan Zhu, Nicholas Chammas, Nicholas Marcott, Nik Vanderhoof, Onur Satici, Pablo Langa, Pascal Gillet, Paul Reidy, Pavithra Ramachandran, Pedro Rossi, Peter Toth, Philipse Guo, Piotr Grzegorski, Prakhar Jain, Prashant Sharma, Qianyang Yu, Qilong Su, Rajat Ahuja, Rakesh Raushan, Rameshkrishnan Muthusamy, Raphael Auv, Richard Penney, Robert (Bobby) Evans, Rohit Mishra,Ruifeng Zheng, Ryan Blue, Ryotaro Tsuzuki, Samir Khan, Samuel Souza, Sandeep Katta, Sander Goos, Saurabh Chawla, Sean Owen, Seongjin Cho, Shane Knapp, Shanyu Zhao, Shaoyun Chen, Shixiong Zhu, Shruti Gumma, Srinivas Rishindra Pothireddi, Stavros Kontopoulos, StefanXiepj, Stijn De Haes, Stuart White, Sudharshann D, Sunitha Kambhampati, Takeshi Yamamuro, Takuya UESHIN, Tanel Kiis, Tathagata Das, Terry Kim, Thomas Graves, Tianshi Zhu, Tom Howland, Tom Van Bussel, Udbhav Agrawal, Uncle Gen, Utkarsh Agarwal, Venkata Krishnan Sowrirajan, Vlad Glinsky, Warren Zhu, Weichen Xu, Wenchen Fan, William Hyun, Wing Yew Poon, Xianyin Xin, Xiao Li, Xiduo You, Xingbo Jiang, Xinrong Meng, Xinyi Yu, Xuedong Luan, Yang Jie, Yaroslav Tkachenko, Ye Zhou, Yi Wu, Yi Zhu, Yu Zhong, Yuanjian Li, Yuexin Zhang, Yuming Wang, Yuning Zhang, Zhen Li, Zhenhua Wang, Zhicheng Jin, Zirui Xu, Zuo Dao, akiyamaneko, artiship, cristichircu, dzlab, huangtianhua, liucht-inspur, manubatham20, waitinfuture, wang-zhun, yzjg

--- a/site/committers.html
+++ b/site/committers.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/community.html
+++ b/site/community.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
@@ -205,6 +205,7 @@
 <p>Setup instructions, programming guides, and other documentation are available for each stable version of Spark below:</p>
 
 <ul>
+  <li><a href="/docs/3.1.1/">Spark 3.1.1</a></li>
   <li><a href="/docs/3.0.2/">Spark 3.0.2</a></li>
   <li><a href="/docs/3.0.1/">Spark 3.0.1</a></li>
   <li><a href="/docs/3.0.0/">Spark 3.0.0</a></li>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
@@ -241,7 +241,7 @@ The latest preview release is Spark 3.0.0-preview2, published on Dec 23, 2019.</
 
 <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>groupId: org.apache.spark
 artifactId: spark-core_2.12
-version: 3.0.2
+version: 3.1.1
 </code></pre></div></div>
 
 <h3 id="installing-with-pypi">Installing with PyPi</h3>

--- a/site/examples.html
+++ b/site/examples.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/faq.html
+++ b/site/faq.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -109,7 +109,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/history.html
+++ b/site/history.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/index.html
+++ b/site/index.html
@@ -108,7 +108,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -164,6 +164,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -172,9 +175,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -23,6 +23,8 @@ var packagesV9 = [hadoop2p7, hadoop2p6, hadoopFree, scala2p12_hadoopFree, source
 // 3.0.0+
 var packagesV10 = [hadoop2p7, hadoop3p2, hadoopFree, sources];
 
+
+addRelease("3.1.1", new Date("03/02/2021"), packagesV10, true);
 addRelease("3.0.2", new Date("02/19/2021"), packagesV10, true);
 addRelease("2.4.7", new Date("09/12/2020"), packagesV9, true);
 

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -109,7 +109,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -109,7 +109,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
@@ -201,6 +201,15 @@
 
   <div class="col-md-9 col-md-pull-3">
     <h2 id="spark-news">Spark News</h2>
+
+<article class="hentry">
+    <header class="entry-header">
+      <h3 class="entry-title"><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a></h3>
+      <div class="entry-date">March 2, 2021</div>
+    </header>
+    <div class="entry-content"><p>We are happy to announce the availability of <a href="/releases/spark-release-3-1-1.html" title="Spark Release 3.1.1">Spark 3.1.1</a>! Visit the <a href="/releases/spark-release-3-1-1.html" title="Spark Release 3.1.1">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+</div>
+  </article>
 
 <article class="hentry">
     <header class="entry-header">

--- a/site/news/next-official-release-spark-3.1.1.html
+++ b/site/news/next-official-release-spark-3.1.1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/plan-for-dropping-python-2-support.html
+++ b/site/news/plan-for-dropping-python-2-support.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-3-released.html
+++ b/site/news/spark-2-1-3-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-2-released.html
+++ b/site/news/spark-2-2-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-1-released.html
+++ b/site/news/spark-2-3-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-2-released.html
+++ b/site/news/spark-2-3-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-3-released.html
+++ b/site/news/spark-2-3-3-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-4-released.html
+++ b/site/news/spark-2-3-4-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-0-released.html
+++ b/site/news/spark-2-4-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-1-released.html
+++ b/site/news/spark-2-4-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-2-released.html
+++ b/site/news/spark-2-4-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-3-released.html
+++ b/site/news/spark-2-4-3-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-4-released.html
+++ b/site/news/spark-2-4-4-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-5-released.html
+++ b/site/news/spark-2-4-5-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-6.html
+++ b/site/news/spark-2-4-6.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-7-released.html
+++ b/site/news/spark-2-4-7-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-0-released.html
+++ b/site/news/spark-3-0-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-1-released.html
+++ b/site/news/spark-3-0-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-2-released.html
+++ b/site/news/spark-3-0-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-1-released.html
+++ b/site/news/spark-3-1-1-released.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark 0.8.1 released | Apache Spark
+     Spark 3.1.1 released | Apache Spark
     
   </title>
 
@@ -200,10 +200,10 @@
   </div>
 
   <div class="col-md-9 col-md-pull-3">
-    <h2>Spark 0.8.1 released</h2>
+    <h2>Spark 3.1.1 released</h2>
 
 
-<p>We&#8217;ve just posted <a href="/releases/spark-release-0-8-1.html" title="Spark Release 0.8.1">Spark Release 0.8.1</a>, a maintenance and performance release for the Scala 2.9 version of Spark. 0.8.1 includes support for YARN 2.2, a high availability mode for the standalone scheduler, optimizations to the shuffle, and many other improvements. We recommend that all users update to this release. Visit the <a href="/releases/spark-release-0-8-1.html" title="Spark Release 0.8.1">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+<p>We are happy to announce the availability of <a href="/releases/spark-release-3-1-1.html" title="Spark Release 3.1.1">Spark 3.1.1</a>! Visit the <a href="/releases/spark-release-3-1-1.html" title="Spark Release 3.1.1">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
 
 
 <p>

--- a/site/news/spark-3.0.0-preview.html
+++ b/site/news/spark-3.0.0-preview.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview2.html
+++ b/site/news/spark-3.0.0-preview2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-apr-2019-agenda-posted.html
+++ b/site/news/spark-ai-summit-apr-2019-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-june-2020-agenda-posted.html
+++ b/site/news/spark-ai-summit-june-2020-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-release-2-2-3.html
+++ b/site/news/spark-release-2-2-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2015.html
+++ b/site/news/spark-summit-east-agenda-posted-2015.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2016.html
+++ b/site/news/spark-summit-east-agenda-posted-2016.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-oct-2018-agenda-posted.html
+++ b/site/news/spark-summit-oct-2018-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-3.html
+++ b/site/releases/spark-release-2-1-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-2.html
+++ b/site/releases/spark-release-2-2-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-3.html
+++ b/site/releases/spark-release-2-2-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-1.html
+++ b/site/releases/spark-release-2-3-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-2.html
+++ b/site/releases/spark-release-2-3-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-3.html
+++ b/site/releases/spark-release-2-3-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-4.html
+++ b/site/releases/spark-release-2-3-4.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-0.html
+++ b/site/releases/spark-release-2-4-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-1.html
+++ b/site/releases/spark-release-2-4-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-2.html
+++ b/site/releases/spark-release-2-4-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-3.html
+++ b/site/releases/spark-release-2-4-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-4.html
+++ b/site/releases/spark-release-2-4-4.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-5.html
+++ b/site/releases/spark-release-2-4-5.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-6.html
+++ b/site/releases/spark-release-2-4-6.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-7.html
+++ b/site/releases/spark-release-2-4-7.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-0.html
+++ b/site/releases/spark-release-3-0-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-1.html
+++ b/site/releases/spark-release-3-0-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-2.html
+++ b/site/releases/spark-release-3-0-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-1.html
+++ b/site/releases/spark-release-3-1-1.html
@@ -1,0 +1,661 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>
+     Spark Release 3.1.1 | Apache Spark
+    
+  </title>
+
+  
+
+  
+
+  <!-- Bootstrap core CSS -->
+  <link href="/css/cerulean.min.css" rel="stylesheet">
+  <link href="/css/custom.css" rel="stylesheet">
+
+  <!-- Code highlighter CSS -->
+  <link href="/css/pygments-default.css" rel="stylesheet">
+
+  <script type="text/javascript">
+  <!-- Google Analytics initialization -->
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-32518208-2']);
+  _gaq.push(['_trackPageview']);
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+
+  <!-- Adds slight delay to links to allow async reporting -->
+  function trackOutboundLink(link, category, action) {
+    try {
+      _gaq.push(['_trackEvent', category , action]);
+    } catch(err){}
+
+    setTimeout(function() {
+      document.location.href = link.href;
+    }, 100);
+  }
+  </script>
+
+  <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+  <!--[if lt IE 9]>
+  <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+  <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+  <![endif]-->
+</head>
+
+<body>
+
+<script src="https://code.jquery.com/jquery.js"></script>
+<script src="https://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
+<script src="/js/lang-tabs.js"></script>
+<script src="/js/downloads.js"></script>
+
+<div class="container" style="max-width: 1200px;">
+
+<div class="masthead">
+  
+    <p class="lead">
+      <a href="/">
+      <img src="/images/spark-logo-trademark.png"
+        style="height:100px; width:auto; vertical-align: bottom; margin-top: 20px;"></a><span class="tagline">
+          Lightning-fast unified analytics engine
+      </span>
+    </p>
+  
+</div>
+
+<nav class="navbar navbar-default" role="navigation">
+  <!-- Brand and toggle get grouped for better mobile display -->
+  <div class="navbar-header">
+    <button type="button" class="navbar-toggle" data-toggle="collapse"
+            data-target="#navbar-collapse-1">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+  </div>
+
+  <!-- Collect the nav links, forms, and other content for toggling -->
+  <div class="collapse navbar-collapse" id="navbar-collapse-1">
+    <ul class="nav navbar-nav">
+      <li><a href="/downloads.html">Download</a></li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Libraries <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/sql/">SQL and DataFrames</a></li>
+          <li><a href="/streaming/">Spark Streaming</a></li>
+          <li><a href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a href="/graphx/">GraphX (graph)</a></li>
+          <li class="divider"></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
+        </ul>
+      </li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Documentation <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
+          <li><a href="/faq.html">Frequently Asked Questions</a></li>
+        </ul>
+      </li>
+      <li><a href="/examples.html">Examples</a></li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Community <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/community.html">Mailing Lists &amp; Resources</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="/improvement-proposals.html">Improvement Proposals (SPIP)</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
+        </ul>
+      </li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+           Developers <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/developer-tools.html">Useful Developer Tools</a></li>
+          <li><a href="/versioning-policy.html">Versioning Policy</a></li>
+          <li><a href="/release-process.html">Release Process</a></li>
+          <li><a href="/security.html">Security</a></li>
+        </ul>
+      </li>
+    </ul>
+    <ul class="nav navbar-nav navbar-right">
+      <li class="dropdown">
+        <a href="https://www.apache.org/" class="dropdown-toggle" data-toggle="dropdown">
+          Apache Software Foundation <b class="caret"></b></a>
+        <ul class="dropdown-menu">
+          <li><a href="https://www.apache.org/">Apache Homepage</a></li>
+          <li><a href="https://www.apache.org/licenses/">License</a></li>
+          <li><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+          <li><a href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
+          <li><a href="https://www.apache.org/security/">Security</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <!-- /.navbar-collapse -->
+</nav>
+
+
+<div class="row">
+  <div class="col-md-3 col-md-push-9">
+    <div class="news" style="margin-bottom: 20px;">
+      <h5>Latest News</h5>
+      <ul class="list-unstyled">
+        
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
+          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
+          <span class="small">(Feb 19, 2021)</span></li>
+        
+          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
+          <span class="small">(Jan 07, 2021)</span></li>
+        
+          <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
+          <span class="small">(Sep 12, 2020)</span></li>
+        
+      </ul>
+      <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
+    </div>
+    <div style="text-align:center; margin-bottom: 20px;">
+      <a href="https://www.apache.org/events/current-event.html">
+        <img src="https://www.apache.org/events/current-event-234x60.png"/>
+      </a>
+    </div>
+    <div class="hidden-xs hidden-sm">
+      <a href="/downloads.html" class="btn btn-success btn-lg btn-block" style="margin-bottom: 30px;">
+        Download Spark
+      </a>
+      <p style="font-size: 16px; font-weight: 500; color: #555;">
+        Built-in Libraries:
+      </p>
+      <ul class="list-none">
+        <li><a href="/sql/">SQL and DataFrames</a></li>
+        <li><a href="/streaming/">Spark Streaming</a></li>
+        <li><a href="/mllib/">MLlib (machine learning)</a></li>
+        <li><a href="/graphx/">GraphX (graph)</a></li>
+      </ul>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
+    </div>
+  </div>
+
+  <div class="col-md-9 col-md-pull-3">
+    <h2>Spark Release 3.1.1</h2>
+
+
+<p>Apache Spark 3.1.1 is the second release of the 3.x line. This release adds Python type annotations and Python dependency management support as part of Project Zen. Other major updates include improved ANSI SQL compliance support, history server support in structured streaming, the general availability (GA) of Kubernetes and node decommissioning in Kubernetes and Standalone. In addition, this release continues to focus on usability, stability, and polish while resolving around 1500 tickets.</p>
+
+<p>To download Apache Spark 3.1.1, visit the <a href="https://spark.apache.org/downloads.html">downloads</a> page. You can consult JIRA for the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315420&amp;version=12349541">detailed changes</a>. We have curated a list of high level changes here, grouped by major modules.</p>
+
+<ul id="markdown-toc">
+  <li><a href="#core-spark-sql-structured-streaming" id="markdown-toc-core-spark-sql-structured-streaming">Core, Spark SQL, Structured Streaming</a></li>
+  <li><a href="#pyspark" id="markdown-toc-pyspark">PySpark</a></li>
+  <li><a href="#structured-streaming" id="markdown-toc-structured-streaming">Structured Streaming</a></li>
+  <li><a href="#mllib" id="markdown-toc-mllib">MLlib</a></li>
+  <li><a href="#sparkr" id="markdown-toc-sparkr">SparkR</a></li>
+  <li><a href="#graphx" id="markdown-toc-graphx">GraphX</a></li>
+  <li><a href="#deprecations-and-removals" id="markdown-toc-deprecations-and-removals">Deprecations and Removals</a></li>
+  <li><a href="#known-issues" id="markdown-toc-known-issues">Known Issues</a></li>
+  <li><a href="#credits" id="markdown-toc-credits">Credits</a></li>
+</ul>
+
+<h3 id="core-spark-sql-structured-streaming">Core, Spark SQL, Structured Streaming</h3>
+
+<p><strong>Highlight</strong></p>
+
+<ul>
+  <li>Unify create table SQL syntax (<a href="https://issues.apache.org/jira/browse/SPARK-31257">SPARK-31257</a>)</li>
+  <li>Shuffled hash join improvement (<a href="https://issues.apache.org/jira/browse/SPARK-32461">SPARK-32461</a>)</li>
+  <li>Experimental node decommissioning for Kubernates and Standalone (<a href="https://issues.apache.org/jira/browse/SPARK-20624">SPARK-20624</a>)</li>
+  <li>Enhanced subexpression elimination (<a href="https://issues.apache.org/jira/browse/SPARK-33092">SPARK-33092</a>, <a href="https://issues.apache.org/jira/browse/SPARK-33337">SPARK-33337</a>, <a href="https://issues.apache.org/jira/browse/SPARK-33427">SPARK-33427</a>, <a href="https://issues.apache.org/jira/browse/SPARK-33540">SPARK-33540</a>)</li>
+  <li>Kubernetes GA (<a href="https://issues.apache.org/jira/browse/SPARK-33005">SPARK-33005</a>)</li>
+  <li>Use Apache Hadoop 3.2.0 by default (<a href="https://issues.apache.org/jira/browse/SPARK-32058">SPARK-32058</a>, <a href="https://issues.apache.org/jira/browse/SPARK-32841">SPARK-32841</a>)</li>
+</ul>
+
+<p><strong>ANSI SQL Compatibility Enhancements</strong></p>
+
+<ul>
+  <li>Support char/varchar data type (<a href="https://issues.apache.org/jira/browse/SPARK-33480">SPARK-33480</a>)</li>
+  <li>ANSI mode: runtime errors instead of returning null (<a href="https://issues.apache.org/jira/browse/SPARK-33275">SPARK-33275</a>)</li>
+  <li>ANSI mode: new explicit cast syntax rules (<a href="https://issues.apache.org/jira/browse/SPARK-33354">SPARK-33354</a>)</li>
+  <li>Add SQL standard command SET TIME ZONE (<a href="https://issues.apache.org/jira/browse/SPARK-32272">SPARK-32272</a>)</li>
+  <li>Unify create table SQL syntax (<a href="https://issues.apache.org/jira/browse/SPARK-31257">SPARK-31257</a>)</li>
+  <li>Unify temp view and permanent view behaviors (<a href="https://issues.apache.org/jira/browse/SPARK-33138">SPARK-33138</a>)</li>
+  <li>Support column list in INSERT statement (<a href="https://issues.apache.org/jira/browse/SPARK-32976">SPARK-32976</a>)</li>
+  <li>Support ANSI nested bracketed comments (<a href="https://issues.apache.org/jira/browse/SPARK-28880">SPARK-28880</a>)</li>
+</ul>
+
+<p><strong>Performance Enhancements</strong></p>
+
+<ul>
+  <li>Host-local shuffle data reading without shuffle service (<a href="https://issues.apache.org/jira/browse/SPARK-32077">SPARK-32077</a>)</li>
+  <li>Remove redundant sorts before repartition nodes (<a href="https://issues.apache.org/jira/browse/SPARK-32276">SPARK-32276</a>)</li>
+  <li>Partially push down predicates (<a href="https://issues.apache.org/jira/browse/SPARK-32302">SPARK-32302</a>, <a href="https://issues.apache.org/jira/browse/SPARK-32352">SPARK-32352</a>)</li>
+  <li>Push down filters through expand (<a href="https://issues.apache.org/jira/browse/SPARK-33302">SPARK-33302</a>)</li>
+  <li>Push more possible predicates through Join via CNF conversion (<a href="https://issues.apache.org/jira/browse/SPARK-31705">SPARK-31705</a>)</li>
+  <li>Remove shuffle by preserving output partitioning of broadcast hash join (<a href="https://issues.apache.org/jira/browse/SPARK-31869">SPARK-31869</a>)</li>
+  <li>Remove shuffle by improving reordering join keys (<a href="https://issues.apache.org/jira/browse/SPARK-32282">SPARK-32282</a>)</li>
+  <li>Remove shuffle by normalizing output partitioning and sortorder (<a href="https://issues.apache.org/jira/browse/SPARK-33399">SPARK-33399</a>)</li>
+  <li>Shuffled hash join improvement (<a href="https://issues.apache.org/jira/browse/SPARK-32461">SPARK-32461</a>)
+    <ul>
+      <li>Preserve shuffled hash join build side partitioning (<a href="https://issues.apache.org/jira/browse/SPARK-32330">SPARK-32330</a>)</li>
+      <li>Preserve hash join (BHJ and SHJ) stream side ordering (<a href="https://issues.apache.org/jira/browse/SPARK-32383">SPARK-32383</a>)</li>
+      <li>Coalesce bucketed tables for shuffled hash join (<a href="https://issues.apache.org/jira/browse/SPARK-32286">SPARK-32286</a>)</li>
+      <li>Add code-gen for shuffled hash join (<a href="https://issues.apache.org/jira/browse/SPARK-32421">SPARK-32421</a>)</li>
+      <li>Support full outer join in shuffled hash join (<a href="https://issues.apache.org/jira/browse/SPARK-32399">SPARK-32399</a>)</li>
+    </ul>
+  </li>
+  <li>Support subexpression elimination in project with whole-stage-codegen (<a href="https://issues.apache.org/jira/browse/SPARK-33092">SPARK-33092</a>)</li>
+  <li>Support subexpression elimination in conditional expressions (<a href="https://issues.apache.org/jira/browse/SPARK-33337">SPARK-33337</a>)</li>
+  <li>Support subexpression elimination for interpreted expression evaluation (<a href="https://issues.apache.org/jira/browse/SPARK-33427">SPARK-33427</a>)</li>
+  <li>Support subexpression elimination for interpreted predicate (<a href="https://issues.apache.org/jira/browse/SPARK-33540">SPARK-33540</a>)</li>
+  <li>Other optimizer rules
+    <ul>
+      <li>Rule ExtractSingleColumnNullAwareAntiJoin (<a href="https://issues.apache.org/jira/browse/SPARK-32290">SPARK-32290</a>)</li>
+      <li>Rule EliminateNullAwareAntiJoin (<a href="https://issues.apache.org/jira/browse/SPARK-32573">SPARK-32573</a>)</li>
+      <li>Rule EliminateAggregateFilter (<a href="https://issues.apache.org/jira/browse/SPARK-32540">SPARK-32540</a>)</li>
+      <li>Rule UnwrapCastInBinaryComparison (<a href="https://issues.apache.org/jira/browse/SPARK-32858">SPARK-32858</a>)</li>
+      <li>Rule DisableUnnecessaryBucketedScan (<a href="https://issues.apache.org/jira/browse/SPARK-32859">SPARK-32859</a>)</li>
+      <li>Rule CoalesceBucketsInJoin (<a href="https://issues.apache.org/jira/browse/SPARK-31350">SPARK-31350</a>)</li>
+      <li>Prune unnecessary nested fields from generate without project (<a href="https://issues.apache.org/jira/browse/SPARK-29721">SPARK-29721</a>)</li>
+      <li>Prune unnecessary nested fields from aggregate and expand (<a href="https://issues.apache.org/jira/browse/SPARK-27217">SPARK-27217</a>)</li>
+      <li>Prune unnecessary nested fields from repartition-by-expression and join (<a href="https://issues.apache.org/jira/browse/SPARK-31736">SPARK-31736</a>)</li>
+      <li>Prune unnecessary nested fields over cosmetic variations (<a href="https://issues.apache.org/jira/browse/SPARK-32163">SPARK-32163</a>)</li>
+      <li>Prune unnecessary nested fields from window and sort (<a href="https://issues.apache.org/jira/browse/SPARK-32059">SPARK-32059</a>)</li>
+      <li>Optimize size of CreateArray/CreateMap to be the size of its children (<a href="https://issues.apache.org/jira/browse/SPARK-33544">SPARK-33544</a>)</li>
+    </ul>
+  </li>
+</ul>
+
+<p><strong>Extensibility Enhancements</strong></p>
+
+<ul>
+  <li>Stage Level Resource configuration and Scheduling (<a href="https://issues.apache.org/jira/browse/SPARK-27495">SPARK-27495</a>)
+    <ul>
+      <li>Expose RDD APIs for Stage Level Scheduling (<a href="https://issues.apache.org/jira/browse/SPARK-29150">SPARK-29150</a>)</li>
+      <li>Merge resource profiles within a stage (<a href="https://issues.apache.org/jira/browse/SPARK-29153">SPARK-29153</a>)</li>
+      <li>Stage level scheduling support for Kubernetes (<a href="https://issues.apache.org/jira/browse/SPARK-33288">SPARK-33288</a>)</li>
+      <li>Add UI support for stage level scheduling (<a href="https://issues.apache.org/jira/browse/SPARK-29303">SPARK-29303</a>)</li>
+    </ul>
+  </li>
+  <li>Remote storage for persisting shuffle data (<a href="https://issues.apache.org/jira/browse/SPARK-25299">SPARK-25299</a>)
+    <ul>
+      <li>Shuffle writer metadata APIs (<a href="https://issues.apache.org/jira/browse/SPARK-31798">SPARK-31798</a>)</li>
+    </ul>
+  </li>
+  <li>Allow to use a custom shuffle manager with external shuffle service (<a href="https://issues.apache.org/jira/browse/SPARK-33037">SPARK-33037</a>)</li>
+  <li>Add SupportsPartitions APIs on DataSourceV2 (<a href="https://issues.apache.org/jira/browse/SPARK-31694">SPARK-31694</a>)</li>
+  <li>Add SupportsMetadataColumns API on DataSourceV2 (<a href="https://issues.apache.org/jira/browse/SPARK-31255">SPARK-31255</a>)</li>
+  <li>Make SQL cache serialization pluggable (<a href="https://issues.apache.org/jira/browse/SPARK-32274">SPARK-32274</a>)</li>
+  <li>Introduce the &#8220;purge&#8221; option in TableCatalog.dropTable for v2 catalog (<a href="https://issues.apache.org/jira/browse/SPARK-33364">SPARK-33364</a>)</li>
+</ul>
+
+<p><strong>Connector Enhancements</strong></p>
+
+<ul>
+  <li>Hive Metastore partition filter pushdown improvement (<a href="https://issues.apache.org/jira/browse/SPARK-33537">SPARK-33537</a>)
+    <ul>
+      <li>Support contains, starts-with and ends-with filters (<a href="https://issues.apache.org/jira/browse/SPARK-33458">SPARK-33458</a>)</li>
+      <li>Support filter by date type (<a href="https://issues.apache.org/jira/browse/SPARK-33477">SPARK-33477</a>)</li>
+      <li>Support filter by not-equals (<a href="https://issues.apache.org/jira/browse/SPARK-33582">SPARK-33582</a>)</li>
+    </ul>
+  </li>
+  <li>Parquet
+    <ul>
+      <li>Allow complex type in map’s key type in Parquet (<a href="https://issues.apache.org/jira/browse/SPARK-32639">SPARK-32639</a>)</li>
+      <li>Allow saving/loading INT96 in Parquet without rebasing (<a href="https://issues.apache.org/jira/browse/SPARK-33160">SPARK-33160</a>)</li>
+    </ul>
+  </li>
+  <li>ORC
+    <ul>
+      <li>Nested column predicate pushdown for ORC (<a href="https://issues.apache.org/jira/browse/SPARK-25557">SPARK-25557</a>)</li>
+      <li>Upgrade Apache ORC to 1.5.12 (<a href="https://issues.apache.org/jira/browse/SPARK-33050">SPARK-33050</a>)</li>
+    </ul>
+  </li>
+  <li>CSV
+    <ul>
+      <li>Leverage SQL text data source during CSV schema inference (<a href="https://issues.apache.org/jira/browse/SPARK-32270">SPARK-32270</a>)</li>
+    </ul>
+  </li>
+  <li>JSON
+    <ul>
+      <li>Support filters pushdown in JSON datasource (<a href="https://issues.apache.org/jira/browse/SPARK-30648">SPARK-30648</a>)</li>
+    </ul>
+  </li>
+  <li>JDBC
+    <ul>
+      <li>Implement catalog APIs for JDBC (<a href="https://issues.apache.org/jira/browse/SPARK-32375">SPARK-32375</a>, <a href="https://issues.apache.org/jira/browse/SPARK-32579">SPARK-32579</a>, <a href="https://issues.apache.org/jira/browse/SPARK-32402">SPARK-32402</a>, <a href="https://issues.apache.org/jira/browse/SPARK-33130">SPARK-33130</a>)</li>
+      <li>Create JDBC authentication provider developer API (<a href="https://issues.apache.org/jira/browse/SPARK-32001">SPARK-32001</a>)</li>
+      <li>Add JDBC connection provider disable possibility (<a href="https://issues.apache.org/jira/browse/SPARK-32047">SPARK-32047</a>)</li>
+    </ul>
+  </li>
+  <li>Avro
+    <ul>
+      <li>Support filters pushdown in Avro datasource (<a href="https://issues.apache.org/jira/browse/SPARK-32346">SPARK-32346</a>)</li>
+    </ul>
+  </li>
+</ul>
+
+<p><strong>Feature Enhancements</strong></p>
+
+<ul>
+  <li>Node Decommissioning (<a href="https://issues.apache.org/jira/browse/SPARK-20624">SPARK-20624</a>)
+    <ul>
+      <li>Basic framework (<a href="https://issues.apache.org/jira/browse/SPARK-20628">SPARK-20628</a>)</li>
+      <li>Migrate RDD blocks during decommission(<a href="https://issues.apache.org/jira/browse/SPARK-20732">SPARK-20732</a>)</li>
+      <li>Graceful decommissioning as part of dynamic scaling (<a href="https://issues.apache.org/jira/browse/SPARK-31198">SPARK-31198</a>)</li>
+      <li>Migrate shuffle blocks during decommission (<a href="https://issues.apache.org/jira/browse/SPARK-20629">SPARK-20629</a>)</li>
+      <li>Only exit executor when tasks and block migration are finished (<a href="https://issues.apache.org/jira/browse/SPARK-31197">SPARK-31197</a>)</li>
+      <li>Support fallback storage during decommission (<a href="https://issues.apache.org/jira/browse/SPARK-33545">SPARK-33545</a>)</li>
+    </ul>
+  </li>
+  <li>New built-in functions
+    <ul>
+      <li>json_array_length (<a href="https://issues.apache.org/jira/browse/SPARK-31008">SPARK-31008</a>)</li>
+      <li>json_object_keys (<a href="https://issues.apache.org/jira/browse/SPARK-31009">SPARK-31009</a>)</li>
+      <li>current_catalog (<a href="https://issues.apache.org/jira/browse/SPARK-30352">SPARK-30352</a>)</li>
+      <li>timestamp_seconds, timestamp_millis, timestamp_micros (<a href="https://issues.apache.org/jira/browse/SPARK-31710">SPARK-31710</a>)</li>
+      <li>width_bucket (<a href="https://issues.apache.org/jira/browse/SPARK-21117">SPARK-21117</a>)</li>
+      <li>regexp_extract_all (<a href="https://issues.apache.org/jira/browse/SPARK-24884">SPARK-24884</a>)</li>
+      <li>nth_value (<a href="https://issues.apache.org/jira/browse/SPARK-27951">SPARK-27951</a>)</li>
+      <li>raise_error (<a href="https://issues.apache.org/jira/browse/SPARK-32793">SPARK-32793</a>)</li>
+      <li>unix_seconds, unix_millis and unix_micros (<a href="https://issues.apache.org/jira/browse/SPARK-33627">SPARK-33627</a>)</li>
+      <li>date_from_unix_date and unix_date (<a href="https://issues.apache.org/jira/browse/SPARK-33646">SPARK-33646</a>)</li>
+      <li>current_timezone (<a href="https://issues.apache.org/jira/browse/SPARK-33469">SPARK-33469</a>)</li>
+    </ul>
+  </li>
+  <li>EXPLAIN command enhancement (<a href="https://issues.apache.org/jira/browse/SPARK-32337">SPARK-32337</a>, <a href="https://issues.apache.org/jira/browse/SPARK-31325">SPARK-31325</a>)</li>
+  <li>Provide a option to disable user supplied Hints (<a href="https://issues.apache.org/jira/browse/SPARK-31875">SPARK-31875</a>)</li>
+  <li>Support Hive style REPLACE COLUMNS syntax (<a href="https://issues.apache.org/jira/browse/SPARK-30613">SPARK-30613</a>)</li>
+  <li>Support &#8216;LIKE ANY&#8217; and &#8216;LIKE ALL&#8217; operators (<a href="https://issues.apache.org/jira/browse/SPARK-30724">SPARK-30724</a>)</li>
+  <li>Support unlimited MATCHED and NOT MATCHED in MERGE INTO (<a href="https://issues.apache.org/jira/browse/SPARK-32030">SPARK-32030</a>)</li>
+  <li>Support &#8216;F&#8217;-suffixed float literals (<a href="https://issues.apache.org/jira/browse/SPARK-32207">SPARK-32207</a>)</li>
+  <li>Support RESET syntax to reset single configuration (<a href="https://issues.apache.org/jira/browse/SPARK-32406">SPARK-32406</a>)</li>
+  <li>Support filter expression allows simultaneous use of DISTINCT (<a href="https://issues.apache.org/jira/browse/SPARK-30276">SPARK-30276</a>)</li>
+  <li>Support alter table add/drop partition command for DSv2 (<a href="https://issues.apache.org/jira/browse/SPARK-32512">SPARK-32512</a>)</li>
+  <li>Support NOT IN subqueries inside nested OR conditions (<a href="https://issues.apache.org/jira/browse/SPARK-25154">SPARK-25154</a>)</li>
+  <li>Support REFRESH FUNCTION command (<a href="https://issues.apache.org/jira/browse/SPARK-31999">SPARK-31999</a>)</li>
+  <li>Add &#8216;sameSemantics&#8217; and &#8216;sementicHash&#8217; methods in Dataset (<a href="https://issues.apache.org/jira/browse/SPARK-30791">SPARK-30791</a>)</li>
+  <li>Support composed type of case class in UDF (<a href="https://issues.apache.org/jira/browse/SPARK-31826">SPARK-31826</a>)</li>
+  <li>Support enumeration in encoders (<a href="https://issues.apache.org/jira/browse/SPARK-32585">SPARK-32585</a>)</li>
+  <li>Support nested field APIs withField and dropFields (<a href="https://issues.apache.org/jira/browse/SPARK-31317">SPARK-31317</a>, <a href="https://issues.apache.org/jira/browse/SPARK-32511">SPARK-32511</a>)</li>
+  <li>Support to fill nulls for missing columns in unionByName (<a href="https://issues.apache.org/jira/browse/SPARK-29358">SPARK-29358</a>)</li>
+  <li>Support DataFrameReader.table to take the specified options (<a href="https://issues.apache.org/jira/browse/SPARK-32592">SPARK-32592</a>, <a href="https://issues.apache.org/jira/browse/SPARK-32844">SPARK-32844</a>)</li>
+  <li>Support HDFS location in <code class="language-plaintext highlighter-rouge">spark.sql.hive.metastore.jars</code> (<a href="https://issues.apache.org/jira/browse/SPARK-32852">SPARK-32852</a>)</li>
+  <li>Support &#8211;archives option natively (<a href="https://issues.apache.org/jira/browse/SPARK-33530">SPARK-33530</a>, <a href="https://issues.apache.org/jira/browse/SPARK-33615">SPARK-33615</a>)</li>
+  <li>Enhance ExecutorPlugin API to include methods for task start and end events (<a href="https://issues.apache.org/jira/browse/SPARK-33088">SPARK-33088</a>)</li>
+</ul>
+
+<p><strong>Other Notable Changes</strong></p>
+
+<ul>
+  <li>Provide Search Function in Spark docs site (<a href="https://issues.apache.org/jira/browse/SPARK-33166">SPARK-33166</a>)</li>
+  <li>Use Apache Hadoop 3.2.0 by default (<a href="https://issues.apache.org/jira/browse/SPARK-32058">SPARK-32058</a>, <a href="https://issues.apache.org/jira/browse/SPARK-32841">SPARK-32841</a>)</li>
+  <li>Upgrade Apache Arrow to 2.0.0 (<a href="https://issues.apache.org/jira/browse/SPARK-33213">SPARK-33213</a>)</li>
+  <li>Kubernetes GA (<a href="https://issues.apache.org/jira/browse/SPARK-33005">SPARK-33005</a>)
+    <ul>
+      <li>Adds support for Kubernetes NFS volume mounts (<a href="https://issues.apache.org/jira/browse/SPARK-31394">SPARK-31394</a>)</li>
+      <li>Support dynamic PVC creation/deletion (<a href="https://issues.apache.org/jira/browse/SPARK-32971">SPARK-32971</a>, <a href="https://issues.apache.org/jira/browse/SPARK-32997">SPARK-32997</a>)</li>
+      <li>Respect environment variables and configurations for Python executables (<a href="https://issues.apache.org/jira/browse/SPARK-33748">SPARK-33748</a>)</li>
+      <li>Support Python dependency (<a href="https://issues.apache.org/jira/browse/SPARK-33748">SPARK-27936</a>)</li>
+      <li>Make pod allocation executor timeouts configurable and allow scheduling with pending pods (<a href="https://issues.apache.org/jira/browse/SPARK-33231">SPARK-33231</a>, <a href="https://issues.apache.org/jira/browse/SPARK-33262">SPARK-33262</a>)</li>
+      <li>Respect executor idle timeout conf in ExecutorPodsAllocator (<a href="https://issues.apache.org/jira/browse/SPARK-33099">SPARK-33099</a>)</li>
+      <li>Support JDBC Kerberos with keytab (<a href="https://issues.apache.org/jira/browse/SPARK-12312">SPARK-12312</a>)</li>
+    </ul>
+  </li>
+  <li>Enable Java 8 time API in thrift server (<a href="https://issues.apache.org/jira/browse/SPARK-31910">SPARK-31910</a>)</li>
+  <li>Enable Java 8 time API in UDFs (<a href="https://issues.apache.org/jira/browse/SPARK-32154">SPARK-32154</a>)</li>
+  <li>Overflow check for aggregate sum with decimals (<a href="https://issues.apache.org/jira/browse/SPARK-28067">SPARK-28067</a>)</li>
+  <li>Fix commit collision in dynamic partition overwrite mode (<a href="https://issues.apache.org/jira/browse/SPARK-27194">SPARK-27194</a>, <a href="https://issues.apache.org/jira/browse/SPARK-29302">SPARK-29302</a>)</li>
+  <li>Removed references to slave, blacklist and whitelist (<a href="https://issues.apache.org/jira/browse/SPARK-32004">SPARK-32004</a>, <a href="https://issues.apache.org/jira/browse/SPARK-32036">SPARK-32036</a>, <a href="https://issues.apache.org/jira/browse/SPARK-32037">SPARK-32037</a>)</li>
+  <li>Remove task result size check for shuffle map stage (<a href="https://issues.apache.org/jira/browse/SPARK-32470">SPARK-32470</a>)</li>
+  <li>Generalize ExecutorSource to expose user-given file system schemes (<a href="https://issues.apache.org/jira/browse/SPARK-33476">SPARK-33476</a>)</li>
+  <li>Add StorageLevel.DISK_ONLY_3 (<a href="https://issues.apache.org/jira/browse/SPARK-32517">SPARK-32517</a>)</li>
+  <li>Expose executor memory metrics in the web UI for executors (<a href="https://issues.apache.org/jira/browse/SPARK-23432">SPARK-23432</a>)</li>
+  <li>Expose executor memory metrics at the stage level, in the Stages tab (<a href="https://issues.apache.org/jira/browse/SPARK-26341">SPARK-26341</a>)</li>
+  <li>Fix explicitly set of <code class="language-plaintext highlighter-rouge">spark.ui.port</code> in YARN cluster mode (<a href="https://issues.apache.org/jira/browse/SPARK-29465">SPARK-29465</a>)</li>
+  <li>Add <code class="language-plaintext highlighter-rouge">spark.submit.waitForCompletion</code> configuration to control spark-submit exit in Standalone cluster mode (<a href="https://issues.apache.org/jira/browse/SPARK-31486">SPARK-31486</a>)</li>
+  <li>Do not propagate Hadoop’s classpath for Spark distribution with built-in Hadoop (<a href="https://issues.apache.org/jira/browse/SPARK-31960">SPARK-31960</a>)</li>
+  <li>Fix jobs disappear intermittently in SHS under high load (<a href="https://issues.apache.org/jira/browse/SPARK-33841">SPARK-33841</a>)</li>
+  <li>Redact sensitive attributes of application log in SHS (<a href="https://issues.apache.org/jira/browse/SPARK-33504">SPARK-33504</a>)</li>
+  <li>Set up yarn.Client to print direct links to driver stdout/stderr (<a href="https://issues.apache.org/jira/browse/SPARK-33185">SPARK-33185</a>)</li>
+  <li>Fix memory leak when fail to store pieces of broadcast (<a href="https://issues.apache.org/jira/browse/SPARK-32715">SPARK-32715</a>)</li>
+  <li>Make BlockManagerMaster driver heartbeat timeout configurable (<a href="https://issues.apache.org/jira/browse/SPARK-34278">SPARK-34278</a>)</li>
+  <li>Unify and complete cache behaviors (<a href="https://issues.apache.org/jira/browse/SPARK-33507">SPARK-33507</a>)</li>
+</ul>
+
+<p><strong>Changes of behavior</strong></p>
+
+<p>Please read the migration guides for each component: <a href="https://spark.apache.org/docs/3.1.1/core-migration-guide.html">Spark Core</a> and <a href="https://spark.apache.org/docs/3.1.1/sql-migration-guide.html">Spark SQL</a>.</p>
+
+<p><em>Programming guides: <a href="https://spark.apache.org/docs/3.1.1/rdd-programming-guide.html">Spark RDD Programming Guide</a> and <a href="https://spark.apache.org/docs/3.1.1/sql-programming-guide.html">Spark SQL, DataFrames and Datasets Guide</a>.</em></p>
+
+<h3 id="pyspark">PySpark</h3>
+
+<p><strong>Project Zen</strong></p>
+
+<ul>
+  <li>Project Zen: Improving Python usability (<a href="https://issues.apache.org/jira/browse/SPARK-32082">SPARK-32082</a>)</li>
+  <li>PySpark type hints support (<a href="https://issues.apache.org/jira/browse/SPARK-32681">SPARK-32681</a>)</li>
+  <li>Redesign PySpark documentation (<a href="https://issues.apache.org/jira/browse/SPARK-31851">SPARK-31851</a>)</li>
+  <li>Migrate to NumPy documentation style (<a href="https://issues.apache.org/jira/browse/SPARK-32085">SPARK-32085</a>)</li>
+  <li>Installation option for PyPI Users (<a href="https://issues.apache.org/jira/browse/SPARK-32017">SPARK-32017</a>)</li>
+  <li>Un-deprecate inferring DataFrame schema from list of dict (<a href="https://issues.apache.org/jira/browse/SPARK-32686">SPARK-32686</a>)</li>
+  <li>Simplify the exception message from Python UDFs (<a href="https://issues.apache.org/jira/browse/SPARK-33407">SPARK-33407</a>)</li>
+</ul>
+
+<p><strong>Other Notable Changes</strong></p>
+
+<ul>
+  <li>Stage Level Scheduling APIs (<a href="https://issues.apache.org/jira/browse/SPARK-29641">SPARK-29641</a>)</li>
+  <li>Deduplicate deterministic PythonUDF calls (<a href="https://issues.apache.org/jira/browse/SPARK-33303">SPARK-33303</a>)</li>
+  <li>Support higher order functions in PySpark functions(<a href="https://issues.apache.org/jira/browse/SPARK-30681">SPARK-30681</a>)</li>
+  <li>Support data source v2x write APIs (<a href="https://issues.apache.org/jira/browse/SPARK-29157">SPARK-29157</a>)</li>
+  <li>Support percentile_approx in PySpark functions(<a href="https://issues.apache.org/jira/browse/SPARK-30569">SPARK-30569</a>)</li>
+  <li>Support inputFiles in PySpark DataFrame (<a href="https://issues.apache.org/jira/browse/SPARK-31763">SPARK-31763</a>)</li>
+  <li>Support withField in PySpark Column (<a href="https://issues.apache.org/jira/browse/SPARK-32835">SPARK-32835</a>)</li>
+  <li>Support dropFields in PySpark Column (<a href="https://issues.apache.org/jira/browse/SPARK-32511">SPARK-32511</a>)</li>
+  <li>Support nth_value in PySpark functions (<a href="https://issues.apache.org/jira/browse/SPARK-33020">SPARK-33020</a>)</li>
+  <li>Support acosh, asinh and atanh (<a href="https://issues.apache.org/jira/browse/SPARK-33563">SPARK-33563</a>)</li>
+  <li>Support getCheckpointDir method in PySpark SparkContext (<a href="https://issues.apache.org/jira/browse/SPARK-33017">SPARK-33017</a>)</li>
+  <li>Support to fill nulls for missing columns in unionByName (<a href="https://issues.apache.org/jira/browse/SPARK-32798">SPARK-32798</a>)</li>
+  <li>Update cloudpickle to v1.5.0 (<a href="https://issues.apache.org/jira/browse/SPARK-32094">SPARK-32094</a>)</li>
+  <li>Add MapType support for PySpark with Arrow (<a href="https://issues.apache.org/jira/browse/SPARK-33748">SPARK-24554</a>)</li>
+  <li>DataStreamReader.table and DataStreamWriter.toTable (<a href="https://issues.apache.org/jira/browse/SPARK-33836">SPARK-33836</a>)</li>
+</ul>
+
+<p><strong>Changes of behavior</strong></p>
+
+<p>Please read the migration guides for <a href="https://spark.apache.org/docs/3.1.1/api/python/migration_guide/index.html">PySpark</a>.</p>
+
+<p><em>Programming guides: <a href="https://spark.apache.org/docs/3.1.1/api/python/getting_started/index.html">PySpark Getting Started</a> and <a href="https://spark.apache.org/docs/3.1.1/api/python/user_guide/index.html">PySpark User Guide</a>.</em></p>
+
+<h3 id="structured-streaming">Structured Streaming</h3>
+
+<p><strong>Performance Enhancements</strong></p>
+
+<ul>
+  <li>Cache fetched list of files beyond maxFilesPerTrigger as unread file (<a href="https://issues.apache.org/jira/browse/SPARK-30866">SPARK-30866</a>)</li>
+  <li>Streamline the logic on file stream source and sink metadata log (<a href="https://issues.apache.org/jira/browse/SPARK-30462">SPARK-30462</a>)</li>
+  <li>Avoid reading compact metadata log twice if the query restarts from compact batch (<a href="https://issues.apache.org/jira/browse/SPARK-30900">SPARK-30900</a>)</li>
+</ul>
+
+<p><strong>Feature Enhancements</strong></p>
+
+<ul>
+  <li>Add DataStreamReader.table API (<a href="https://issues.apache.org/jira/browse/SPARK-32885">SPARK-32885</a>)</li>
+  <li>Add DataStreamWriter.toTable API (<a href="https://issues.apache.org/jira/browse/SPARK-32896">SPARK-32896</a>)</li>
+  <li>Left semi stream-stream join (<a href="https://issues.apache.org/jira/browse/SPARK-32862">SPARK-32862</a>)</li>
+  <li>Full outer stream-stream join (<a href="https://issues.apache.org/jira/browse/SPARK-32863">SPARK-32863</a>)</li>
+  <li>Provide a new option to have retention on output files (<a href="https://issues.apache.org/jira/browse/SPARK-27188">SPARK-27188</a>)</li>
+  <li>Add Spark Structured Streaming History Server Support (<a href="https://issues.apache.org/jira/browse/SPARK-31953">SPARK-31953</a>)</li>
+  <li>Introduce State schema validation among query restart (<a href="https://issues.apache.org/jira/browse/SPARK-27237">SPARK-27237</a>)</li>
+</ul>
+
+<p><strong>Other Notable Changes</strong></p>
+
+<ul>
+  <li>Introduce schema validation for streaming state store (<a href="https://issues.apache.org/jira/browse/SPARK-31894">SPARK-31894</a>)</li>
+  <li>Support to use a different compression codec in state store (<a href="https://issues.apache.org/jira/browse/SPARK-33263">SPARK-33263</a>)</li>
+  <li>Kafka connector infinite wait because metadata never updated (<a href="https://issues.apache.org/jira/browse/SPARK-28367">SPARK-28367</a>)</li>
+  <li>Upgrade Kafka to 2.6.0 (<a href="https://issues.apache.org/jira/browse/SPARK-32568">SPARK-32568</a>)</li>
+  <li>Pagination support for Structured Streaming UI pages (<a href="https://issues.apache.org/jira/browse/SPARK-31642">SPARK-31642</a>, <a href="https://issues.apache.org/jira/browse/SPARK-30119">SPARK-30119</a>)</li>
+  <li>State information in Structured Streaming UI (<a href="https://issues.apache.org/jira/browse/SPARK-33223">SPARK-33223</a>)</li>
+  <li>Watermark gap information in Structured Streaming UI (<a href="https://issues.apache.org/jira/browse/SPARK-33224">SPARK-33224</a>)</li>
+  <li>Expose state custom metrics information on SS UI (<a href="https://issues.apache.org/jira/browse/SPARK-33287">SPARK-33287</a>)</li>
+  <li>Add a new metric regarding number of rows later than watermark (<a href="https://issues.apache.org/jira/browse/SPARK-24634">SPARK-24634</a>)</li>
+</ul>
+
+<p><strong>Changes of behavior</strong></p>
+
+<p>Please read the migration guides for <a href="https://spark.apache.org/docs/3.1.1/ss-migration-guide.html">Structured Streaming</a>.</p>
+
+<p><em>Programming guides: <a href="https://spark.apache.org/docs/3.1.1/structured-streaming-programming-guide.html">Structured Streaming Programming Guide</a>.</em></p>
+
+<h3 id="mllib">MLlib</h3>
+
+<p><strong>Highlight</strong></p>
+
+<ul>
+  <li>LinearSVC blockify input vectors (<a href="https://issues.apache.org/jira/browse/SPARK-30642">SPARK-30642</a>)</li>
+  <li>LogisticRegression blockify input vectors (<a href="https://issues.apache.org/jira/browse/SPARK-30659">SPARK-30659</a>)</li>
+  <li>LinearRegression blockify input vectors (<a href="https://issues.apache.org/jira/browse/SPARK-30660">SPARK-30660</a>)</li>
+  <li>AFT blockify input vectors (<a href="https://issues.apache.org/jira/browse/SPARK-31656">SPARK-31656</a>)</li>
+  <li>Add support for association rules in ML (<a href="https://issues.apache.org/jira/browse/SPARK-19939">SPARK-19939</a>)</li>
+  <li>Add training summary for LinearSVCModel (<a href="https://issues.apache.org/jira/browse/SPARK-20249">SPARK-20249</a>)</li>
+  <li>Add summary to RandomForestClassificationModel (<a href="https://issues.apache.org/jira/browse/SPARK-23631">SPARK-23631</a>)</li>
+  <li>Add training summary to FMClassificationModel (<a href="https://issues.apache.org/jira/browse/SPARK-32140">SPARK-32140</a>)</li>
+  <li>Add summary to MultilayerPerceptronClassificationModel (<a href="https://issues.apache.org/jira/browse/SPARK-32449">SPARK-32449</a>)</li>
+  <li>Add FMClassifier to SparkR (<a href="https://issues.apache.org/jira/browse/SPARK-30820">SPARK-30820</a>)</li>
+  <li>Add SparkR LinearRegression wrapper (<a href="https://issues.apache.org/jira/browse/SPARK-30818">SPARK-30818</a>)</li>
+  <li>Add FMRegressor wrapper to SparkR (<a href="https://issues.apache.org/jira/browse/SPARK-30819">SPARK-30819</a>)</li>
+  <li>Add SparkR wrapper for vector_to_array (<a href="https://issues.apache.org/jira/browse/SPARK-33040">SPARK-33040</a>)</li>
+  <li>adaptively blockify instances - LinearSVC (<a href="https://issues.apache.org/jira/browse/SPARK-32907">SPARK-32907</a>)</li>
+  <li>make CrossValidator/TrainValidateSplit/OneVsRest Reader/Writer support Python backend estimator/evaluator (<a href="https://issues.apache.org/jira/browse/SPARK-33520">SPARK-33520</a>)</li>
+  <li>Improve performance of ML ALS recommendForAll by GEMV (<a href="https://issues.apache.org/jira/browse/SPARK-33520">SPARK-33518</a>)</li>
+  <li>Add UnivariateFeatureSelector (<a href="https://issues.apache.org/jira/browse/SPARK-34080">SPARK-34080</a>)</li>
+</ul>
+
+<p><strong>Other Notable Changes</strong></p>
+
+<ul>
+  <li>GMM compute summary and update distributions in one job (<a href="https://issues.apache.org/jira/browse/SPARK-31032">SPARK-31032</a>)</li>
+  <li>Remove ChiSqSelector dependency on mllib.ChiSqSelectorModel (<a href="https://issues.apache.org/jira/browse/SPARK-31077">SPARK-31077</a>)</li>
+  <li>Flatten the result dataframe of tests in testChiSquare (<a href="https://issues.apache.org/jira/browse/SPARK-31301">SPARK-31301</a>)</li>
+  <li>MinHash keyDistance optimization (<a href="https://issues.apache.org/jira/browse/SPARK-31436">SPARK-31436</a>)</li>
+  <li>KMeans optimization based on triangle-inequality (<a href="https://issues.apache.org/jira/browse/SPARK-31007">SPARK-31007</a>)</li>
+  <li>Add weight support in ClusteringEvaluator (<a href="https://issues.apache.org/jira/browse/SPARK-31734">SPARK-31734</a>)</li>
+  <li>Add getMetrics in Evaluators (<a href="https://issues.apache.org/jira/browse/SPARK-31768">SPARK-31768</a>)</li>
+  <li>Add instance weight support in LinearRegressionSummary (<a href="https://issues.apache.org/jira/browse/SPARK-31944">SPARK-31944</a>)</li>
+  <li>Add user-specified fold column to CrossValidator (<a href="https://issues.apache.org/jira/browse/SPARK-31777">SPARK-31777</a>)</li>
+  <li>ML params default value parity in feature and tuning (<a href="https://issues.apache.org/jira/browse/SPARK-32310">SPARK-32310</a>)</li>
+  <li>Fix double caching in KMeans/BiKMeans (<a href="https://issues.apache.org/jira/browse/SPARK-32676">SPARK-32676</a>)</li>
+  <li>aft transform optimization (<a href="https://issues.apache.org/jira/browse/SPARK-33111">SPARK-33111</a>)</li>
+  <li>FeatureHasher transform optimization (<a href="https://issues.apache.org/jira/browse/SPARK-32974">SPARK-32974</a>)</li>
+  <li>Add array_to_vector function for dataframe column (<a href="https://issues.apache.org/jira/browse/SPARK-33556">SPARK-33556</a>)</li>
+  <li>ML params default value parity in classification, regression, clustering and fpm (<a href="https://issues.apache.org/jira/browse/SPARK-32310">SPARK-32310</a>)</li>
+  <li>Summary.totalIterations greater than maxIters (<a href="https://issues.apache.org/jira/browse/SPARK-31925">SPARK-31925</a>)</li>
+  <li>tree models prediction optimization (<a href="https://issues.apache.org/jira/browse/SPARK-32298">SPARK-32298</a>)</li>
+</ul>
+
+<p><strong>Changes of behavior</strong></p>
+
+<p>Please read the migration guides for <a href="https://spark.apache.org/docs/3.1.1/ml-migration-guide.html">MLlib</a>.</p>
+
+<p><em>Programming guide: <a href="https://spark.apache.org/docs/3.1.1/ml-guide.html">Machine Learning Library (MLlib) Guide</a>.</em></p>
+
+<h3 id="sparkr">SparkR</h3>
+
+<ul>
+  <li>Add SparkR interface for higher order functions (<a href="https://issues.apache.org/jira/browse/SPARK-30682">SPARK-30682</a>)</li>
+  <li>Support to fill nulls for missing columns in unionByName (<a href="https://issues.apache.org/jira/browse/SPARK-32798">SPARK-32798</a>)</li>
+  <li>Support withColumn in SparkR functions (<a href="https://issues.apache.org/jira/browse/SPARK-32946">SPARK-32946</a>)</li>
+  <li>Support timestamp_seconds in SparkR functions (<a href="https://issues.apache.org/jira/browse/SPARK-32949">SPARK-32949</a>)</li>
+  <li>Support nth_value in SparkR functions (<a href="https://issues.apache.org/jira/browse/SPARK-33030">SPARK-33030</a>)</li>
+  <li>Minimum Arrow version bumped up to 1.0.0 (<a href="https://issues.apache.org/jira/browse/SPARK-32452">SPARK-32452</a>)</li>
+  <li>Support array_to_vector in SparkR functions (<a href="https://issues.apache.org/jira/browse/SPARK-33622">SPARK-33622</a>)</li>
+  <li>Support acosh, asinh and atanh (<a href="https://issues.apache.org/jira/browse/SPARK-33563">SPARK-33563</a>)</li>
+  <li>Support from_avro and to_avro (<a href="https://issues.apache.org/jira/browse/SPARK-33304">SPARK-33304</a>)</li>
+</ul>
+
+<p><strong>Changes of behavior</strong></p>
+
+<p>Please read the <a href="https://spark.apache.org/docs/3.1.1/sparkr-migration-guide.html">migration guide</a> for details.</p>
+
+<p><em>Programming guide: <a href="https://spark.apache.org/docs/3.1.1/sparkr.html">SparkR (R on Spark)</a>.</em></p>
+
+<h3 id="graphx">GraphX</h3>
+
+<p><em>Programming guide: <a href="https://spark.apache.org/docs/3.1.1/graphx-programming-guide.html">GraphX Programming Guide</a>.</em></p>
+
+<h3 id="deprecations-and-removals">Deprecations and Removals</h3>
+
+<ul>
+  <li>Drop Python 2.7, 3.4 and 3.5 (<a href="https://issues.apache.org/jira/browse/SPARK-32138">SPARK-32138</a>)</li>
+  <li>Drop R &lt; 3.5 support (<a href="https://issues.apache.org/jira/browse/SPARK-32073">SPARK-32073</a>)</li>
+  <li>Remove hive-1.2 distribution (<a href="https://issues.apache.org/jira/browse/SPARK-32981">SPARK-32981</a>)</li>
+  <li>Remove references to org.spark-project.hive (<a href="https://issues.apache.org/jira/browse/SPARK-20202">SPARK-20202</a>)</li>
+  <li>Deprecate support of multiple workers on the same host in Standalone (<a href="https://issues.apache.org/jira/browse/SPARK-31018">SPARK-31018</a>)</li>
+</ul>
+
+<h2 id="known-issues">Known Issues</h2>
+
+<ul>
+  <li>[<a href="https://issues.apache.org/jira/browse/SPARK-34543">SPARK-33392</a>] Respect case sensitivity in V1 ALTER TABLE .. SET LOCATION</li>
+  <li>[<a href="https://issues.apache.org/jira/browse/SPARK-34531">SPARK-34531</a>] Remove Experimental API tag in PrometheusServlet</li>
+  <li>[<a href="https://issues.apache.org/jira/browse/SPARK-34515">SPARK-34515</a>] Fix NPE if InSet contains null value during getPartitionsByFilter</li>
+  <li>[<a href="https://issues.apache.org/jira/browse/SPARK-34497">SPARK-34497</a>] JDBC connection provider is not removing kerberos credentials from JVM security context</li>
+  <li>[<a href="https://issues.apache.org/jira/browse/SPARK-34490">SPARK-34490</a>] table maybe resolved as a view if the table is dropped</li>
+  <li>[<a href="https://issues.apache.org/jira/browse/SPARK-34473">SPARK-34473</a>] avoid NPE in DataFrameReader.schema(StructType)</li>
+  <li>[<a href="https://issues.apache.org/jira/browse/SPARK-34436">SPARK-34436</a>] DPP support LIKE ANY/ALL</li>
+</ul>
+
+<h2 id="credits">Credits</h2>
+
+<p>Last but not least, this release would not have been possible without the following contributors: Abhishek Dixit, Adam Binford, Ajith S, Akshat Bordia, Alessandro Patti, Alex Favaro, Ali Afroozeh, Ali Smesseim, Allison Wang, Ankit Srivastava, Anton Okolnychyi, Antonin Delpeuch, Artsiom Yudovin, Arwin Tio, Attila Zsolt Piros, Baohe Zhang, Bo Yang, Bo Zhang, Brandon Jiang, Bruce Robbins, Bryan Cutler, CC Highman, Chandni Singh, Chao Sun, Chen Zhang, Cheng Su, Chuliang Xiao, DB Tsai, Dale Clarke, Daniel Himmelstein, Daniel Moore, David Toneian, Denis Pyshev, Devesh Agrawal, Dilip Biswal, Dmitry Sabanin, Dongjoon Hyun, Du Ripeng, Emilian Bold, Eren Avsarogullari, Eric Lemmon, Eric Wu, Erik Krogen, Fabian Höring, Farhan Khan, Farooq Qaiser, Fei Wang, Fokko Driesprong, Frank Yin, Fuwang Hu, Gabor Somogyi, Gengliang Wang, Gera Shegalov, German Schiavon Matteo, Goki Mori, Guangxin Wang, Gustavo Martin Morcuende, Herman Van Hovell, Holden Karau, Huang Yi, Haejoon Lee, Huaxin Gao, Hyukjin Kwon, Izek Greenfield, Jackey Lee, Jacob Kim, Jalpan Randeri, Jatin Puri, Jiaan Geng, Jinxin Tang, Josh Soref, Jonathan Lafleche, Jungtaek Lim, Karen Feng, Karol Chmist, Kaxil Naik, Kazuaki Ishizaki, Ke Jia, Keiji Yoshida, Kent Yao, Kevin Su, Kevin Wang, Koert Kuipers, Kousuke Saruta, Kyle Bendickson, Lantao Jin, Leanken Lin, Liang Zhang, Liang-Chi Hsieh, Linhong Liu, Lipeng Zhu, Lu Lu, Luca Canali, Maciej Szymkiewicz, Manu Zhang, Marcelo Vanzin, Maryann Xue, Matthew Cheah, Maxim Gekk, Michael Chirico, Michael Munday, Michał Wieleba, Min Shen, Nan Zhu, Nicholas Chammas, Nicholas Marcott, Nik Vanderhoof, Onur Satici, Pablo Langa, Pascal Gillet, Paul Reidy, Pavithra Ramachandran, Pedro Rossi, Peter Toth, Philipse Guo, Piotr Grzegorski, Prakhar Jain, Prashant Sharma, Qianyang Yu, Qilong Su, Rajat Ahuja, Rakesh Raushan, Rameshkrishnan Muthusamy, Raphael Auv, Richard Penney, Robert (Bobby) Evans, Rohit Mishra,Ruifeng Zheng, Ryan Blue, Ryotaro Tsuzuki, Samir Khan, Samuel Souza, Sandeep Katta, Sander Goos, Saurabh Chawla, Sean Owen, Seongjin Cho, Shane Knapp, Shanyu Zhao, Shaoyun Chen, Shixiong Zhu, Shruti Gumma, Srinivas Rishindra Pothireddi, Stavros Kontopoulos, StefanXiepj, Stijn De Haes, Stuart White, Sudharshann D, Sunitha Kambhampati, Takeshi Yamamuro, Takuya UESHIN, Tanel Kiis, Tathagata Das, Terry Kim, Thomas Graves, Tianshi Zhu, Tom Howland, Tom Van Bussel, Udbhav Agrawal, Uncle Gen, Utkarsh Agarwal, Venkata Krishnan Sowrirajan, Vlad Glinsky, Warren Zhu, Weichen Xu, Wenchen Fan, William Hyun, Wing Yew Poon, Xianyin Xin, Xiao Li, Xiduo You, Xingbo Jiang, Xinrong Meng, Xinyi Yu, Xuedong Luan, Yang Jie, Yaroslav Tkachenko, Ye Zhou, Yi Wu, Yi Zhu, Yu Zhong, Yuanjian Li, Yuexin Zhang, Yuming Wang, Yuning Zhang, Zhen Li, Zhenhua Wang, Zhicheng Jin, Zirui Xu, Zuo Dao, akiyamaneko, artiship, cristichircu, dzlab, huangtianhua, liucht-inspur, manubatham20, waitinfuture, wang-zhun, yzjg</p>
+
+
+<p>
+<br/>
+<a href="/news/">Spark News Archive</a>
+</p>
+
+  </div>
+</div>
+
+
+
+<footer class="small">
+  <hr>
+  Apache Spark, Spark, Apache, the Apache feather logo, and the Apache Spark project logo are either registered
+  trademarks or trademarks of The Apache Software Foundation in the United States and other countries.
+  See guidance on use of Apache Spark <a href="/trademarks.html">trademarks</a>.
+  All other marks mentioned may be trademarks or registered trademarks of their respective owners.
+  Copyright &copy; 2018 The Apache Software Foundation, Licensed under the
+  <a href="https://www.apache.org/licenses/">Apache License, Version 2.0</a>.
+</footer>
+
+</div>
+
+</body>
+</html>

--- a/site/research.html
+++ b/site/research.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/security.html
+++ b/site/security.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -139,6 +139,14 @@
 </url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
+  <loc>https://spark.apache.org/releases/spark-release-3-1-1.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/news/spark-3-1-1-released.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/releases/spark-release-3-0-2.html</loc>
   <changefreq>weekly</changefreq>
 </url>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -109,7 +109,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -109,7 +109,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.0.2)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-2-4-7-released.html">Spark 2.4.7 released</a>
           <span class="small">(Sep 12, 2020)</span></li>
-        
-          <li><a href="/news/spark-3-0-1-released.html">Spark 3.0.1 released</a>
-          <span class="small">(Sep 08, 2020)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>


### PR DESCRIPTION
This PR fixes to update our website. I checked the followings are available as of now.

- https://dist.apache.org/repos/dist/release/spark/spark-3.1.1/
- https://repo1.maven.org/maven2/org/apache/spark/spark-core_2.12/3.1.1/
- https://pypi.org/project/pyspark/3.1.1/


https://spark.apache.org/docs/3.1.1/ will be available after https://github.com/apache/spark-website/pull/319 