### PR TITLE
update the spark-packages post

### DIFF
--- a/news/_posts/2021-04-28-new-repository-service.md
+++ b/news/_posts/2021-04-28-new-repository-service.md
@@ -11,10 +11,10 @@ meta:
   _edit_last: '4'
   _wpas_done_all: '1'
 ---
-The spark-packages team has spun up a new repository service at <a href="https://repos.spark-packages.org">https://repos.spark-packages.org</a> and it will be the new home for the artifacts on spark-packages.
+The <a href="https://spark-packages.org">spark-packages</a> team has spun up a new repository service at <a href="https://repos.spark-packages.org">https://repos.spark-packages.org</a> and it will be the new home for the artifacts on spark-packages.
 
 <a href="https://bintray.com/">Bintray</a>, the original repository service used for <a href="https://spark-packages.org/">https://spark-packages.org/</a>, is in its <a href="https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/">sunset process</a>, and will no longer be available from May 1st. To consume artifacts from the new repository service, please replace "dl.bintray.com/spark-packages/maven" with "repos.spark-packages.org" in the Maven pom files or sbt build files in your repositories.
 
-If you are using `--packages` to specify artifacts on spark-packages, with spark-submit, spark-shell, etc., you need to set the system env `DEFAULT_ARTIFACT_REPOSITORY` to `https://repos.spark-packages.org/`, before Spark 2.4.8, 3.0.3 and 3.1.2 are released.
+If you are using `--packages` to specify artifacts on spark-packages, with spark-submit, spark-shell, etc., you need to set the environment variable `DEFAULT_ARTIFACT_REPOSITORY` to `https://repos.spark-packages.org/`, before Spark 2.4.8, 3.0.3 and 3.1.2 are released.
 
 If you have any questions for using the new repository service, or any general questions for spark-packages, please reach out to feedback@spark-packages.org.

--- a/news/_posts/2021-04-28-new-repository-service.md
+++ b/news/_posts/2021-04-28-new-repository-service.md
@@ -11,8 +11,10 @@ meta:
   _edit_last: '4'
   _wpas_done_all: '1'
 ---
-We have spun up a new repository service at <a href="https://repos.spark-packages.org">https://repos.spark-packages.org</a> and it will be the new home for the artifacts on spark-packages.
+The spark-packages team has spun up a new repository service at <a href="https://repos.spark-packages.org">https://repos.spark-packages.org</a> and it will be the new home for the artifacts on spark-packages.
 
 <a href="https://bintray.com/">Bintray</a>, the original repository service used for <a href="https://spark-packages.org/">https://spark-packages.org/</a>, is in its <a href="https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/">sunset process</a>, and will no longer be available from May 1st. To consume artifacts from the new repository service, please replace "dl.bintray.com/spark-packages/maven" with "repos.spark-packages.org" in the Maven pom files or sbt build files in your repositories.
+
+If you are using `--packages` to specify artifacts on spark-packages, with spark-submit, spark-shell, etc., you need to set the system env `DEFAULT_ARTIFACT_REPOSITORY` to `https://repos.spark-packages.org/`, before Spark 2.4.8, 3.0.3 and 3.1.2 are released.
 
 If you have any questions for using the new repository service, or any general questions for spark-packages, please reach out to feedback@spark-packages.org.

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -207,7 +207,7 @@
       <h3 class="entry-title"><a href="/news/new-repository-service.html">New repository service for spark-packages</a></h3>
       <div class="entry-date">April 28, 2021</div>
     </header>
-    <div class="entry-content"><p>We have spun up a new repository service at <a href="https://repos.spark-packages.org">https://repos.spark-packages.org</a> and it will be the new home for the artifacts on spark-packages.</p>
+    <div class="entry-content"><p>The spark-packages team has spun up a new repository service at <a href="https://repos.spark-packages.org">https://repos.spark-packages.org</a> and it will be the new home for the artifacts on spark-packages.</p>
 </div>
   </article>
 

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -207,7 +207,7 @@
       <h3 class="entry-title"><a href="/news/new-repository-service.html">New repository service for spark-packages</a></h3>
       <div class="entry-date">April 28, 2021</div>
     </header>
