### PR TITLE
Fix 3.2 release window

### DIFF
--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -339,15 +339,15 @@ in between feature releases. Major releases do not happen according to a fixed s
   </thead>
   <tbody>
     <tr>
-      <td>June 1st 2021</td>
+      <td>July 1st 2021</td>
       <td>Code freeze. Release branch cut.</td>
     </tr>
     <tr>
-      <td>Mid June 2021</td>
+      <td>Mid July 2021</td>
       <td>QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.</td>
     </tr>
     <tr>
-      <td>July 2021</td>
+      <td>August 2021</td>
       <td>Release candidates (RC), voting, etc. until final release passes</td>
     </tr>
   </tbody>

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -107,9 +107,9 @@ in between feature releases. Major releases do not happen according to a fixed s
 
 | Date  | Event |
 | ----- | ----- |
-| June 1st 2021 | Code freeze. Release branch cut.|
-| Mid June 2021 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
-| July 2021 | Release candidates (RC), voting, etc. until final release passes|
+| July 1st 2021 | Code freeze. Release branch cut.|
+| Mid July 2021 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
+| August 2021 | Release candidates (RC), voting, etc. until final release passes|
 
 <h2>Maintenance Releases and EOL</h2>
 


### PR DESCRIPTION
The 3.1 was released on Mar 2, so the target release day for 3.2 should be September 2 according to the 6 months release cycle.

Then the RC stage should start one month before the target release day, which is August.