### PR TITLE
Fix URL in twitter:image of home page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -22,7 +22,7 @@
   <meta name="twitter:site" content="@ApacheSpark">
   <meta name="twitter:title" content="{% if page.custom_title %} {{page.custom_title}}{% else %} {{page.title}} | Apache Spark{% endif %}">
   <meta name="twitter:description" content="{% if page.description %}{{page.description}}{% else %}Apache Spark is a unified engine for large-scale analytics{% endif %}">
-  <meta name="twitter:image" content="{{site.url}}{{site.baseurl}}images/spark-twitter-card-large.jpg">
+  <meta name="twitter:image" content="{{site.url}}{{site.baseurl}}/images/spark-twitter-card-large.jpg">
 
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"

--- a/site/index.html
+++ b/site/index.html
@@ -18,7 +18,7 @@
   <meta name="twitter:site" content="@ApacheSpark">
   <meta name="twitter:title" content=" Apache Spark&trade; - Unified Engine for large-scale data analytics">
   <meta name="twitter:description" content="Apache Spark is a multi-language engine for executing data engineering, data science, and machine learning on single-node machines or clusters.">
-  <meta name="twitter:image" content="https://spark.apache.orgimages/spark-twitter-card-large.jpg">
+  <meta name="twitter:image" content="https://spark.apache.org/images/spark-twitter-card-large.jpg">
 
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->
The URL of `twitter:image` misses one slash. This PR is to fix it.