### PR TITLE
[SPARK-36335] Add local-cluster docs to developer-tools.md

### DIFF
--- a/developer-tools.md
+++ b/developer-tools.md
@@ -610,3 +610,15 @@ When running Spark tests through SBT, add `javaOptions in Test += "-agentpath:/p
 to `SparkBuild.scala` to launch the tests with the YourKit profiler agent enabled.  
 The platform-specific paths to the profiler agents are listed in the 
 <a href="http://www.yourkit.com/docs/80/help/agent.jsp">YourKit documentation</a>.
+
+<a name="local-cluster"></a>
+<h3>Local-cluster mode</h3>
+
+When launching applications with spark-submit, besides options in 
+<a href="https://spark.apache.org/docs/latest/submitting-applications.html#master-urls">Master URLs</a>
+, set local-cluster option to emulate a distributed cluster in a single JVM. 
+
+<table class="table">
+<tr><th>Master URL</th><th>Meaning</th></tr>
+<tr><td> <code>local-cluster[N,C,M]</code> </td><td> Run Spark cluster locally with N number of workers, C cores per worker and M MiB of memory per worker (only for unit test purpose).</td></tr>
+</table>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -793,6 +793,18 @@ to <code class="language-plaintext highlighter-rouge">SparkBuild.scala</code> to
 The platform-specific paths to the profiler agents are listed in the 
 <a href="http://www.yourkit.com/docs/80/help/agent.jsp">YourKit documentation</a>.</p>
 
+<p><a name="local-cluster"></a></p>
+<h3>Local-cluster mode</h3>
+
+<p>When launching applications with spark-submit, besides options in 
+<a href="https://spark.apache.org/docs/latest/submitting-applications.html#master-urls">Master URLs</a>
+, set local-cluster option to emulate a distributed cluster in a single JVM.</p>
+
+<table class="table">
+<tr><th>Master URL</th><th>Meaning</th></tr>
+<tr><td> <code>local-cluster[N,C,M]</code> </td><td> Run Spark cluster locally with N number of workers, C cores per worker and M MiB of memory per worker (only for unit test purpose).</td></tr>
+</table>
+
   </div>
 </div>
 

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -908,6 +908,10 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
+  <loc>https://spark.apache.org/streaming/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/news/</loc>
   <changefreq>weekly</changefreq>
 </url>
@@ -917,10 +921,6 @@
 </url>
 <url>
   <loc>https://spark.apache.org/sql/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>https://spark.apache.org/streaming/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -908,10 +908,6 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/streaming/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
   <loc>https://spark.apache.org/news/</loc>
   <changefreq>weekly</changefreq>
 </url>
@@ -921,6 +917,10 @@
 </url>
 <url>
   <loc>https://spark.apache.org/sql/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/streaming/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>


### PR DESCRIPTION
Document "local-cluster" mode on developer-tools.md.

Related links:
https://github.com/apache/spark/pull/33568
https://github.com/apache/spark/pull/33537
https://issues.apache.org/jira/browse/SPARK-36335
https://issues.apache.org/jira/browse/SPARK-595
