### PR TITLE
Fix remotes URLs to point to apache/spark

### DIFF
--- a/committers.md
+++ b/committers.md
@@ -179,12 +179,12 @@ After cloning your fork of Spark you already have a remote `origin` pointing the
 contains at least these lines:
 
 ```
-apache	git@github.com:apache/spark-website.git (fetch)
-apache	git@github.com:apache/spark-website.git (push)
-apache-github	git@github.com:apache/spark-website.git (fetch)
-apache-github	git@github.com:apache/spark-website.git (push)
-origin	git@github.com:[your username]/spark-website.git (fetch)
-origin	git@github.com:[your username]/spark-website.git (push)
+apache	git@github.com:apache/spark.git (fetch)
+apache	git@github.com:apache/spark.git (push)
+apache-github	git@github.com:apache/spark.git (fetch)
+apache-github	git@github.com:apache/spark.git (push)
+origin	git@github.com:[your username]/spark.git (fetch)
+origin	git@github.com:[your username]/spark.git (push)
 ```
 
 For the `apache` repo, you will need to set up command-line authentication to GitHub. This may

--- a/site/committers.html
+++ b/site/committers.html
@@ -626,12 +626,12 @@ into the official Spark repo just by specifying your fork in the <code class="la
 <p>After cloning your fork of Spark you already have a remote <code class="language-plaintext highlighter-rouge">origin</code> pointing there. So if correct, your <code class="language-plaintext highlighter-rouge">git remote -v</code>
 contains at least these lines:</p>
 
-<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>apache	git@github.com:apache/spark-website.git (fetch)
-apache	git@github.com:apache/spark-website.git (push)
-apache-github	git@github.com:apache/spark-website.git (fetch)
-apache-github	git@github.com:apache/spark-website.git (push)
-origin	git@github.com:[your username]/spark-website.git (fetch)
-origin	git@github.com:[your username]/spark-website.git (push)
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>apache	git@github.com:apache/spark.git (fetch)
+apache	git@github.com:apache/spark.git (push)
+apache-github	git@github.com:apache/spark.git (fetch)
+apache-github	git@github.com:apache/spark.git (push)
+origin	git@github.com:[your username]/spark.git (fetch)
+origin	git@github.com:[your username]/spark.git (push)
 </code></pre></div></div>
 
 <p>For the <code class="language-plaintext highlighter-rouge">apache</code> repo, you will need to set up command-line authentication to GitHub. This may


### PR DESCRIPTION
How to Merge a Pull Request section describes process of working with main Spark
repositiory. However, `git remote` links in the How to Merge a Pull Request point to apache/spark-website.

<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->
