### PR TITLE
Update the messages for the new repository service

### DIFF
--- a/news/_posts/2021-04-28-new-repository-service.md
+++ b/news/_posts/2021-04-28-new-repository-service.md
@@ -15,6 +15,6 @@ The <a href="https://spark-packages.org">spark-packages</a> team has spun up a n
 
 <a href="https://bintray.com/">Bintray</a>, the original repository service used for <a href="https://spark-packages.org/">https://spark-packages.org/</a>, is in its <a href="https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/">sunset process</a>, and will no longer be available from May 1st. To consume artifacts from the new repository service, please replace "dl.bintray.com/spark-packages/maven" with "repos.spark-packages.org" in the Maven pom files or sbt build files in your repositories.
 
-If you are using `--packages` to specify artifacts on spark-packages, with spark-submit, spark-shell, etc., you need to set the environment variable `DEFAULT_ARTIFACT_REPOSITORY` to `https://repos.spark-packages.org/`, before Spark 2.4.8, 3.0.3 and 3.1.2 are released.
+If you are using `--packages` to specify artifacts on spark-packages, with spark-submit, spark-shell, etc., you will have to manually download and install the artifacts, before Spark 2.4.8, 3.0.3 and 3.1.2 are released.
 
 If you have any questions for using the new repository service, or any general questions for spark-packages, please reach out to feedback@spark-packages.org.

--- a/site/news/new-repository-service.html
+++ b/site/news/new-repository-service.html
@@ -207,7 +207,7 @@
 
 <p><a href="https://bintray.com/">Bintray</a>, the original repository service used for <a href="https://spark-packages.org/">https://spark-packages.org/</a>, is in its <a href="https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/">sunset process</a>, and will no longer be available from May 1st. To consume artifacts from the new repository service, please replace &#8220;dl.bintray.com/spark-packages/maven&#8221; with &#8220;repos.spark-packages.org&#8221; in the Maven pom files or sbt build files in your repositories.</p>
 
-<p>If you are using <code class="language-plaintext highlighter-rouge">--packages</code> to specify artifacts on spark-packages, with spark-submit, spark-shell, etc., you need to set the environment variable <code class="language-plaintext highlighter-rouge">DEFAULT_ARTIFACT_REPOSITORY</code> to <code class="language-plaintext highlighter-rouge">https://repos.spark-packages.org/</code>, before Spark 2.4.8, 3.0.3 and 3.1.2 are released.</p>
+<p>If you are using <code class="language-plaintext highlighter-rouge">--packages</code> to specify artifacts on spark-packages, with spark-submit, spark-shell, etc., you will have to manually download and install the artifacts, before Spark 2.4.8, 3.0.3 and 3.1.2 are released.</p>
 
 <p>If you have any questions for using the new repository service, or any general questions for spark-packages, please reach out to feedback@spark-packages.org.</p>
 


### PR DESCRIPTION
In SparkSubmit, we use the same environment variable `DEFAULT_ARTIFACT_REPOSITORY` for both central and spark-packages. So it will cause other problems if setting It to `https://repos.spark-packages.org/`.

In this PR we change the workaround to manually download the artifacts.