### PR TITLE
Update website for 2.4.8 release

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -16,6 +16,7 @@ navigation:
   <li><a href="{{site.baseurl}}/docs/3.0.2/">Spark 3.0.2</a></li>
   <li><a href="{{site.baseurl}}/docs/3.0.1/">Spark 3.0.1</a></li>
   <li><a href="{{site.baseurl}}/docs/3.0.0/">Spark 3.0.0</a></li>
+  <li><a href="{{site.baseurl}}/docs/2.4.8/">Spark 2.4.8</a></li>
   <li><a href="{{site.baseurl}}/docs/2.4.7/">Spark 2.4.7</a></li>
   <li><a href="{{site.baseurl}}/docs/2.4.6/">Spark 2.4.6</a></li>
   <li><a href="{{site.baseurl}}/docs/2.4.5/">Spark 2.4.5</a></li>

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -26,7 +26,7 @@ var packagesV10 = [hadoop2p7, hadoop3p2, hadoopFree, sources];
 
 addRelease("3.1.1", new Date("03/02/2021"), packagesV10, true);
 addRelease("3.0.2", new Date("02/19/2021"), packagesV10, true);
-addRelease("2.4.7", new Date("09/12/2020"), packagesV9, true);
+addRelease("2.4.8", new Date("05/17/2021"), packagesV9, true);
 
 function append(el, contents) {
   el.innerHTML += contents;

--- a/news/_posts/2021-05-17-spark-2-4-8-released.md
+++ b/news/_posts/2021-05-17-spark-2-4-8-released.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: Spark 2.4.8 released
+categories:
+- News
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+We are happy to announce the availability of <a href="{{site.baseurl}}/releases/spark-release-2-4-8.html" title="Spark Release 2.4.8">Spark 2.4.8</a>! Visit the <a href="{{site.baseurl}}/releases/spark-release-2-4-8.html" title="Spark Release 2.4.8">release notes</a> to read about the new features, or <a href="{{site.baseurl}}/downloads.html">download</a> the release today.

--- a/releases/_posts/2021-05-17-spark-release-2-4-8.md
+++ b/releases/_posts/2021-05-17-spark-release-2-4-8.md
@@ -1,0 +1,93 @@
+---
+layout: post
+title: Spark Release 2.4.8
+categories: []
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+
+Spark 2.4.8 is a maintenance release containing stability, correctness, and security fixes. This release is based on the branch-2.4 maintenance branch of Spark. We strongly recommend all 2.4 users to upgrade to this stable release.
+
+### Notable changes
+
+  - [[SPARK-21492]](https://issues.apache.org/jira/browse/SPARK-21492): Fix memory leak in SortMergeJoin
+  - [[SPARK-25271]](https://issues.apache.org/jira/browse/SPARK-25271): Creating parquet table with all the column null throws exception
+  - [[SPARK-26625]](https://issues.apache.org/jira/browse/SPARK-26625): spark.redaction.regex should include oauthToken
+  - [[SPARK-26645]](https://issues.apache.org/jira/browse/SPARK-26645): CSV infer schema bug infers decimal(9,-1)
+  - [[SPARK-27575]](https://issues.apache.org/jira/browse/SPARK-27575): Spark overwrites existing value of spark.yarn.dist.* instead of merging value
+  - [[SPARK-27872]](https://issues.apache.org/jira/browse/SPARK-27872): Driver and executors use a different service account breaking pull secrets
+  - [[SPARK-29574]](https://issues.apache.org/jira/browse/SPARK-27872): spark with user provided hadoop doesn't work on kubernetes
+  - [[SPARK-30201]](https://issues.apache.org/jira/browse/SPARK-30201): HiveOutputWriter standardOI should use ObjectInspectorCopyOption.DEFAULT
+  - [[SPARK-32635]](https://issues.apache.org/jira/browse/SPARK-32635): When pyspark.sql.functions.lit() function is used with dataframe cache, it returns wrong result
+  - [[SPARK-32708]](https://issues.apache.org/jira/browse/SPARK-32708): Query optimization fails to reuse exchange with DataSourceV2
+  - [[SPARK-32715]](https://issues.apache.org/jira/browse/SPARK-32715): Broadcast block pieces may memory leak
+  - [[SPARK-32738]](https://issues.apache.org/jira/browse/SPARK-32738): thread safe endpoints may hang due to fatal error
+  - [[SPARK-32794]](https://issues.apache.org/jira/browse/SPARK-32794): Rare corner case error in micro-batch engine with some stateful queries + no-data-batches + V1 streaming sources
+  - [[SPARK-32815]](https://issues.apache.org/jira/browse/SPARK-32815): Fix LibSVM data source loading error on file paths with glob metacharacters
+  - [[SPARK-32836]](https://issues.apache.org/jira/browse/SPARK-32836): Fix DataStreamReaderWriterSuite to check writer options correctly
+  - [[SPARK-32872]](https://issues.apache.org/jira/browse/SPARK-32872): BytesToBytesMap at MAX_CAPACITY exceeds growth threshold
+  - [[SPARK-32900]](https://issues.apache.org/jira/browse/SPARK-32900): UnsafeExternalSorter.SpillableIterator cannot spill when there are NULLs in the input and radix sorting is used.
+  - [[SPARK-32901]](https://issues.apache.org/jira/browse/SPARK-32901): UnsafeExternalSorter may cause a SparkOutOfMemoryError to be thrown while spilling
+  - [[SPARK-32908]](https://issues.apache.org/jira/browse/SPARK-32908): percentile_approx() returns incorrect results
+  - [[SPARK-32999]](https://issues.apache.org/jira/browse/SPARK-32999): TreeNode.nodeName should not throw malformed class name error
+  - [[SPARK-33094]](https://issues.apache.org/jira/browse/SPARK-33094): ORC format does not propagate Hadoop config from DS options to underlying HDFS file system
+  - [[SPARK-33101]](https://issues.apache.org/jira/browse/SPARK-33101): LibSVM format does not propagate Hadoop config from DS options to underlying HDFS file system
+  - [[SPARK-33131]](https://issues.apache.org/jira/browse/SPARK-33131): Fix grouping sets with having clause can not resolve qualified col name
+  - [[SPARK-33136]](https://issues.apache.org/jira/browse/SPARK-33136): Handling nullability for complex types is broken during resolution of V2 write command
+  - [[SPARK-33183]](https://issues.apache.org/jira/browse/SPARK-33183): Bug in optimizer rule EliminateSorts
+  - [[SPARK-33230]](https://issues.apache.org/jira/browse/SPARK-33230): FileOutputWriter jobs have duplicate JobIDs if launched in same second
+  - [[SPARK-33268]](https://issues.apache.org/jira/browse/SPARK-33268): Fix bugs for casting data from/to PythonUserDefinedType
+  - [[SPARK-33277]](https://issues.apache.org/jira/browse/SPARK-33277): Python/Pandas UDF right after off-heap vectorized reader could cause executor crash.
+  - [[SPARK-33292]](https://issues.apache.org/jira/browse/SPARK-33292): Make Literal ArrayBasedMapData string representation disambiguous
+  - [[SPARK-33338]](https://issues.apache.org/jira/browse/SPARK-33338): GROUP BY using literal map should not fail
+  - [[SPARK-33339]](https://issues.apache.org/jira/browse/SPARK-33339): Pyspark application will hang due to non Exception
+  - [[SPARK-33372]](https://issues.apache.org/jira/browse/SPARK-33372): Fix InSet bucket pruning
+  - [[SPARK-33472]](https://issues.apache.org/jira/browse/SPARK-33472): IllegalArgumentException when applying RemoveRedundantSorts before EnsureRequirements
+  - [[SPARK-33588]](https://issues.apache.org/jira/browse/SPARK-33588): Partition spec in SHOW TABLE EXTENDED doesn't respect `spark.sql.caseSensitive`
+  - [[SPARK-33593]](https://issues.apache.org/jira/browse/SPARK-33593): Vector reader got incorrect data with binary partition value
+  - [[SPARK-33726]](https://issues.apache.org/jira/browse/SPARK-33726): Duplicate field names causes wrong answers during aggregation
+  - [[SPARK-33733]](https://issues.apache.org/jira/browse/SPARK-33733): PullOutNondeterministic should check and collect deterministic field
+  - [[SPARK-33756]](https://issues.apache.org/jira/browse/SPARK-33756): BytesToBytesMap's iterator hasNext method should be idempotent.
+  - [[SPARK-34125]](https://issues.apache.org/jira/browse/SPARK-34125): Make EventLoggingListener.codecMap thread-safe
+  - [[SPARK-34187]](https://issues.apache.org/jira/browse/SPARK-34187): Use available offset range obtained during polling when checking offset validation
+  - [[SPARK-34212]](https://issues.apache.org/jira/browse/SPARK-34212): For parquet table, after changing the precision and scale of decimal type in hive, spark reads incorrect value
+  - [[SPARK-34229]](https://issues.apache.org/jira/browse/SPARK-34229): Avro should read decimal values with the file schema
+  - [[SPARK-34260]](https://issues.apache.org/jira/browse/SPARK-34260): UnresolvedException when creating temp view twice
+  - [[SPARK-34273]](https://issues.apache.org/jira/browse/SPARK-34273): Do not reregister BlockManager when SparkContext is stopped
+  - [[SPARK-34318]](https://issues.apache.org/jira/browse/SPARK-34318): Dataset.colRegex should work with column names and qualifiers which contain newlines
+  - [[SPARK-34327]](https://issues.apache.org/jira/browse/SPARK-34327): Omit inlining passwords during build process.
+  - [[SPARK-34596]](https://issues.apache.org/jira/browse/SPARK-34596): NewInstance.doGenCode should not throw malformed class name error
+  - [[SPARK-34607]](https://issues.apache.org/jira/browse/SPARK-34607): NewInstance.resolved should not throw malformed class name error
+  - [[SPARK-34724]](https://issues.apache.org/jira/browse/SPARK-34724): Fix Interpreted evaluation by using getClass.getMethod instead of getDeclaredMethod
+  - [[SPARK-34726]](https://issues.apache.org/jira/browse/SPARK-34726): Fix collectToPython timeouts
+  - [[SPARK-34776]](https://issues.apache.org/jira/browse/SPARK-34776): Catalyst error on on certain struct operation (Couldn't find _gen_alias_)
+  - [[SPARK-34811]](https://issues.apache.org/jira/browse/SPARK-34811): Redact fs.s3a.access.key like secret and token
+  - [[SPARK-34855]](https://issues.apache.org/jira/browse/SPARK-34855): SparkContext - avoid using local lazy val
+  - [[SPARK-34876]](https://issues.apache.org/jira/browse/SPARK-34876): Non-nullable aggregates can return NULL in a correlated subquery
+  - [[SPARK-34909]](https://issues.apache.org/jira/browse/SPARK-34909): conv() does not convert negative inputs to unsigned correctly
+  - [[SPARK-34939]](https://issues.apache.org/jira/browse/SPARK-34939): Throw fetch failure exception when unable to deserialize broadcasted map statuses
+  - [[SPARK-34963]](https://issues.apache.org/jira/browse/SPARK-34963): Nested column pruning fails to extract case-insensitive struct field from array
+  - [[SPARK-35080]](https://issues.apache.org/jira/browse/SPARK-35080): Correlated subqueries with equality predicates can return wrong results
+  - [[SPARK-35278]](https://issues.apache.org/jira/browse/SPARK-35278): Invoke should find the method with correct number of parameters
+  - [[SPARK-35288]](https://issues.apache.org/jira/browse/SPARK-35288): StaticInvoke should find the method without exact argument classes match
+
+### Dependency Changes
+  - [[SPARK-30228]](https://issues.apache.org/jira/browse/SPARK-30228): Update zstd-jni to 1.4.4-3
+  - [[SPARK-33831]](https://issues.apache.org/jira/browse/SPARK-33831): Update Jetty to 9.4.34
+  - [[SPARK-33333]](https://issues.apache.org/jira/browse/SPARK-33333): Upgrade Jetty to 9.4.28.v20200408
+  - [[SPARK-33405]](https://issues.apache.org/jira/browse/SPARK-33405): Upgrade commons-compress to 1.20
+  - [[SPARK-33725]](https://issues.apache.org/jira/browse/SPARK-33725): Upgrade snappy-java to 1.1.8.2
+  - [[SPARK-34449]](https://issues.apache.org/jira/browse/SPARK-34449): Upgrade Jetty to fix CVE-2020-27218
+  - [[SPARK-34988]](https://issues.apache.org/jira/browse/SPARK-34988): Upgrade Jetty for CVE-2021-28165
+
+### Known issues
+
+You can consult JIRA for the [detailed changes](https://s.apache.org/spark-2.4.8).
+
+We would like to acknowledge all community members for contributing patches to this release.
+

--- a/site/committers.html
+++ b/site/committers.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/community.html
+++ b/site/community.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
@@ -209,6 +209,7 @@
   <li><a href="/docs/3.0.2/">Spark 3.0.2</a></li>
   <li><a href="/docs/3.0.1/">Spark 3.0.1</a></li>
   <li><a href="/docs/3.0.0/">Spark 3.0.0</a></li>
+  <li><a href="/docs/2.4.8/">Spark 2.4.8</a></li>
   <li><a href="/docs/2.4.7/">Spark 2.4.7</a></li>
   <li><a href="/docs/2.4.6/">Spark 2.4.6</a></li>
   <li><a href="/docs/2.4.5/">Spark 2.4.5</a></li>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/error-message-guidelines.html
+++ b/site/error-message-guidelines.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/examples.html
+++ b/site/examples.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/faq.html
+++ b/site/faq.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/history.html
+++ b/site/history.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/index.html
+++ b/site/index.html
@@ -164,6 +164,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -172,9 +175,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -26,7 +26,7 @@ var packagesV10 = [hadoop2p7, hadoop3p2, hadoopFree, sources];
 
 addRelease("3.1.1", new Date("03/02/2021"), packagesV10, true);
 addRelease("3.0.2", new Date("02/19/2021"), packagesV10, true);
-addRelease("2.4.7", new Date("09/12/2020"), packagesV9, true);
+addRelease("2.4.8", new Date("05/17/2021"), packagesV9, true);
 
 function append(el, contents) {
   el.innerHTML += contents;

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
@@ -201,6 +201,15 @@
 
   <div class="col-md-9 col-md-pull-3">
     <h2 id="spark-news">Spark News</h2>
+
+<article class="hentry">
+    <header class="entry-header">
+      <h3 class="entry-title"><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a></h3>
+      <div class="entry-date">May 17, 2021</div>
+    </header>
+    <div class="entry-content"><p>We are happy to announce the availability of <a href="/releases/spark-release-2-4-8.html" title="Spark Release 2.4.8">Spark 2.4.8</a>! Visit the <a href="/releases/spark-release-2-4-8.html" title="Spark Release 2.4.8">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+</div>
+  </article>
 
 <article class="hentry">
     <header class="entry-header">

--- a/site/news/new-repository-service.html
+++ b/site/news/new-repository-service.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/next-official-release-spark-3.1.1.html
+++ b/site/news/next-official-release-spark-3.1.1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/plan-for-dropping-python-2-support.html
+++ b/site/news/plan-for-dropping-python-2-support.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-3-released.html
+++ b/site/news/spark-2-1-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-2-released.html
+++ b/site/news/spark-2-2-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-1-released.html
+++ b/site/news/spark-2-3-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-2-released.html
+++ b/site/news/spark-2-3-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-3-released.html
+++ b/site/news/spark-2-3-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-4-released.html
+++ b/site/news/spark-2-3-4-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-0-released.html
+++ b/site/news/spark-2-4-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-1-released.html
+++ b/site/news/spark-2-4-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-2-released.html
+++ b/site/news/spark-2-4-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-3-released.html
+++ b/site/news/spark-2-4-3-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-4-released.html
+++ b/site/news/spark-2-4-4-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-5-released.html
+++ b/site/news/spark-2-4-5-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-6.html
+++ b/site/news/spark-2-4-6.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-7-released.html
+++ b/site/news/spark-2-4-7-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-8-released.html
+++ b/site/news/spark-2-4-8-released.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark 1.6.0 released | Apache Spark
+     Spark 2.4.8 released | Apache Spark
     
   </title>
 
@@ -200,16 +200,10 @@
   </div>
 
   <div class="col-md-9 col-md-pull-3">
-    <h2>Spark 1.6.0 released</h2>
+    <h2>Spark 2.4.8 released</h2>
 
 
-<p>We are happy to announce the availability of 
-<a href="/releases/spark-release-1-6-0.html" title="Spark Release 1.6.0">Spark 1.6.0</a>! 
-Spark 1.6.0 is the seventh release on the API-compatible 1.X line. 
-With this release the Spark community continues to grow, with contributions from 248 developers!</p>
-
-<p>Visit the <a href="/releases/spark-release-1-6-0.html" title="Spark Release 1.6.0">release notes</a> 
-to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+<p>We are happy to announce the availability of <a href="/releases/spark-release-2-4-8.html" title="Spark Release 2.4.8">Spark 2.4.8</a>! Visit the <a href="/releases/spark-release-2-4-8.html" title="Spark Release 2.4.8">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
 
 
 <p>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-0-released.html
+++ b/site/news/spark-3-0-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-1-released.html
+++ b/site/news/spark-3-0-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-2-released.html
+++ b/site/news/spark-3-0-2-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-1-released.html
+++ b/site/news/spark-3-1-1-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview.html
+++ b/site/news/spark-3.0.0-preview.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview2.html
+++ b/site/news/spark-3.0.0-preview2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-apr-2019-agenda-posted.html
+++ b/site/news/spark-ai-summit-apr-2019-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-june-2020-agenda-posted.html
+++ b/site/news/spark-ai-summit-june-2020-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-release-2-2-3.html
+++ b/site/news/spark-release-2-2-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2015.html
+++ b/site/news/spark-summit-east-agenda-posted-2015.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2016.html
+++ b/site/news/spark-summit-east-agenda-posted-2016.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-oct-2018-agenda-posted.html
+++ b/site/news/spark-summit-oct-2018-agenda-posted.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-3.html
+++ b/site/releases/spark-release-2-1-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-2.html
+++ b/site/releases/spark-release-2-2-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-3.html
+++ b/site/releases/spark-release-2-2-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-1.html
+++ b/site/releases/spark-release-2-3-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-2.html
+++ b/site/releases/spark-release-2-3-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-3.html
+++ b/site/releases/spark-release-2-3-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-4.html
+++ b/site/releases/spark-release-2-3-4.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-0.html
+++ b/site/releases/spark-release-2-4-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-1.html
+++ b/site/releases/spark-release-2-4-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-2.html
+++ b/site/releases/spark-release-2-4-2.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-3.html
+++ b/site/releases/spark-release-2-4-3.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-4.html
+++ b/site/releases/spark-release-2-4-4.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-5.html
+++ b/site/releases/spark-release-2-4-5.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-6.html
+++ b/site/releases/spark-release-2-4-6.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-7.html
+++ b/site/releases/spark-release-2-4-7.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-8.html
+++ b/site/releases/spark-release-2-4-8.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark Release 3.0.2 | Apache Spark
+     Spark Release 2.4.8 | Apache Spark
     
   </title>
 
@@ -200,61 +200,93 @@
   </div>
 
   <div class="col-md-9 col-md-pull-3">
-    <h2>Spark Release 3.0.2</h2>
+    <h2>Spark Release 2.4.8</h2>
 
 
-<p>Spark 3.0.2 is a maintenance release containing stability fixes. This release is based on the branch-3.0 maintenance branch of Spark. We strongly recommend all 3.0 users to upgrade to this stable release.</p>
+<p>Spark 2.4.8 is a maintenance release containing stability, correctness, and security fixes. This release is based on the branch-2.4 maintenance branch of Spark. We strongly recommend all 2.4 users to upgrade to this stable release.</p>
 
 <h3 id="notable-changes">Notable changes</h3>
 
 <ul>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-31511">[SPARK-31511]</a>: Make BytesToBytesMap iterator() thread-safe</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-21492">[SPARK-21492]</a>: Fix memory leak in SortMergeJoin</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-25271">[SPARK-25271]</a>: Creating parquet table with all the column null throws exception</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-26625">[SPARK-26625]</a>: spark.redaction.regex should include oauthToken</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-26645">[SPARK-26645]</a>: CSV infer schema bug infers decimal(9,-1)</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-27575">[SPARK-27575]</a>: Spark overwrites existing value of spark.yarn.dist.* instead of merging value</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-27872">[SPARK-27872]</a>: Driver and executors use a different service account breaking pull secrets</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-27872">[SPARK-29574]</a>: spark with user provided hadoop doesn&#8217;t work on kubernetes</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-30201">[SPARK-30201]</a>: HiveOutputWriter standardOI should use ObjectInspectorCopyOption.DEFAULT</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-32635">[SPARK-32635]</a>: When pyspark.sql.functions.lit() function is used with dataframe cache, it returns wrong result</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-32753">[SPARK-32753]</a>: Deduplicating and repartitioning the same column create duplicate rows with AQE</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-32764">[SPARK-32764]</a>: compare of -0.0 &lt; 0.0 return true</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-32840">[SPARK-32840]</a>: Invalid interval value can happen to be just adhesive with the unit</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32708">[SPARK-32708]</a>: Query optimization fails to reuse exchange with DataSourceV2</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32715">[SPARK-32715]</a>: Broadcast block pieces may memory leak</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32738">[SPARK-32738]</a>: thread safe endpoints may hang due to fatal error</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32794">[SPARK-32794]</a>: Rare corner case error in micro-batch engine with some stateful queries + no-data-batches + V1 streaming sources</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32815">[SPARK-32815]</a>: Fix LibSVM data source loading error on file paths with glob metacharacters</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32836">[SPARK-32836]</a>: Fix DataStreamReaderWriterSuite to check writer options correctly</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32872">[SPARK-32872]</a>: BytesToBytesMap at MAX_CAPACITY exceeds growth threshold</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32900">[SPARK-32900]</a>: UnsafeExternalSorter.SpillableIterator cannot spill when there are NULLs in the input and radix sorting is used.</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32901">[SPARK-32901]</a>: UnsafeExternalSorter may cause a SparkOutOfMemoryError to be thrown while spilling</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-32908">[SPARK-32908]</a>: percentile_approx() returns incorrect results</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-33019">[SPARK-33019]</a>: Use spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1 by default</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32999">[SPARK-32999]</a>: TreeNode.nodeName should not throw malformed class name error</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33094">[SPARK-33094]</a>: ORC format does not propagate Hadoop config from DS options to underlying HDFS file system</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33101">[SPARK-33101]</a>: LibSVM format does not propagate Hadoop config from DS options to underlying HDFS file system</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33131">[SPARK-33131]</a>: Fix grouping sets with having clause can not resolve qualified col name</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33136">[SPARK-33136]</a>: Handling nullability for complex types is broken during resolution of V2 write command</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-33183">[SPARK-33183]</a>: Bug in optimizer rule EliminateSorts</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-33260">[SPARK-33260]</a>: SortExec produces incorrect results if sortOrder is a Stream</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-33290">[SPARK-33290]</a>: SPARK-33507 REFRESH TABLE should invalidate cache even though the table itself may not be cached</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-33358">[SPARK-33358]</a>: Spark SQL CLI command processing loop can&#8217;t exit while one comand fail</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-33404">[SPARK-33404]</a>: &#8220;date_trunc&#8221; expression returns incorrect results</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-33435">[SPARK-33435]</a>: SPARK-33507 DSv2: REFRESH TABLE should invalidate caches</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-33591">[SPARK-33591]</a>: NULL is recognized as the &#8220;null&#8221; string in partition specs</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33230">[SPARK-33230]</a>: FileOutputWriter jobs have duplicate JobIDs if launched in same second</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33268">[SPARK-33268]</a>: Fix bugs for casting data from/to PythonUserDefinedType</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33277">[SPARK-33277]</a>: Python/Pandas UDF right after off-heap vectorized reader could cause executor crash.</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33292">[SPARK-33292]</a>: Make Literal ArrayBasedMapData string representation disambiguous</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33338">[SPARK-33338]</a>: GROUP BY using literal map should not fail</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33339">[SPARK-33339]</a>: Pyspark application will hang due to non Exception</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33372">[SPARK-33372]</a>: Fix InSet bucket pruning</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33472">[SPARK-33472]</a>: IllegalArgumentException when applying RemoveRedundantSorts before EnsureRequirements</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33588">[SPARK-33588]</a>: Partition spec in SHOW TABLE EXTENDED doesn&#8217;t respect <code class="language-plaintext highlighter-rouge">spark.sql.caseSensitive</code></li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-33593">[SPARK-33593]</a>: Vector reader got incorrect data with binary partition value</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-33726">[SPARK-33726]</a>: Duplicate field names causes wrong answers during aggregation</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-33819">[SPARK-33819]</a>: SingleFileEventLogFileReader/RollingEventLogFilesFileReader should be <code class="language-plaintext highlighter-rouge">package private</code></li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-33950">[SPARK-33950]</a>: ALTER TABLE .. DROP PARTITION doesn&#8217;t refresh cache</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-34011">[SPARK-34011]</a>: ALTER TABLE .. RENAME TO PARTITION doesn&#8217;t refresh cache</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-34027">[SPARK-34027]</a>: ALTER TABLE .. RECOVER PARTITIONS doesn&#8217;t refresh cache</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-34055">[SPARK-34055]</a>: ALTER TABLE .. ADD PARTITION doesn&#8217;t refresh cache</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33733">[SPARK-33733]</a>: PullOutNondeterministic should check and collect deterministic field</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33756">[SPARK-33756]</a>: BytesToBytesMap&#8217;s iterator hasNext method should be idempotent.</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34125">[SPARK-34125]</a>: Make EventLoggingListener.codecMap thread-safe</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-34187">[SPARK-34187]</a>: Use available offset range obtained during polling when checking offset validation</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-34212">[SPARK-34212]</a>: For parquet table, after changing the precision and scale of decimal type in hive, spark reads incorrect value</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-34213">[SPARK-34213]</a>: LOAD DATA doesn&#8217;t refresh v1 table cache</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-34229">[SPARK-34229]</a>: Avro should read decimal values with the file schema</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-34262">[SPARK-34262]</a>: ALTER TABLE .. SET LOCATION doesn&#8217;t refresh v1 table cache</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34260">[SPARK-34260]</a>: UnresolvedException when creating temp view twice</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34273">[SPARK-34273]</a>: Do not reregister BlockManager when SparkContext is stopped</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34318">[SPARK-34318]</a>: Dataset.colRegex should work with column names and qualifiers which contain newlines</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34327">[SPARK-34327]</a>: Omit inlining passwords during build process.</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34596">[SPARK-34596]</a>: NewInstance.doGenCode should not throw malformed class name error</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34607">[SPARK-34607]</a>: NewInstance.resolved should not throw malformed class name error</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34724">[SPARK-34724]</a>: Fix Interpreted evaluation by using getClass.getMethod instead of getDeclaredMethod</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34726">[SPARK-34726]</a>: Fix collectToPython timeouts</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34776">[SPARK-34776]</a>: Catalyst error on on certain struct operation (Couldn&#8217;t find <em>gen_alias</em>)</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34811">[SPARK-34811]</a>: Redact fs.s3a.access.key like secret and token</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34855">[SPARK-34855]</a>: SparkContext - avoid using local lazy val</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34876">[SPARK-34876]</a>: Non-nullable aggregates can return NULL in a correlated subquery</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34909">[SPARK-34909]</a>: conv() does not convert negative inputs to unsigned correctly</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34939">[SPARK-34939]</a>: Throw fetch failure exception when unable to deserialize broadcasted map statuses</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34963">[SPARK-34963]</a>: Nested column pruning fails to extract case-insensitive struct field from array</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35080">[SPARK-35080]</a>: Correlated subqueries with equality predicates can return wrong results</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35278">[SPARK-35278]</a>: Invoke should find the method with correct number of parameters</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35288">[SPARK-35288]</a>: StaticInvoke should find the method without exact argument classes match</li>
 </ul>
 
 <h3 id="dependency-changes">Dependency Changes</h3>
-
-<p>While being a maintence release we did still upgrade some dependencies in this release they are:</p>
-
 <ul>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-32691">[SPARK-32691]</a>: Bump commons-crypto to v1.1.0</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-30228">[SPARK-30228]</a>: Update zstd-jni to 1.4.4-3</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-33831">[SPARK-33831]</a>: Update Jetty to 9.4.34</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-33725">[SPARK-33725]</a>: Upgrade snappy-java to 1.1.8.2</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33333">[SPARK-33333]</a>: Upgrade Jetty to 9.4.28.v20200408</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-33405">[SPARK-33405]</a>: Upgrade commons-compress to 1.20</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33725">[SPARK-33725]</a>: Upgrade snappy-java to 1.1.8.2</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34449">[SPARK-34449]</a>: Upgrade Jetty to fix CVE-2020-27218</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34988">[SPARK-34988]</a>: Upgrade Jetty for CVE-2021-28165</li>
 </ul>
 
 <h3 id="known-issues">Known issues</h3>
-<ul>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-34449">[SPARK-34449]</a>: Upgrade Jetty to 9.4.36</li>
-</ul>
 
-<p>You can consult JIRA for the <a href="https://s.apache.org/spark-3.0.2">detailed changes</a>.</p>
+<p>You can consult JIRA for the <a href="https://s.apache.org/spark-2.4.8">detailed changes</a>.</p>
 
 <p>We would like to acknowledge all community members for contributing patches to this release.</p>
+
 
 
 <p>

--- a/site/releases/spark-release-3-0-0.html
+++ b/site/releases/spark-release-3-0-0.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-1.html
+++ b/site/releases/spark-release-3-0-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-1.html
+++ b/site/releases/spark-release-3-1-1.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/research.html
+++ b/site/research.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/security.html
+++ b/site/security.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -139,6 +139,14 @@
 </url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
+  <loc>https://spark.apache.org/releases/spark-release-2-4-8.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/news/spark-2-4-8-released.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/news/new-repository-service.html</loc>
   <changefreq>weekly</changefreq>
 </url>
@@ -876,11 +884,7 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/screencasts/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>https://spark.apache.org/streaming/</loc>
+  <loc>https://spark.apache.org/graphx/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
@@ -892,11 +896,15 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
+  <loc>https://spark.apache.org/screencasts/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/sql/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/graphx/</loc>
+  <loc>https://spark.apache.org/streaming/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
           <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
           <span class="small">(Apr 28, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
           <span class="small">(Feb 19, 2021)</span></li>
-        
-          <li><a href="/news/next-official-release-spark-3.1.1.html">Next official release: Spark 3.1.1</a>
-          <span class="small">(Jan 07, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>


### PR DESCRIPTION
Update website for 2.4.8 release:

Added:
releases/_posts/2021-05-17-spark-release-2-4-8.md
news/_posts/2021-05-17-spark-2-4-8-released.md 

Run `bundle exec jekyll build` to update html files.