### PR TITLE
Update release process

### DIFF
--- a/release-process.md
+++ b/release-process.md
@@ -203,10 +203,6 @@ $ svn rm https://dist.apache.org/repos/dist/release/spark/spark-1.1.0
 You will also need to update `js/download.js` to indicate the release is not mirrored
 anymore, so that the correct links are generated on the site.
 
-Also take a moment to check `HiveExternalCatalogVersionsSuite.scala` starting with branch-2.2
-and see if it needs to be adjusted, since that test relies on mirrored downloads of previous
-releases.
-
 
 <h4>Update the Spark Apache Repository</h4>
 
@@ -316,15 +312,6 @@ $ git shortlog v1.1.1 --grep "$EXPR" > contrib.txt
 # Large patch list (300+ lines)
 $ git log v1.1.1 --grep "$expr" --shortstat --oneline | grep -B 1 -e "[3-9][0-9][0-9] insert" -e "[1-9][1-9][1-9][1-9] insert" | grep SPARK > large-patches.txt
 ```
-
-<h4>Update `HiveExternalCatalogVersionsSuite`</h4>
-
-When a new release occurs, `PROCESS_TABLES.testingVersions` in `HiveExternalCatalogVersionsSuite`
-must be updated shortly thereafter. This list should contain the latest release in all active
-maintenance branches, and no more.
-For example, as of this writing, it has value `val testingVersions = Seq("2.1.3", "2.2.2", "2.3.2")`.
-"2.4.0" will be added to the list when it's released. "2.1.3" will be removed (and removed from the Spark dist mirrors)
-when the branch is no longer maintained. "2.3.2" will become "2.3.3" when "2.3.3" is released.
 
 <h4>Create an Announcement</h4>
 

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -398,10 +398,6 @@ To delete older versions simply use svn rm:</p>
 <p>You will also need to update <code class="language-plaintext highlighter-rouge">js/download.js</code> to indicate the release is not mirrored
 anymore, so that the correct links are generated on the site.</p>
 
-<p>Also take a moment to check <code class="language-plaintext highlighter-rouge">HiveExternalCatalogVersionsSuite.scala</code> starting with branch-2.2
-and see if it needs to be adjusted, since that test relies on mirrored downloads of previous
-releases.</p>
-
 <h4>Update the Spark Apache Repository</h4>
 
 <p>Check out the tagged commit for the release candidate that passed and apply the correct version tag.</p>
@@ -507,15 +503,6 @@ $ git shortlog v1.1.1 --grep "$EXPR" &gt; contrib.txt
 # Large patch list (300+ lines)
 $ git log v1.1.1 --grep "$expr" --shortstat --oneline | grep -B 1 -e "[3-9][0-9][0-9] insert" -e "[1-9][1-9][1-9][1-9] insert" | grep SPARK &gt; large-patches.txt
 </code></pre></div></div>
-
-<h4>Update `HiveExternalCatalogVersionsSuite`</h4>
-
-<p>When a new release occurs, <code class="language-plaintext highlighter-rouge">PROCESS_TABLES.testingVersions</code> in <code class="language-plaintext highlighter-rouge">HiveExternalCatalogVersionsSuite</code>
-must be updated shortly thereafter. This list should contain the latest release in all active
-maintenance branches, and no more.
-For example, as of this writing, it has value <code class="language-plaintext highlighter-rouge">val testingVersions = Seq("2.1.3", "2.2.2", "2.3.2")</code>.
-&#8220;2.4.0&#8221; will be added to the list when it&#8217;s released. &#8220;2.1.3&#8221; will be removed (and removed from the Spark dist mirrors)
-when the branch is no longer maintained. &#8220;2.3.2&#8221; will become &#8220;2.3.3&#8221; when &#8220;2.3.3&#8221; is released.</p>
 
 <h4>Create an Announcement</h4>
 

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -876,11 +876,7 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/screencasts/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>https://spark.apache.org/streaming/</loc>
+  <loc>https://spark.apache.org/graphx/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
@@ -892,11 +888,15 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
+  <loc>https://spark.apache.org/screencasts/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/sql/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/graphx/</loc>
+  <loc>https://spark.apache.org/streaming/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -876,7 +876,11 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/graphx/</loc>
+  <loc>https://spark.apache.org/screencasts/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/streaming/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
@@ -888,15 +892,11 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/screencasts/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
   <loc>https://spark.apache.org/sql/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/streaming/</loc>
+  <loc>https://spark.apache.org/graphx/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>


### PR DESCRIPTION
`HiveExternalCatalogVersionsSuite` now doesn't need to manually update for `testingVersions`. It automatically gets the latest releases now.