-    <div class="entry-content"><p>The spark-packages team has spun up a new repository service at <a href="https://repos.spark-packages.org">https://repos.spark-packages.org</a> and it will be the new home for the artifacts on spark-packages.</p>
+    <div class="entry-content"><p>The <a href="https://spark-packages.org">spark-packages</a> team has spun up a new repository service at <a href="https://repos.spark-packages.org">https://repos.spark-packages.org</a> and it will be the new home for the artifacts on spark-packages.</p>
 </div>
   </article>
 

--- a/site/news/new-repository-service.html
+++ b/site/news/new-repository-service.html
@@ -203,9 +203,11 @@
     <h2>New repository service for spark-packages</h2>
 
 
-<p>We have spun up a new repository service at <a href="https://repos.spark-packages.org">https://repos.spark-packages.org</a> and it will be the new home for the artifacts on spark-packages.</p>
+<p>The spark-packages team has spun up a new repository service at <a href="https://repos.spark-packages.org">https://repos.spark-packages.org</a> and it will be the new home for the artifacts on spark-packages.</p>
 
 <p><a href="https://bintray.com/">Bintray</a>, the original repository service used for <a href="https://spark-packages.org/">https://spark-packages.org/</a>, is in its <a href="https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/">sunset process</a>, and will no longer be available from May 1st. To consume artifacts from the new repository service, please replace &#8220;dl.bintray.com/spark-packages/maven&#8221; with &#8220;repos.spark-packages.org&#8221; in the Maven pom files or sbt build files in your repositories.</p>
+
+<p>If you are using <code class="language-plaintext highlighter-rouge">--packages</code> to specify artifacts on spark-packages, with spark-submit, spark-shell, etc., you need to set the system env <code class="language-plaintext highlighter-rouge">DEFAULT_ARTIFACT_REPOSITORY</code> to <code class="language-plaintext highlighter-rouge">https://repos.spark-packages.org/</code>, before Spark 2.4.8, 3.0.3 and 3.1.2 are released.</p>
 
 <p>If you have any questions for using the new repository service, or any general questions for spark-packages, please reach out to feedback@spark-packages.org.</p>
 

--- a/site/news/new-repository-service.html
+++ b/site/news/new-repository-service.html
@@ -203,11 +203,11 @@
     <h2>New repository service for spark-packages</h2>
 
 
-<p>The spark-packages team has spun up a new repository service at <a href="https://repos.spark-packages.org">https://repos.spark-packages.org</a> and it will be the new home for the artifacts on spark-packages.</p>
+<p>The <a href="https://spark-packages.org">spark-packages</a> team has spun up a new repository service at <a href="https://repos.spark-packages.org">https://repos.spark-packages.org</a> and it will be the new home for the artifacts on spark-packages.</p>
 
 <p><a href="https://bintray.com/">Bintray</a>, the original repository service used for <a href="https://spark-packages.org/">https://spark-packages.org/</a>, is in its <a href="https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/">sunset process</a>, and will no longer be available from May 1st. To consume artifacts from the new repository service, please replace &#8220;dl.bintray.com/spark-packages/maven&#8221; with &#8220;repos.spark-packages.org&#8221; in the Maven pom files or sbt build files in your repositories.</p>
 
-<p>If you are using <code class="language-plaintext highlighter-rouge">--packages</code> to specify artifacts on spark-packages, with spark-submit, spark-shell, etc., you need to set the system env <code class="language-plaintext highlighter-rouge">DEFAULT_ARTIFACT_REPOSITORY</code> to <code class="language-plaintext highlighter-rouge">https://repos.spark-packages.org/</code>, before Spark 2.4.8, 3.0.3 and 3.1.2 are released.</p>
+<p>If you are using <code class="language-plaintext highlighter-rouge">--packages</code> to specify artifacts on spark-packages, with spark-submit, spark-shell, etc., you need to set the environment variable <code class="language-plaintext highlighter-rouge">DEFAULT_ARTIFACT_REPOSITORY</code> to <code class="language-plaintext highlighter-rouge">https://repos.spark-packages.org/</code>, before Spark 2.4.8, 3.0.3 and 3.1.2 are released.</p>
 
 <p>If you have any questions for using the new repository service, or any general questions for spark-packages, please reach out to feedback@spark-packages.org.</p>
 


### PR DESCRIPTION
This is a followup of https://github.com/apache/spark-website/pull/333 , to refine the post:
1. technically spark-packages is not owned by the Apache Spark project, so it should say "the spark-packages team"
2. mention a workaround for people using `--packages`, before the new spark releases are out.