### PR TITLE
Remove Apache Spark 2.4 from download page

### DIFF
--- a/js/downloads.js
+++ b/js/downloads.js
@@ -13,13 +13,10 @@ function addRelease(version, releaseDate, packages, mirrored) {
 
 var sources = {pretty: "Source Code", tag: "sources"};
 var hadoopFree = {pretty: "Pre-built with user-provided Apache Hadoop", tag: "without-hadoop"};
-var hadoop2p6 = {pretty: "Pre-built for Apache Hadoop 2.6", tag: "hadoop2.6"};
 var hadoop2p7 = {pretty: "Pre-built for Apache Hadoop 2.7", tag: "hadoop2.7"};
 var hadoop3p2 = {pretty: "Pre-built for Apache Hadoop 3.2 and later", tag: "hadoop3.2"};
 var scala2p12_hadoopFree = {pretty: "Pre-built with Scala 2.12 and user-provided Apache Hadoop", tag: "without-hadoop-scala-2.12"};
 
-// 2.4.0+
-var packagesV9 = [hadoop2p7, hadoop2p6, hadoopFree, scala2p12_hadoopFree, sources];
 // 3.0.0+
 var packagesV10 = [hadoop2p7, hadoop3p2, hadoopFree, sources];
 // 3.1.0+
@@ -28,7 +25,6 @@ var packagesV11 = [hadoop3p2, hadoop2p7, hadoopFree, sources];
 
 addRelease("3.1.2", new Date("06/01/2021"), packagesV11, true);
 addRelease("3.0.3", new Date("06/23/2021"), packagesV10, true);
-addRelease("2.4.8", new Date("05/17/2021"), packagesV9, true);
 
 function append(el, contents) {
   el.innerHTML += contents;

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -13,13 +13,10 @@ function addRelease(version, releaseDate, packages, mirrored) {
 
 var sources = {pretty: "Source Code", tag: "sources"};
 var hadoopFree = {pretty: "Pre-built with user-provided Apache Hadoop", tag: "without-hadoop"};
-var hadoop2p6 = {pretty: "Pre-built for Apache Hadoop 2.6", tag: "hadoop2.6"};
 var hadoop2p7 = {pretty: "Pre-built for Apache Hadoop 2.7", tag: "hadoop2.7"};
 var hadoop3p2 = {pretty: "Pre-built for Apache Hadoop 3.2 and later", tag: "hadoop3.2"};
 var scala2p12_hadoopFree = {pretty: "Pre-built with Scala 2.12 and user-provided Apache Hadoop", tag: "without-hadoop-scala-2.12"};
 
-// 2.4.0+
-var packagesV9 = [hadoop2p7, hadoop2p6, hadoopFree, scala2p12_hadoopFree, sources];
 // 3.0.0+
 var packagesV10 = [hadoop2p7, hadoop3p2, hadoopFree, sources];
 // 3.1.0+
@@ -28,7 +25,6 @@ var packagesV11 = [hadoop3p2, hadoop2p7, hadoopFree, sources];
 
 addRelease("3.1.2", new Date("06/01/2021"), packagesV11, true);
 addRelease("3.0.3", new Date("06/23/2021"), packagesV10, true);
-addRelease("2.4.8", new Date("05/17/2021"), packagesV9, true);
 
 function append(el, contents) {
   el.innerHTML += contents;


### PR DESCRIPTION
This PR aims to remove Apache Spark 2.4.8 download link from the download page because it's already EOL and we had better recommend the latest versions: 3.1.2, 3.0.3.

We should not change the 2.4.8 binary distribution because they are still used in the test suite.