### PR TITLE
Add 3.1.2 announcement news, release note and download link

### DIFF
--- a/_layouts/global.html
+++ b/_layouts/global.html
@@ -121,7 +121,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="{{site.baseurl}}/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="{{site.baseurl}}/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="{{site.baseurl}}/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="{{site.baseurl}}/faq.html">Frequently Asked Questions</a></li>
         </ul>

--- a/documentation.md
+++ b/documentation.md
@@ -12,6 +12,7 @@ navigation:
 <p>Setup instructions, programming guides, and other documentation are available for each stable version of Spark below:</p>
 
 <ul>
+  <li><a href="{{site.baseurl}}/docs/3.1.2/">Spark 3.1.2</a></li>
   <li><a href="{{site.baseurl}}/docs/3.1.1/">Spark 3.1.1</a></li>
   <li><a href="{{site.baseurl}}/docs/3.0.2/">Spark 3.0.2</a></li>
   <li><a href="{{site.baseurl}}/docs/3.0.1/">Spark 3.0.1</a></li>

--- a/downloads.md
+++ b/downloads.md
@@ -41,7 +41,7 @@ Spark artifacts are [hosted in Maven Central](https://search.maven.org/search?q=
 
     groupId: org.apache.spark
     artifactId: spark-core_2.12
-    version: 3.1.1
+    version: 3.1.2
 
 ### Installing with PyPi
 <a href="https://pypi.org/project/pyspark/">PySpark</a> is now available in pypi. To install just run `pip install pyspark`.

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -22,9 +22,11 @@ var scala2p12_hadoopFree = {pretty: "Pre-built with Scala 2.12 and user-provided
 var packagesV9 = [hadoop2p7, hadoop2p6, hadoopFree, scala2p12_hadoopFree, sources];
 // 3.0.0+
 var packagesV10 = [hadoop2p7, hadoop3p2, hadoopFree, sources];
+// 3.1.0+
+var packagesV11 = [hadoop3p2, hadoop2p7, hadoopFree, sources];
 
 
-addRelease("3.1.1", new Date("03/02/2021"), packagesV10, true);
+addRelease("3.1.2", new Date("06/01/2021"), packagesV11, true);
 addRelease("3.0.2", new Date("02/19/2021"), packagesV10, true);
 addRelease("2.4.8", new Date("05/17/2021"), packagesV9, true);
 

--- a/news/_posts/2021-06-01-spark-3-1-2-released.md
+++ b/news/_posts/2021-06-01-spark-3-1-2-released.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: Spark 3.1.2 released
+categories:
+- News
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+We are happy to announce the availability of <a href="{{site.baseurl}}/releases/spark-release-3-1-2.html" title="Spark Release 3.1.2">Spark 3.1.2</a>! Visit the <a href="{{site.baseurl}}/releases/spark-release-3-1-2.html" title="Spark Release 3.1.2">release notes</a> to read about the new features, or <a href="{{site.baseurl}}/downloads.html">download</a> the release today.

--- a/releases/_posts/2021-06-01-spark-release-3-1-2.md
+++ b/releases/_posts/2021-06-01-spark-release-3-1-2.md
@@ -1,0 +1,126 @@
+---
+layout: post
+title: Spark Release 3.1.2
+categories: []
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+
+Spark 3.1.2 is a maintenance release containing stability fixes. This release is based on the branch-3.1 maintenance branch of Spark. We strongly recommend all 3.1 users to upgrade to this stable release.
+
+### Notable changes
+
+  - [[SPARK-32924]](https://issues.apache.org/jira/browse/SPARK-32924): Web UI sort on duration is wrong
+  - [[SPARK-33482]](https://issues.apache.org/jira/browse/SPARK-33482): V2 Datasources that extend FileScan preclude exchange reuse
+  - [[SPARK-34361]](https://issues.apache.org/jira/browse/SPARK-34361): Dynamic allocation on K8s kills executors with running tasks
+  - [[SPARK-34392]](https://issues.apache.org/jira/browse/SPARK-34392): Invalid ID for offset-based ZoneId since Spark 3.0
+  - [[SPARK-34417]](https://issues.apache.org/jira/browse/SPARK-34417): DataFrameNaFunctions.fillMap(values: Seq[(String, Any)]) fails for column name having a dot
+  - [[SPARK-34436]](https://issues.apache.org/jira/browse/SPARK-34436): DPP support LIKE ANY/ALL
+  - [[SPARK-34473]](https://issues.apache.org/jira/browse/SPARK-34473): Avoid NPE in DataFrameReader.schema(StructType)
+  - [[SPARK-34482]](https://issues.apache.org/jira/browse/SPARK-34482): Correct the active SparkSession for streaming query
+  - [[SPARK-34490]](https://issues.apache.org/jira/browse/SPARK-34490): Table maybe resolved as a view if the table is dropped
+  - [[SPARK-34497]](https://issues.apache.org/jira/browse/SPARK-34497): JDBC connection provider is not removing kerberos credentials from JVM security context
+  - [[SPARK-34504]](https://issues.apache.org/jira/browse/SPARK-34504): Avoid unnecessary view resolving and remove the `performCheck` flag
+  - [[SPARK-34515]](https://issues.apache.org/jira/browse/SPARK-34515): Fix NPE if InSet contains null value during getPartitionsByFilter
+  - [[SPARK-34534]](https://issues.apache.org/jira/browse/SPARK-34534): New protocol FetchShuffleBlocks in OneForOneBlockFetcher lead to data loss or correctness
+  - [[SPARK-34543]](https://issues.apache.org/jira/browse/SPARK-34543): Respect case sensitivity in V1 ALTER TABLE .. SET LOCATION
+  - [[SPARK-34545]](https://issues.apache.org/jira/browse/SPARK-34545): Fix inconsistent results when applying 2 Python UDFs with different return type to 2 columns together
+  - [[SPARK-34547]](https://issues.apache.org/jira/browse/SPARK-34547): Resolve using child metadata attributes as fallback
+  - [[SPARK-34550]](https://issues.apache.org/jira/browse/SPARK-34550): Skip InSet null value during push filter to Hive metastore
+  - [[SPARK-34555]](https://issues.apache.org/jira/browse/SPARK-34555): Resolve metadata output from DataFrame
+  - [[SPARK-34556]](https://issues.apache.org/jira/browse/SPARK-34556): Checking duplicate static partition columns doesn't respect case sensitive conf
+  - [[SPARK-34561]](https://issues.apache.org/jira/browse/SPARK-34561): Cannot drop/add columns from/to a dataset of v2 `DESCRIBE TABLE`
+  - [[SPARK-34567]](https://issues.apache.org/jira/browse/SPARK-34567): CreateTableAsSelect should have metrics update too
+  - [[SPARK-34577]](https://issues.apache.org/jira/browse/SPARK-34577): Cannot drop/add columns from/to a dataset of v2 `DESCRIBE NAMESPACE`
+  - [[SPARK-34584]](https://issues.apache.org/jira/browse/SPARK-34584): When insert into a partition table with a illegal partition value, DSV2 behavior different as others
+  - [[SPARK-34596]](https://issues.apache.org/jira/browse/SPARK-34596): NewInstance.doGenCode should not throw malformed class name error
+  - [[SPARK-34599]](https://issues.apache.org/jira/browse/SPARK-34599): INSERT INTO OVERWRITE doesn't support partition columns containing dot for DSv2
+  - [[SPARK-34607]](https://issues.apache.org/jira/browse/SPARK-34607): NewInstance.resolved should not throw malformed class name error
+  - [[SPARK-34610]](https://issues.apache.org/jira/browse/SPARK-34610): Fix Python UDF used in GroupedAggPandasUDFTests
+  - [[SPARK-34613]](https://issues.apache.org/jira/browse/SPARK-34613): Fix view does not capture disable hint config
+  - [[SPARK-34630]](https://issues.apache.org/jira/browse/SPARK-34630): Add type hints of pyspark.__version__ and pyspark.sql.Column.contains
+  - [[SPARK-34639]](https://issues.apache.org/jira/browse/SPARK-34639): Always remove unnecessary Alias in Analyzer.resolveExpression
+  - [[SPARK-34674]](https://issues.apache.org/jira/browse/SPARK-34674): Spark app on k8s doesn't terminate without call to sparkContext.stop() method
+  - [[SPARK-34681]](https://issues.apache.org/jira/browse/SPARK-34681): Full outer shuffled hash join when building left side produces wrong result
+  - [[SPARK-34682]](https://issues.apache.org/jira/browse/SPARK-34682): Regression in "operating on canonicalized plan" check in CustomShuffleReaderExec
+  - [[SPARK-34697]](https://issues.apache.org/jira/browse/SPARK-34697): Allow DESCRIBE FUNCTION and SHOW FUNCTIONS explain about || (string concatenation operator)
+  - [[SPARK-34713]](https://issues.apache.org/jira/browse/SPARK-34713): Group by CreateStruct with ExtractValue fails analysis
+  - [[SPARK-34714]](https://issues.apache.org/jira/browse/SPARK-34714): collect_list(struct()) fails when used with GROUP BY
+  - [[SPARK-34719]](https://issues.apache.org/jira/browse/SPARK-34719): Fail if the view query has duplicated column names
+  - [[SPARK-34723]](https://issues.apache.org/jira/browse/SPARK-34723): Correct parameter type for subexpression elimination under whole-stage
+  - [[SPARK-34724]](https://issues.apache.org/jira/browse/SPARK-34724): Fix Interpreted evaluation by using getClass.getMethod instead of getDeclaredMethod
+  - [[SPARK-34727]](https://issues.apache.org/jira/browse/SPARK-34727): Difference in results of casting float to timestamp
+  - [[SPARK-34731]](https://issues.apache.org/jira/browse/SPARK-34731): ConcurrentModificationException in EventLoggingListener when redacting properties
+  - [[SPARK-34737]](https://issues.apache.org/jira/browse/SPARK-34737): Discrepancy between TIMESTAMP_SECONDS and cast from float
+  - [[SPARK-34756]](https://issues.apache.org/jira/browse/SPARK-34756): Fix FileScan equality check
+  - [[SPARK-34763]](https://issues.apache.org/jira/browse/SPARK-34763): col(), $"<name>" and df("name") should handle quoted column names properly
+  - [[SPARK-34766]](https://issues.apache.org/jira/browse/SPARK-34766): Do not capture maven config for views
+  - [[SPARK-34768]](https://issues.apache.org/jira/browse/SPARK-34768): Respect the default input buffer size in Univocity
+  - [[SPARK-34770]](https://issues.apache.org/jira/browse/SPARK-34770): InMemoryCatalog.tableExists should not fail if database doesn't exist
+  - [[SPARK-34772]](https://issues.apache.org/jira/browse/SPARK-34772): RebaseDateTime loadRebaseRecords should use Spark classloader instead of context
+  - [[SPARK-34776]](https://issues.apache.org/jira/browse/SPARK-34776): Catalyst error on on certain struct operation (Couldn't find _gen_alias_)
+  - [[SPARK-34790]](https://issues.apache.org/jira/browse/SPARK-34790): Fail in fetch shuffle blocks in batch when i/o encryption is enabled
+  - [[SPARK-34794]](https://issues.apache.org/jira/browse/SPARK-34794): Nested higher-order functions broken in DSL
+  - [[SPARK-34796]](https://issues.apache.org/jira/browse/SPARK-34796): Codegen compilation error for query with LIMIT operator and without AQE
+  - [[SPARK-34803]](https://issues.apache.org/jira/browse/SPARK-34803): Pass the raised ImportError if pandas or pyarrow fail to import
+  - [[SPARK-34811]](https://issues.apache.org/jira/browse/SPARK-34811): Redact fs.s3a.access.key like secret and token
+  - [[SPARK-34814]](https://issues.apache.org/jira/browse/SPARK-34814): LikeSimplification should handle NULL
+  - [[SPARK-34829]](https://issues.apache.org/jira/browse/SPARK-34829): Fix higher order function results
+  - [[SPARK-34833]](https://issues.apache.org/jira/browse/SPARK-34833): Apply right-padding correctly for correlated subqueries
+  - [[SPARK-34834]](https://issues.apache.org/jira/browse/SPARK-34834): There is a potential Netty memory leak in TransportResponseHandler
+  - [[SPARK-34840]](https://issues.apache.org/jira/browse/SPARK-34840): Fix cases of corruption in merged shuffle blocks that are pushed
+  - [[SPARK-34845]](https://issues.apache.org/jira/browse/SPARK-34845): computeAllMetrics may return partial metrics when some child metrics are missing
+  - [[SPARK-34876]](https://issues.apache.org/jira/browse/SPARK-34876): Non-nullable aggregates can return NULL in a correlated subquery
+  - [[SPARK-34897]](https://issues.apache.org/jira/browse/SPARK-34897): Support reconcile schemas based on index after nested column pruning
+  - [[SPARK-34909]](https://issues.apache.org/jira/browse/SPARK-34909): conv() does not convert negative inputs to unsigned correctly
+  - [[SPARK-34922]](https://issues.apache.org/jira/browse/SPARK-34922): Use better CBO cost function
+  - [[SPARK-34923]](https://issues.apache.org/jira/browse/SPARK-34923): Metadata output should not always be propagated
+  - [[SPARK-34926]](https://issues.apache.org/jira/browse/SPARK-34926): PartitionUtils.getPathFragment should handle null value
+  - [[SPARK-34939]](https://issues.apache.org/jira/browse/SPARK-34939): Throw fetch failure exception when unable to deserialize broadcasted map statuses
+  - [[SPARK-34948]](https://issues.apache.org/jira/browse/SPARK-34948): Add ownerReference to executor configmap to fix leakages
+  - [[SPARK-34949]](https://issues.apache.org/jira/browse/SPARK-34949): Executor.reportHeartBeat reregisters blockManager even when Executor is shutting down
+  - [[SPARK-34963]](https://issues.apache.org/jira/browse/SPARK-34963): Nested column pruning fails to extract case-insensitive struct field from array
+  - [[SPARK-34970]](https://issues.apache.org/jira/browse/SPARK-34970): Redact map-type options in the output of explain()
+  - [[SPARK-35014]](https://issues.apache.org/jira/browse/SPARK-35014): A foldable expression could not be replaced by an AttributeReference
+  - [[SPARK-35019]](https://issues.apache.org/jira/browse/SPARK-35019): Improve type hints on pyspark.sql.*
+  - [[SPARK-35045]](https://issues.apache.org/jira/browse/SPARK-35045): Add an internal option to control input buffer in univocity
+  - [[SPARK-35079]](https://issues.apache.org/jira/browse/SPARK-35079): Transform with udf gives incorrect result
+  - [[SPARK-35080]](https://issues.apache.org/jira/browse/SPARK-35080): Correlated subqueries with equality predicates can return wrong results
+  - [[SPARK-35087]](https://issues.apache.org/jira/browse/SPARK-35087): Fix some columns in table `Aggregated Metrics by Executor` of stage-detail page
+  - [[SPARK-35093]](https://issues.apache.org/jira/browse/SPARK-35093): AQE columnar mismatch on exchange reuse
+  - [[SPARK-35096]](https://issues.apache.org/jira/browse/SPARK-35096): foreachBatch throws ArrayIndexOutOfBoundsException if schema is case Insensitive
+  - [[SPARK-35106]](https://issues.apache.org/jira/browse/SPARK-35106): HadoopMapReduceCommitProtocol performs bad rename when dynamic partition overwrite is used
+  - [[SPARK-35117]](https://issues.apache.org/jira/browse/SPARK-35117): UI progress bar no longer highlights in progress tasks
+  - [[SPARK-35127]](https://issues.apache.org/jira/browse/SPARK-35127): When switching between different stage-detail pages, the entry in newly-opened page may be blank
+  - [[SPARK-35136]](https://issues.apache.org/jira/browse/SPARK-35136): Initial null value of LiveStage.info can lead to NPE
+  - [[SPARK-35142]](https://issues.apache.org/jira/browse/SPARK-35142): `OneVsRest` classifier uses incorrect data type for `rawPrediction` column
+  - [[SPARK-35168]](https://issues.apache.org/jira/browse/SPARK-35168): mapred.reduce.tasks should be shuffle.partitions not adaptive.coalescePartitions.initialPartitionNum
+  - [[SPARK-35213]](https://issues.apache.org/jira/browse/SPARK-35213): Corrupt DataFrame for certain withField patterns
+  - [[SPARK-35226]](https://issues.apache.org/jira/browse/SPARK-35226): JDBC datasources should accept refreshKrb5Config parameter
+  - [[SPARK-35227]](https://issues.apache.org/jira/browse/SPARK-35227): Replace Bintray with the new repository service for the spark-packages resolver in SparkSubmit
+  - [[SPARK-35244]](https://issues.apache.org/jira/browse/SPARK-35244): invoke should throw the original exception
+  - [[SPARK-35278]](https://issues.apache.org/jira/browse/SPARK-35278): Invoke should find the method with correct number of parameters
+  - [[SPARK-35288]](https://issues.apache.org/jira/browse/SPARK-35288): StaticInvoke should find the method without exact argument classes match
+  - [[SPARK-35359]](https://issues.apache.org/jira/browse/SPARK-35359): Insert data with char/varchar datatype will fail when data length exceed length limitation
+  - [[SPARK-35381]](https://issues.apache.org/jira/browse/SPARK-35381): Fix lambda variable name issues in nested DataFrame functions in R APIs
+  - [[SPARK-35382]](https://issues.apache.org/jira/browse/SPARK-35382): Fix lambda variable name issues in nested DataFrame functions in Python APIs
+  - [[SPARK-35411]](https://issues.apache.org/jira/browse/SPARK-35411): Essential information missing in TreeNode json string
+  - [[SPARK-35482]](https://issues.apache.org/jira/browse/SPARK-35482): case sensitive block manager port key should be used in BasicExecutorFeatureStep
+  - [[SPARK-35493]](https://issues.apache.org/jira/browse/SPARK-35493): spark.blockManager.port does not work for driver pod
+
+### Dependency Changes
+
+While being a maintence release we did still upgrade some dependencies in this release they are:
+
+  - [[SPARK-34752]](https://issues.apache.org/jira/browse/SPARK-34752): Upgrade Jetty to 9.4.37 to fix CVE-2020-27223
+  - [[SPARK-34988]](https://issues.apache.org/jira/browse/SPARK-34988): Upgrade Jetty to 9.4.39 to fix CVE-2021-28165
+  - [[SPARK-35210]](https://issues.apache.org/jira/browse/SPARK-35210): Upgrade Jetty to 9.4.40 to fix ERR_CONNECTION_RESET issue
+
+You can consult JIRA for the [detailed changes](https://s.apache.org/spark-3.1.2).
+
+We would like to acknowledge all community members for contributing patches to this release.

--- a/releases/_posts/2021-06-01-spark-release-3-1-2.md
+++ b/releases/_posts/2021-06-01-spark-release-3-1-2.md
@@ -48,7 +48,7 @@ Spark 3.1.2 is a maintenance release containing stability fixes. This release is
   - [[SPARK-34674]](https://issues.apache.org/jira/browse/SPARK-34674): Spark app on k8s doesn't terminate without call to sparkContext.stop() method
   - [[SPARK-34681]](https://issues.apache.org/jira/browse/SPARK-34681): Full outer shuffled hash join when building left side produces wrong result
   - [[SPARK-34682]](https://issues.apache.org/jira/browse/SPARK-34682): Regression in "operating on canonicalized plan" check in CustomShuffleReaderExec
-  - [[SPARK-34697]](https://issues.apache.org/jira/browse/SPARK-34697): Allow DESCRIBE FUNCTION and SHOW FUNCTIONS explain about || (string concatenation operator)
+  - [[SPARK-34697]](https://issues.apache.org/jira/browse/SPARK-34697): Allow DESCRIBE FUNCTION and SHOW FUNCTIONS explain about string concatenation operator
   - [[SPARK-34713]](https://issues.apache.org/jira/browse/SPARK-34713): Group by CreateStruct with ExtractValue fails analysis
   - [[SPARK-34714]](https://issues.apache.org/jira/browse/SPARK-34714): collect_list(struct()) fails when used with GROUP BY
   - [[SPARK-34719]](https://issues.apache.org/jira/browse/SPARK-34719): Fail if the view query has duplicated column names

--- a/site/committers.html
+++ b/site/committers.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/community.html
+++ b/site/community.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
@@ -205,6 +205,7 @@
 <p>Setup instructions, programming guides, and other documentation are available for each stable version of Spark below:</p>
 
 <ul>
+  <li><a href="/docs/3.1.2/">Spark 3.1.2</a></li>
   <li><a href="/docs/3.1.1/">Spark 3.1.1</a></li>
   <li><a href="/docs/3.0.2/">Spark 3.0.2</a></li>
   <li><a href="/docs/3.0.1/">Spark 3.0.1</a></li>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
@@ -241,7 +241,7 @@ The latest preview release is Spark 3.0.0-preview2, published on Dec 23, 2019.</
 
 <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>groupId: org.apache.spark
 artifactId: spark-core_2.12
-version: 3.1.1
+version: 3.1.2
 </code></pre></div></div>
 
 <h3 id="installing-with-pypi">Installing with PyPi</h3>

--- a/site/error-message-guidelines.html
+++ b/site/error-message-guidelines.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/examples.html
+++ b/site/examples.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/faq.html
+++ b/site/faq.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -109,7 +109,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/history.html
+++ b/site/history.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/index.html
+++ b/site/index.html
@@ -108,7 +108,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -164,6 +164,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -172,9 +175,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -22,9 +22,11 @@ var scala2p12_hadoopFree = {pretty: "Pre-built with Scala 2.12 and user-provided
 var packagesV9 = [hadoop2p7, hadoop2p6, hadoopFree, scala2p12_hadoopFree, sources];
 // 3.0.0+
 var packagesV10 = [hadoop2p7, hadoop3p2, hadoopFree, sources];
+// 3.1.0+
+var packagesV11 = [hadoop3p2, hadoop2p7, hadoopFree, sources];
 
 
-addRelease("3.1.1", new Date("03/02/2021"), packagesV10, true);
+addRelease("3.1.2", new Date("06/01/2021"), packagesV11, true);
 addRelease("3.0.2", new Date("02/19/2021"), packagesV10, true);
 addRelease("2.4.8", new Date("05/17/2021"), packagesV9, true);
 

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -109,7 +109,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -109,7 +109,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
@@ -201,6 +201,15 @@
 
   <div class="col-md-9 col-md-pull-3">
     <h2 id="spark-news">Spark News</h2>
+
+<article class="hentry">
+    <header class="entry-header">
+      <h3 class="entry-title"><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a></h3>
+      <div class="entry-date">June 1, 2021</div>
+    </header>
+    <div class="entry-content"><p>We are happy to announce the availability of <a href="/releases/spark-release-3-1-2.html" title="Spark Release 3.1.2">Spark 3.1.2</a>! Visit the <a href="/releases/spark-release-3-1-2.html" title="Spark Release 3.1.2">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+</div>
+  </article>
 
 <article class="hentry">
     <header class="entry-header">

--- a/site/news/new-repository-service.html
+++ b/site/news/new-repository-service.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/next-official-release-spark-3.1.1.html
+++ b/site/news/next-official-release-spark-3.1.1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/plan-for-dropping-python-2-support.html
+++ b/site/news/plan-for-dropping-python-2-support.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-3-released.html
+++ b/site/news/spark-2-1-3-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-2-released.html
+++ b/site/news/spark-2-2-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-1-released.html
+++ b/site/news/spark-2-3-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-2-released.html
+++ b/site/news/spark-2-3-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-3-released.html
+++ b/site/news/spark-2-3-3-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-4-released.html
+++ b/site/news/spark-2-3-4-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-0-released.html
+++ b/site/news/spark-2-4-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-1-released.html
+++ b/site/news/spark-2-4-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-2-released.html
+++ b/site/news/spark-2-4-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-3-released.html
+++ b/site/news/spark-2-4-3-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-4-released.html
+++ b/site/news/spark-2-4-4-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-5-released.html
+++ b/site/news/spark-2-4-5-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-6.html
+++ b/site/news/spark-2-4-6.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-7-released.html
+++ b/site/news/spark-2-4-7-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-8-released.html
+++ b/site/news/spark-2-4-8-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-0-released.html
+++ b/site/news/spark-3-0-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-1-released.html
+++ b/site/news/spark-3-0-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-2-released.html
+++ b/site/news/spark-3-0-2-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-1-released.html
+++ b/site/news/spark-3-1-1-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-2-released.html
+++ b/site/news/spark-3-1-2-released.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark Summit Europe agenda posted | Apache Spark
+     Spark 3.1.2 released | Apache Spark
     
   </title>
 
@@ -200,10 +200,10 @@
   </div>
 
   <div class="col-md-9 col-md-pull-3">
-    <h2>Spark Summit Europe agenda posted</h2>
+    <h2>Spark 3.1.2 released</h2>
 
 
-<p>The <a href="http://spark-summit.org/eu-2015/schedule">agenda for Spark Summit Europe</a> is now posted, with 38 talks from organizations including Barclays, Netflix, Elsevier, Intel and others. This inaugural Spark conference in Europe will run October 27th-29th 2015 in Amsterdam and feature a full program of speakers along with Spark training opportunities. More details are available on the <a href="https://spark-summit.org/eu-2015/">Spark Summit Europe website</a>, where you can also <a href="https://www.prevalentdesignevents.com/sparksummit2015/europe/registration.aspx?source=header">register</a> to attend.</p>
+<p>We are happy to announce the availability of <a href="/releases/spark-release-3-1-2.html" title="Spark Release 3.1.2">Spark 3.1.2</a>! Visit the <a href="/releases/spark-release-3-1-2.html" title="Spark Release 3.1.2">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
 
 
 <p>

--- a/site/news/spark-3.0.0-preview.html
+++ b/site/news/spark-3.0.0-preview.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview2.html
+++ b/site/news/spark-3.0.0-preview2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-apr-2019-agenda-posted.html
+++ b/site/news/spark-ai-summit-apr-2019-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-june-2020-agenda-posted.html
+++ b/site/news/spark-ai-summit-june-2020-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-release-2-2-3.html
+++ b/site/news/spark-release-2-2-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2015.html
+++ b/site/news/spark-summit-east-agenda-posted-2015.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2016.html
+++ b/site/news/spark-summit-east-agenda-posted-2016.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-oct-2018-agenda-posted.html
+++ b/site/news/spark-summit-oct-2018-agenda-posted.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-3.html
+++ b/site/releases/spark-release-2-1-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-2.html
+++ b/site/releases/spark-release-2-2-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-3.html
+++ b/site/releases/spark-release-2-2-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-1.html
+++ b/site/releases/spark-release-2-3-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-2.html
+++ b/site/releases/spark-release-2-3-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-3.html
+++ b/site/releases/spark-release-2-3-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-4.html
+++ b/site/releases/spark-release-2-3-4.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-0.html
+++ b/site/releases/spark-release-2-4-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-1.html
+++ b/site/releases/spark-release-2-4-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-2.html
+++ b/site/releases/spark-release-2-4-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-3.html
+++ b/site/releases/spark-release-2-4-3.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-4.html
+++ b/site/releases/spark-release-2-4-4.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-5.html
+++ b/site/releases/spark-release-2-4-5.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-6.html
+++ b/site/releases/spark-release-2-4-6.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-7.html
+++ b/site/releases/spark-release-2-4-7.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-8.html
+++ b/site/releases/spark-release-2-4-8.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-0.html
+++ b/site/releases/spark-release-3-0-0.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-1.html
+++ b/site/releases/spark-release-3-0-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-2.html
+++ b/site/releases/spark-release-3-0-2.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-1.html
+++ b/site/releases/spark-release-3-1-1.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-2.html
+++ b/site/releases/spark-release-3-1-2.html
@@ -1,0 +1,358 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>
+     Spark Release 3.1.2 | Apache Spark
+    
+  </title>
+
+  
+
+  
+
+  <!-- Bootstrap core CSS -->
+  <link href="/css/cerulean.min.css" rel="stylesheet">
+  <link href="/css/custom.css" rel="stylesheet">
+
+  <!-- Code highlighter CSS -->
+  <link href="/css/pygments-default.css" rel="stylesheet">
+
+  <script type="text/javascript">
+  <!-- Google Analytics initialization -->
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-32518208-2']);
+  _gaq.push(['_trackPageview']);
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+
+  <!-- Adds slight delay to links to allow async reporting -->
+  function trackOutboundLink(link, category, action) {
+    try {
+      _gaq.push(['_trackEvent', category , action]);
+    } catch(err){}
+
+    setTimeout(function() {
+      document.location.href = link.href;
+    }, 100);
+  }
+  </script>
+
+  <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+  <!--[if lt IE 9]>
+  <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+  <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
+  <![endif]-->
+</head>
+
+<body>
+
+<script src="https://code.jquery.com/jquery.js"></script>
+<script src="https://netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
+<script src="/js/lang-tabs.js"></script>
+<script src="/js/downloads.js"></script>
+
+<div class="container" style="max-width: 1200px;">
+
+<div class="masthead">
+  
+    <p class="lead">
+      <a href="/">
+      <img src="/images/spark-logo-trademark.png"
+        style="height:100px; width:auto; vertical-align: bottom; margin-top: 20px;"></a><span class="tagline">
+          Lightning-fast unified analytics engine
+      </span>
+    </p>
+  
+</div>
+
+<nav class="navbar navbar-default" role="navigation">
+  <!-- Brand and toggle get grouped for better mobile display -->
+  <div class="navbar-header">
+    <button type="button" class="navbar-toggle" data-toggle="collapse"
+            data-target="#navbar-collapse-1">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+  </div>
+
+  <!-- Collect the nav links, forms, and other content for toggling -->
+  <div class="collapse navbar-collapse" id="navbar-collapse-1">
+    <ul class="nav navbar-nav">
+      <li><a href="/downloads.html">Download</a></li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Libraries <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/sql/">SQL and DataFrames</a></li>
+          <li><a href="/streaming/">Spark Streaming</a></li>
+          <li><a href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a href="/graphx/">GraphX (graph)</a></li>
+          <li class="divider"></li>
+          <li><a href="/third-party-projects.html">Third-Party Projects</a></li>
+        </ul>
+      </li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Documentation <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
+          <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
+          <li><a href="/faq.html">Frequently Asked Questions</a></li>
+        </ul>
+      </li>
+      <li><a href="/examples.html">Examples</a></li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Community <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/community.html">Mailing Lists &amp; Resources</a></li>
+          <li><a href="/contributing.html">Contributing to Spark</a></li>
+          <li><a href="/improvement-proposals.html">Improvement Proposals (SPIP)</a></li>
+          <li><a href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a></li>
+          <li><a href="/powered-by.html">Powered By</a></li>
+          <li><a href="/committers.html">Project Committers</a></li>
+          <li><a href="/history.html">Project History</a></li>
+        </ul>
+      </li>
+      <li class="dropdown">
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+           Developers <b class="caret"></b>
+        </a>
+        <ul class="dropdown-menu">
+          <li><a href="/developer-tools.html">Useful Developer Tools</a></li>
+          <li><a href="/versioning-policy.html">Versioning Policy</a></li>
+          <li><a href="/release-process.html">Release Process</a></li>
+          <li><a href="/security.html">Security</a></li>
+        </ul>
+      </li>
+    </ul>
+    <ul class="nav navbar-nav navbar-right">
+      <li class="dropdown">
+        <a href="https://www.apache.org/" class="dropdown-toggle" data-toggle="dropdown">
+          Apache Software Foundation <b class="caret"></b></a>
+        <ul class="dropdown-menu">
+          <li><a href="https://www.apache.org/">Apache Homepage</a></li>
+          <li><a href="https://www.apache.org/licenses/">License</a></li>
+          <li><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+          <li><a href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
+          <li><a href="https://www.apache.org/security/">Security</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <!-- /.navbar-collapse -->
+</nav>
+
+
+<div class="row">
+  <div class="col-md-3 col-md-push-9">
+    <div class="news" style="margin-bottom: 20px;">
+      <h5>Latest News</h5>
+      <ul class="list-unstyled">
+        
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
+          <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
+          <span class="small">(May 17, 2021)</span></li>
+        
+          <li><a href="/news/new-repository-service.html">New repository service for spark-packages</a>
+          <span class="small">(Apr 28, 2021)</span></li>
+        
+          <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
+          <span class="small">(Mar 02, 2021)</span></li>
+        
+      </ul>
+      <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
+    </div>
+    <div style="text-align:center; margin-bottom: 20px;">
+      <a href="https://www.apache.org/events/current-event.html">
+        <img src="https://www.apache.org/events/current-event-234x60.png"/>
+      </a>
+    </div>
+    <div class="hidden-xs hidden-sm">
+      <a href="/downloads.html" class="btn btn-success btn-lg btn-block" style="margin-bottom: 30px;">
+        Download Spark
+      </a>
+      <p style="font-size: 16px; font-weight: 500; color: #555;">
+        Built-in Libraries:
+      </p>
+      <ul class="list-none">
+        <li><a href="/sql/">SQL and DataFrames</a></li>
+        <li><a href="/streaming/">Spark Streaming</a></li>
+        <li><a href="/mllib/">MLlib (machine learning)</a></li>
+        <li><a href="/graphx/">GraphX (graph)</a></li>
+      </ul>
+      <a href="/third-party-projects.html">Third-Party Projects</a>
+    </div>
+  </div>
+
+  <div class="col-md-9 col-md-pull-3">
+    <h2>Spark Release 3.1.2</h2>
+
+
+<p>Spark 3.1.2 is a maintenance release containing stability fixes. This release is based on the branch-3.1 maintenance branch of Spark. We strongly recommend all 3.1 users to upgrade to this stable release.</p>
+
+<h3 id="notable-changes">Notable changes</h3>
+
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32924">[SPARK-32924]</a>: Web UI sort on duration is wrong</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-33482">[SPARK-33482]</a>: V2 Datasources that extend FileScan preclude exchange reuse</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34361">[SPARK-34361]</a>: Dynamic allocation on K8s kills executors with running tasks</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34392">[SPARK-34392]</a>: Invalid ID for offset-based ZoneId since Spark 3.0</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34417">[SPARK-34417]</a>: DataFrameNaFunctions.fillMap(values: Seq[(String, Any)]) fails for column name having a dot</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34436">[SPARK-34436]</a>: DPP support LIKE ANY/ALL</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34473">[SPARK-34473]</a>: Avoid NPE in DataFrameReader.schema(StructType)</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34482">[SPARK-34482]</a>: Correct the active SparkSession for streaming query</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34490">[SPARK-34490]</a>: Table maybe resolved as a view if the table is dropped</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34497">[SPARK-34497]</a>: JDBC connection provider is not removing kerberos credentials from JVM security context</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34504">[SPARK-34504]</a>: Avoid unnecessary view resolving and remove the <code class="language-plaintext highlighter-rouge">performCheck</code> flag</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34515">[SPARK-34515]</a>: Fix NPE if InSet contains null value during getPartitionsByFilter</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34534">[SPARK-34534]</a>: New protocol FetchShuffleBlocks in OneForOneBlockFetcher lead to data loss or correctness</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34543">[SPARK-34543]</a>: Respect case sensitivity in V1 ALTER TABLE .. SET LOCATION</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34545">[SPARK-34545]</a>: Fix inconsistent results when applying 2 Python UDFs with different return type to 2 columns together</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34547">[SPARK-34547]</a>: Resolve using child metadata attributes as fallback</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34550">[SPARK-34550]</a>: Skip InSet null value during push filter to Hive metastore</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34555">[SPARK-34555]</a>: Resolve metadata output from DataFrame</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34556">[SPARK-34556]</a>: Checking duplicate static partition columns doesn&#8217;t respect case sensitive conf</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34561">[SPARK-34561]</a>: Cannot drop/add columns from/to a dataset of v2 <code class="language-plaintext highlighter-rouge">DESCRIBE TABLE</code></li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34567">[SPARK-34567]</a>: CreateTableAsSelect should have metrics update too</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34577">[SPARK-34577]</a>: Cannot drop/add columns from/to a dataset of v2 <code class="language-plaintext highlighter-rouge">DESCRIBE NAMESPACE</code></li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34584">[SPARK-34584]</a>: When insert into a partition table with a illegal partition value, DSV2 behavior different as others</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34596">[SPARK-34596]</a>: NewInstance.doGenCode should not throw malformed class name error</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34599">[SPARK-34599]</a>: INSERT INTO OVERWRITE doesn&#8217;t support partition columns containing dot for DSv2</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34607">[SPARK-34607]</a>: NewInstance.resolved should not throw malformed class name error</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34610">[SPARK-34610]</a>: Fix Python UDF used in GroupedAggPandasUDFTests</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34613">[SPARK-34613]</a>: Fix view does not capture disable hint config</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34630">[SPARK-34630]</a>: Add type hints of pyspark.<strong>version</strong> and pyspark.sql.Column.contains</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34639">[SPARK-34639]</a>: Always remove unnecessary Alias in Analyzer.resolveExpression</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34674">[SPARK-34674]</a>: Spark app on k8s doesn&#8217;t terminate without call to sparkContext.stop() method</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34681">[SPARK-34681]</a>: Full outer shuffled hash join when building left side produces wrong result</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34682">[SPARK-34682]</a>: Regression in &#8220;operating on canonicalized plan&#8221; check in CustomShuffleReaderExec</li>
+  <li>
+    <table>
+      <tbody>
+        <tr>
+          <td><a href="https://issues.apache.org/jira/browse/SPARK-34697">[SPARK-34697]</a>: Allow DESCRIBE FUNCTION and SHOW FUNCTIONS explain about</td>
+          <td>&#160;</td>
+          <td>(string concatenation operator)</td>
+        </tr>
+      </tbody>
+    </table>
+  </li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34713">[SPARK-34713]</a>: Group by CreateStruct with ExtractValue fails analysis</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34714">[SPARK-34714]</a>: collect_list(struct()) fails when used with GROUP BY</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34719">[SPARK-34719]</a>: Fail if the view query has duplicated column names</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34723">[SPARK-34723]</a>: Correct parameter type for subexpression elimination under whole-stage</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34724">[SPARK-34724]</a>: Fix Interpreted evaluation by using getClass.getMethod instead of getDeclaredMethod</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34727">[SPARK-34727]</a>: Difference in results of casting float to timestamp</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34731">[SPARK-34731]</a>: ConcurrentModificationException in EventLoggingListener when redacting properties</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34737">[SPARK-34737]</a>: Discrepancy between TIMESTAMP_SECONDS and cast from float</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34756">[SPARK-34756]</a>: Fix FileScan equality check</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34763">[SPARK-34763]</a>: col(), $&#8221;<name>" and df("name") should handle quoted column names properly</name></li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34766">[SPARK-34766]</a>: Do not capture maven config for views</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34768">[SPARK-34768]</a>: Respect the default input buffer size in Univocity</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34770">[SPARK-34770]</a>: InMemoryCatalog.tableExists should not fail if database doesn&#8217;t exist</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34772">[SPARK-34772]</a>: RebaseDateTime loadRebaseRecords should use Spark classloader instead of context</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34776">[SPARK-34776]</a>: Catalyst error on on certain struct operation (Couldn&#8217;t find <em>gen_alias</em>)</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34790">[SPARK-34790]</a>: Fail in fetch shuffle blocks in batch when i/o encryption is enabled</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34794">[SPARK-34794]</a>: Nested higher-order functions broken in DSL</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34796">[SPARK-34796]</a>: Codegen compilation error for query with LIMIT operator and without AQE</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34803">[SPARK-34803]</a>: Pass the raised ImportError if pandas or pyarrow fail to import</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34811">[SPARK-34811]</a>: Redact fs.s3a.access.key like secret and token</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34814">[SPARK-34814]</a>: LikeSimplification should handle NULL</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34829">[SPARK-34829]</a>: Fix higher order function results</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34833">[SPARK-34833]</a>: Apply right-padding correctly for correlated subqueries</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34834">[SPARK-34834]</a>: There is a potential Netty memory leak in TransportResponseHandler</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34840">[SPARK-34840]</a>: Fix cases of corruption in merged shuffle blocks that are pushed</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34845">[SPARK-34845]</a>: computeAllMetrics may return partial metrics when some child metrics are missing</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34876">[SPARK-34876]</a>: Non-nullable aggregates can return NULL in a correlated subquery</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34897">[SPARK-34897]</a>: Support reconcile schemas based on index after nested column pruning</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34909">[SPARK-34909]</a>: conv() does not convert negative inputs to unsigned correctly</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34922">[SPARK-34922]</a>: Use better CBO cost function</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34923">[SPARK-34923]</a>: Metadata output should not always be propagated</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34926">[SPARK-34926]</a>: PartitionUtils.getPathFragment should handle null value</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34939">[SPARK-34939]</a>: Throw fetch failure exception when unable to deserialize broadcasted map statuses</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34948">[SPARK-34948]</a>: Add ownerReference to executor configmap to fix leakages</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34949">[SPARK-34949]</a>: Executor.reportHeartBeat reregisters blockManager even when Executor is shutting down</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34963">[SPARK-34963]</a>: Nested column pruning fails to extract case-insensitive struct field from array</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34970">[SPARK-34970]</a>: Redact map-type options in the output of explain()</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35014">[SPARK-35014]</a>: A foldable expression could not be replaced by an AttributeReference</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35019">[SPARK-35019]</a>: Improve type hints on pyspark.sql.*</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35045">[SPARK-35045]</a>: Add an internal option to control input buffer in univocity</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35079">[SPARK-35079]</a>: Transform with udf gives incorrect result</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35080">[SPARK-35080]</a>: Correlated subqueries with equality predicates can return wrong results</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35087">[SPARK-35087]</a>: Fix some columns in table <code class="language-plaintext highlighter-rouge">Aggregated Metrics by Executor</code> of stage-detail page</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35093">[SPARK-35093]</a>: AQE columnar mismatch on exchange reuse</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35096">[SPARK-35096]</a>: foreachBatch throws ArrayIndexOutOfBoundsException if schema is case Insensitive</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35106">[SPARK-35106]</a>: HadoopMapReduceCommitProtocol performs bad rename when dynamic partition overwrite is used</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35117">[SPARK-35117]</a>: UI progress bar no longer highlights in progress tasks</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35127">[SPARK-35127]</a>: When switching between different stage-detail pages, the entry in newly-opened page may be blank</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35136">[SPARK-35136]</a>: Initial null value of LiveStage.info can lead to NPE</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35142">[SPARK-35142]</a>: <code class="language-plaintext highlighter-rouge">OneVsRest</code> classifier uses incorrect data type for <code class="language-plaintext highlighter-rouge">rawPrediction</code> column</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35168">[SPARK-35168]</a>: mapred.reduce.tasks should be shuffle.partitions not adaptive.coalescePartitions.initialPartitionNum</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35213">[SPARK-35213]</a>: Corrupt DataFrame for certain withField patterns</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35226">[SPARK-35226]</a>: JDBC datasources should accept refreshKrb5Config parameter</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35227">[SPARK-35227]</a>: Replace Bintray with the new repository service for the spark-packages resolver in SparkSubmit</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35244">[SPARK-35244]</a>: invoke should throw the original exception</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35278">[SPARK-35278]</a>: Invoke should find the method with correct number of parameters</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35288">[SPARK-35288]</a>: StaticInvoke should find the method without exact argument classes match</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35359">[SPARK-35359]</a>: Insert data with char/varchar datatype will fail when data length exceed length limitation</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35381">[SPARK-35381]</a>: Fix lambda variable name issues in nested DataFrame functions in R APIs</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35382">[SPARK-35382]</a>: Fix lambda variable name issues in nested DataFrame functions in Python APIs</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35411">[SPARK-35411]</a>: Essential information missing in TreeNode json string</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35482">[SPARK-35482]</a>: case sensitive block manager port key should be used in BasicExecutorFeatureStep</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35493">[SPARK-35493]</a>: spark.blockManager.port does not work for driver pod</li>
+</ul>
+
+<h3 id="dependency-changes">Dependency Changes</h3>
+
+<p>While being a maintence release we did still upgrade some dependencies in this release they are:</p>
+
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34752">[SPARK-34752]</a>: Upgrade Jetty to 9.4.37 to fix CVE-2020-27223</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34988">[SPARK-34988]</a>: Upgrade Jetty to 9.4.39 to fix CVE-2021-28165</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35210">[SPARK-35210]</a>: Upgrade Jetty to 9.4.40 to fix ERR_CONNECTION_RESET issue</li>
+</ul>
+
+<p>You can consult JIRA for the <a href="https://s.apache.org/spark-3.1.2">detailed changes</a>.</p>
+
+<p>We would like to acknowledge all community members for contributing patches to this release.</p>
+
+
+<p>
+<br/>
+<a href="/news/">Spark News Archive</a>
+</p>
+
+  </div>
+</div>
+
+
+
+<footer class="small">
+  <hr>
+  Apache Spark, Spark, Apache, the Apache feather logo, and the Apache Spark project logo are either registered
+  trademarks or trademarks of The Apache Software Foundation in the United States and other countries.
+  See guidance on use of Apache Spark <a href="/trademarks.html">trademarks</a>.
+  All other marks mentioned may be trademarks or registered trademarks of their respective owners.
+  Copyright &copy; 2018 The Apache Software Foundation, Licensed under the
+  <a href="https://www.apache.org/licenses/">Apache License, Version 2.0</a>.
+</footer>
+
+</div>
+
+</body>
+</html>

--- a/site/releases/spark-release-3-1-2.html
+++ b/site/releases/spark-release-3-1-2.html
@@ -241,17 +241,7 @@
   <li><a href="https://issues.apache.org/jira/browse/SPARK-34674">[SPARK-34674]</a>: Spark app on k8s doesn&#8217;t terminate without call to sparkContext.stop() method</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-34681">[SPARK-34681]</a>: Full outer shuffled hash join when building left side produces wrong result</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-34682">[SPARK-34682]</a>: Regression in &#8220;operating on canonicalized plan&#8221; check in CustomShuffleReaderExec</li>
-  <li>
-    <table>
-      <tbody>
-        <tr>
-          <td><a href="https://issues.apache.org/jira/browse/SPARK-34697">[SPARK-34697]</a>: Allow DESCRIBE FUNCTION and SHOW FUNCTIONS explain about</td>
-          <td>&#160;</td>
-          <td>(string concatenation operator)</td>
-        </tr>
-      </tbody>
-    </table>
-  </li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-34697">[SPARK-34697]</a>: Allow DESCRIBE FUNCTION and SHOW FUNCTIONS explain about string concatenation operator</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-34713">[SPARK-34713]</a>: Group by CreateStruct with ExtractValue fails analysis</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-34714">[SPARK-34714]</a>: collect_list(struct()) fails when used with GROUP BY</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-34719">[SPARK-34719]</a>: Fail if the view query has duplicated column names</li>

--- a/site/research.html
+++ b/site/research.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/security.html
+++ b/site/security.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -139,6 +139,14 @@
 </url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
+  <loc>https://spark.apache.org/releases/spark-release-3-1-2.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/news/spark-3-1-2-released.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/releases/spark-release-2-4-8.html</loc>
   <changefreq>weekly</changefreq>
 </url>
@@ -892,6 +900,10 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
+  <loc>https://spark.apache.org/streaming/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/news/</loc>
   <changefreq>weekly</changefreq>
 </url>
@@ -901,10 +913,6 @@
 </url>
 <url>
   <loc>https://spark.apache.org/sql/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>https://spark.apache.org/streaming/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -109,7 +109,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -109,7 +109,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -165,6 +165,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -173,9 +176,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -106,7 +106,7 @@
           Documentation <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/docs/latest/">Latest Release (Spark 3.1.1)</a></li>
+          <li><a href="/docs/latest/">Latest Release (Spark 3.1.2)</a></li>
           <li><a href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
       <h5>Latest News</h5>
       <ul class="list-unstyled">
         
+          <li><a href="/news/spark-3-1-2-released.html">Spark 3.1.2 released</a>
+          <span class="small">(Jun 01, 2021)</span></li>
+        
           <li><a href="/news/spark-2-4-8-released.html">Spark 2.4.8 released</a>
           <span class="small">(May 17, 2021)</span></li>
         
@@ -170,9 +173,6 @@
         
           <li><a href="/news/spark-3-1-1-released.html">Spark 3.1.1 released</a>
           <span class="small">(Mar 02, 2021)</span></li>
-        
-          <li><a href="/news/spark-3-0-2-released.html">Spark 3.0.2 released</a>
-          <span class="small">(Feb 19, 2021)</span></li>
         
       </ul>
       <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>


### PR DESCRIPTION
This PR aims the followings.
- Add 3.1.2 announcement news and release note
- Add 3.1.2 download link and reorder to expose the default Hadoop distribution (Hadoop 3.2)