### PR TITLE
Add new section "Update the version index of DocSearch" in release process

### DIFF
--- a/release-process.md
+++ b/release-process.md
@@ -213,6 +213,10 @@ $ git tag v1.1.1 v1.1.1-rc2 # the RC that passed
 $ git push apache v1.1.1
 ```
 
+<h4>Update the version index of DocSearch</h4>
+- In the  <a href="https://github.com/algolia/docsearch-configs">algolia/docsearch-configs</a> repository, create a PR to add the new release version into <a href="https://github.com/algolia/docsearch-configs/blob/master/configs/apache_spark.json">apache_spark.json</a>
+- In the Spark repository, update the `facetFilters` of file `docs/_config.yml` as the new release version in the release branch. 
+
 <h4>Update the Spark Website</h4>
 
 The website repository is located at

--- a/release-process.md
+++ b/release-process.md
@@ -214,8 +214,7 @@ $ git push apache v1.1.1
 ```
 
 <h4>Update the version index of DocSearch</h4>
-- In the  <a href="https://github.com/algolia/docsearch-configs">algolia/docsearch-configs</a> repository, create a PR to add the new release version into <a href="https://github.com/algolia/docsearch-configs/blob/master/configs/apache_spark.json">apache_spark.json</a>
-- In the Spark repository, update the `facetFilters` of file `docs/_config.yml` as the new release version in the release branch. 
+In the repository <a href="https://github.com/algolia/docsearch-configs">algolia/docsearch-configs</a>, submit a PR to add the new Spark version into the array `version` on <a href="https://github.com/algolia/docsearch-configs/blob/master/configs/apache_spark.json">apache_spark.json</a>.
 
 <h4>Update the Spark Website</h4>
 

--- a/release-process.md
+++ b/release-process.md
@@ -214,7 +214,7 @@ $ git push apache v1.1.1
 ```
 
 <h4>Update the version index of DocSearch</h4>
-In the repository <a href="https://github.com/algolia/docsearch-configs">algolia/docsearch-configs</a>, submit a PR to add the new Spark version into the array `version` on <a href="https://github.com/algolia/docsearch-configs/blob/master/configs/apache_spark.json">apache_spark.json</a>.
+In the repository <a href="https://github.com/algolia/docsearch-configs">algolia/docsearch-configs</a>, submit a PR to add the new Spark version in <a href="https://github.com/algolia/docsearch-configs/blob/master/configs/apache_spark.json">apache_spark.json</a>.
 
 <h4>Update the Spark Website</h4>
 

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -406,6 +406,9 @@ anymore, so that the correct links are generated on the site.</p>
 $ git push apache v1.1.1
 </code></pre></div></div>
 
+<h4>Update the version index of DocSearch</h4>
+<p>In the repository <a href="https://github.com/algolia/docsearch-configs">algolia/docsearch-configs</a>, submit a PR to add the new Spark version in <a href="https://github.com/algolia/docsearch-configs/blob/master/configs/apache_spark.json">apache_spark.json</a>.</p>
+
 <h4>Update the Spark Website</h4>
 
 <p>The website repository is located at


### PR DESCRIPTION
*Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request also. See README.md for more information. Please remove this message.*
Since Spark 3.1.1 release, the documentation site supports online searching via DocSearch. 

For the documentation sites which are not the latest one, the search results will point to themself as well, instead of showing results from https://spark.apache.org/docs/latest/. For example, after we release Spark 3.1.2, the search result of https://spark.apache.org/docs/3.1.1 will point to itself instead of the latest version.
This requires extra steps. We need to update the version index in both algolia/docsearch-configs and apache/spark for every release. 
For example, for the release of Spark 3.1.2, we need to make following updates
https://github.com/apache/spark/pull/32654
https://github.com/algolia/docsearch-configs/pull/4110

This PR is to add the steps in the release process.


Doc change preview:
![image](https://user-images.githubusercontent.com/1097932/119496595-7ed9cd80-bd18-11eb-8ee7-b4251905f1c2.png)
