### PR TITLE
Remove duplicated command instruction from developer-tools

### DIFF
--- a/developer-tools.md
+++ b/developer-tools.md
@@ -25,8 +25,6 @@ $ export SPARK_PREPEND_CLASSES=true
 $ ./bin/spark-shell # Now it's using compiled classes
 # ... do some local development ... #
 $ build/sbt compile
-# ... do some local development ... #
-$ build/sbt compile
 $ unset SPARK_PREPEND_CLASSES
 $ ./bin/spark-shell
  

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -217,8 +217,6 @@ $ export SPARK_PREPEND_CLASSES=true
 $ ./bin/spark-shell # Now it's using compiled classes
 # ... do some local development ... #
 $ build/sbt compile
-# ... do some local development ... #
-$ build/sbt compile
 $ unset SPARK_PREPEND_CLASSES
 $ ./bin/spark-shell
  


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->
I'm not so sure if it is intended but `build/sbt compile` is duplicated in developer-tools.