### PR TITLE
Make release windows up-to-date for 3.2.0 and 2.4.8

### DIFF
--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -328,7 +328,7 @@ available APIs.</p>
 generally be released about 6 months after 2.2.0. Maintenance releases happen as needed
 in between feature releases. Major releases do not happen according to a fixed schedule.</p>
 
-<h3>Spark 3.1 Release Window</h3>
+<h3>Spark 3.2 Release Window</h3>
 
 <table>
   <thead>
@@ -339,15 +339,15 @@ in between feature releases. Major releases do not happen according to a fixed s
   </thead>
   <tbody>
     <tr>
-      <td>Early Dec 2020</td>
+      <td>June 1st 2021</td>
       <td>Code freeze. Release branch cut.</td>
     </tr>
     <tr>
-      <td>Mid Dec 2020</td>
+      <td>Mid June 2021</td>
       <td>QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.</td>
     </tr>
     <tr>
-      <td>Early Jan 2021</td>
+      <td>July 2021</td>
       <td>Release candidates (RC), voting, etc. until final release passes</td>
     </tr>
   </tbody>
@@ -360,8 +360,7 @@ For example, branch 2.3.x is no longer considered maintained as of September 201
 of 2.3.0 in February 2018. No more 2.3.x releases should be expected after that point, even for bug fixes.</p>
 
 <p>The last minor release within a major a release will typically be maintained for longer as an &#8220;LTS&#8221; release.
-For example, 2.4.0 was released in November 2018, but will likely see releases for more than 18 months,
-beyond May 2020.</p>
+For example, 2.4.0 was released in November 2nd 2018 and has been maintained for 29 months as of March 2021. 2.4.8 will be the last release and no more 2.4.x releases should be expected after that, even for bug fixes.</p>
 
 <h3>Spark 2.4 LTS Release Window</h3>
 
@@ -374,12 +373,8 @@ beyond May 2020.</p>
   </thead>
   <tbody>
     <tr>
-      <td>Jan 2020</td>
-      <td>Release 2.4.5</td>
-    </tr>
-    <tr>
-      <td>Jul 2020</td>
-      <td>Release 2.4.6</td>
+      <td>Mar 2021</td>
+      <td>Release 2.4.8</td>
     </tr>
   </tbody>
 </table>

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -103,13 +103,13 @@ In general, feature ("minor") releases occur about every 6 months. Hence, Spark 
 generally be released about 6 months after 2.2.0. Maintenance releases happen as needed
 in between feature releases. Major releases do not happen according to a fixed schedule.
 
-<h3>Spark 3.1 Release Window</h3>
+<h3>Spark 3.2 Release Window</h3>
 
 | Date  | Event |
 | ----- | ----- |
-| Early Dec 2020 | Code freeze. Release branch cut.|
-| Mid Dec 2020 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
-| Early Jan 2021 | Release candidates (RC), voting, etc. until final release passes|
+| June 1st 2021 | Code freeze. Release branch cut.|
+| Mid June 2021 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
+| July 2021 | Release candidates (RC), voting, etc. until final release passes|
 
 <h2>Maintenance Releases and EOL</h2>
 
@@ -118,12 +118,11 @@ For example, branch 2.3.x is no longer considered maintained as of September 201
 of 2.3.0 in February 2018. No more 2.3.x releases should be expected after that point, even for bug fixes.
 
 The last minor release within a major a release will typically be maintained for longer as an "LTS" release.
-For example, 2.4.0 was released in November 2018, but will likely see releases for more than 18 months,
-beyond May 2020.
+For example, 2.4.0 was released in November 2nd 2018 and has been maintained for 29 months as of March 2021. 2.4.8 will be the last release and no more 2.4.x releases should be expected after that, even for bug fixes.
+
 
 <h3>Spark 2.4 LTS Release Window</h3>
 
 | Date     | Event         |
 | -------- | ------------- |
-| Jan 2020 | Release 2.4.5 |
-| Jul 2020 | Release 2.4.6 |
+| Mar 2021 | Release 2.4.8 |


### PR DESCRIPTION
This PR aims to make our release windows up-to-date for Apache Spark 3.2.0 and 2.4.8.