### PR TITLE
Remove duplicated Structured Streaming in the titles

### DIFF
--- a/releases/_posts/2021-03-02-spark-release-3-1-1.md
+++ b/releases/_posts/2021-03-02-spark-release-3-1-1.md
@@ -19,7 +19,7 @@ To download Apache Spark 3.1.1, visit the [downloads](https://spark.apache.org/d
 {:toc}
 
 
-### Core, Spark SQL, Structured Streaming
+### Core and Spark SQL
 
 **Highlight**
 

--- a/site/releases/spark-release-3-1-1.html
+++ b/site/releases/spark-release-3-1-1.html
@@ -208,7 +208,7 @@
 <p>To download Apache Spark 3.1.1, visit the <a href="https://spark.apache.org/downloads.html">downloads</a> page. You can consult JIRA for the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315420&amp;version=12349541">detailed changes</a>. We have curated a list of high level changes here, grouped by major modules.</p>
 
 <ul id="markdown-toc">
-  <li><a href="#core-spark-sql-structured-streaming" id="markdown-toc-core-spark-sql-structured-streaming">Core, Spark SQL, Structured Streaming</a></li>
+  <li><a href="#core-and-spark-sql" id="markdown-toc-core-and-spark-sql">Core and Spark SQL</a></li>
   <li><a href="#pyspark" id="markdown-toc-pyspark">PySpark</a></li>
   <li><a href="#structured-streaming" id="markdown-toc-structured-streaming">Structured Streaming</a></li>
   <li><a href="#mllib" id="markdown-toc-mllib">MLlib</a></li>
@@ -219,7 +219,7 @@
   <li><a href="#credits" id="markdown-toc-credits">Credits</a></li>
 </ul>
 
-<h3 id="core-spark-sql-structured-streaming">Core, Spark SQL, Structured Streaming</h3>
+<h3 id="core-and-spark-sql">Core and Spark SQL</h3>
 
 <p><strong>Highlight</strong></p>
 


### PR DESCRIPTION
This PR proposes to remove duplicated "Structured Streaming" in the title. Structured Streaming was separate as a separate section from Spark 3.1.1 release note.