### PR TITLE
Update DocSearch facet filter of 3.2.0 documentation

### DIFF
--- a/site/docs/3.2.0/building-spark.html
+++ b/site/docs/3.2.0/building-spark.html
@@ -523,7 +523,7 @@ Change the major Scala version using (e.g. 2.13):</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/cloud-integration.html
+++ b/site/docs/3.2.0/cloud-integration.html
@@ -489,7 +489,7 @@ under-reported with Hadoop versions before 3.3.1.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/cluster-overview.html
+++ b/site/docs/3.2.0/cluster-overview.html
@@ -300,7 +300,7 @@ The <a href="job-scheduling.html">job scheduling overview</a> describes this in 
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/configuration.html
+++ b/site/docs/3.2.0/configuration.html
@@ -4557,7 +4557,7 @@ This is only available for the RDD API in Scala, Java, and Python.  It is availa
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/core-migration-guide.html
+++ b/site/docs/3.2.0/core-migration-guide.html
@@ -316,7 +316,7 @@ interface must be modified to extend the new interfaces. Check the
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/graphx-programming-guide.html
+++ b/site/docs/3.2.0/graphx-programming-guide.html
@@ -1197,7 +1197,7 @@ all of this in just a few lines with GraphX:</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/hadoop-provided.html
+++ b/site/docs/3.2.0/hadoop-provided.html
@@ -205,7 +205,7 @@ ENTRYPOINT <span class="o">[</span> <span class="s2">"/opt/entrypoint.sh"</span>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/hardware-provisioning.html
+++ b/site/docs/3.2.0/hardware-provisioning.html
@@ -237,7 +237,7 @@ either CPU- or network-bound.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/index.html
+++ b/site/docs/3.2.0/index.html
@@ -334,7 +334,7 @@ available online for free.</li>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/job-scheduling.html
+++ b/site/docs/3.2.0/job-scheduling.html
@@ -464,7 +464,7 @@ later.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/migration-guide.html
+++ b/site/docs/3.2.0/migration-guide.html
@@ -253,7 +253,7 @@ for users to migrate effectively.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-advanced.html
+++ b/site/docs/3.2.0/ml-advanced.html
@@ -497,7 +497,7 @@ Currently IRLS is used as the default solver of <a href="api/scala/org/apache/sp
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-ann.html
+++ b/site/docs/3.2.0/ml-ann.html
@@ -401,7 +401,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-classification-regression.html
+++ b/site/docs/3.2.0/ml-classification-regression.html
@@ -4396,7 +4396,7 @@ All output columns are optional; to exclude an output column, set its correspond
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-clustering.html
+++ b/site/docs/3.2.0/ml-clustering.html
@@ -1131,7 +1131,7 @@ using truncated power iteration on a normalized pair-wise similarity matrix of t
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-collaborative-filtering.html
+++ b/site/docs/3.2.0/ml-collaborative-filtering.html
@@ -773,7 +773,7 @@ better results:</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-datasource.html
+++ b/site/docs/3.2.0/ml-datasource.html
@@ -607,7 +607,7 @@ only showing top 10 rows
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-decision-tree.html
+++ b/site/docs/3.2.0/ml-decision-tree.html
@@ -401,7 +401,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-ensembles.html
+++ b/site/docs/3.2.0/ml-ensembles.html
@@ -401,7 +401,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-features.html
+++ b/site/docs/3.2.0/ml-features.html
@@ -5128,7 +5128,7 @@ for more details on the API.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-frequent-pattern-mining.html
+++ b/site/docs/3.2.0/ml-frequent-pattern-mining.html
@@ -698,7 +698,7 @@ nulls in this column are ignored.</li>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-guide.html
+++ b/site/docs/3.2.0/ml-guide.html
@@ -498,7 +498,7 @@ watch Sam Halliday&#8217;s ScalaX talk on <a href="http://fommil.github.io/scala
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-linalg-guide.html
+++ b/site/docs/3.2.0/ml-linalg-guide.html
@@ -477,7 +477,7 @@ java.lang.RuntimeException: Unable to load native implementation
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-linear-methods.html
+++ b/site/docs/3.2.0/ml-linear-methods.html
@@ -401,7 +401,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-migration-guide.html
+++ b/site/docs/3.2.0/ml-migration-guide.html
@@ -775,7 +775,7 @@ take advantage of sparsity in both storage and computation. Details are describe
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-pipeline.html
+++ b/site/docs/3.2.0/ml-pipeline.html
@@ -1066,7 +1066,7 @@ the <a href="api/python/reference/api/pyspark.ml.param.Params.html"><code class=
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-statistics.html
+++ b/site/docs/3.2.0/ml-statistics.html
@@ -718,7 +718,7 @@ to compute the mean and variance for a vector column of the input dataframe, wit
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-survival-regression.html
+++ b/site/docs/3.2.0/ml-survival-regression.html
@@ -401,7 +401,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ml-tuning.html
+++ b/site/docs/3.2.0/ml-tuning.html
@@ -879,7 +879,7 @@ It splits the dataset into these two parts using the <code class="language-plain
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/mllib-classification-regression.html
+++ b/site/docs/3.2.0/mllib-classification-regression.html
@@ -496,7 +496,7 @@ the supported algorithms for each type of problem.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/mllib-clustering.html
+++ b/site/docs/3.2.0/mllib-clustering.html
@@ -1354,7 +1354,7 @@ you will see predictions. With new data, the cluster centers will change!</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/mllib-collaborative-filtering.html
+++ b/site/docs/3.2.0/mllib-collaborative-filtering.html
@@ -640,7 +640,7 @@ a dependency.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/mllib-data-types.html
+++ b/site/docs/3.2.0/mllib-data-types.html
@@ -1135,7 +1135,7 @@ can be created from an <code class="language-plaintext highlighter-rouge">RDD</c
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/mllib-decision-tree.html
+++ b/site/docs/3.2.0/mllib-decision-tree.html
@@ -901,7 +901,7 @@ depth of 5. The Mean Squared Error (MSE) is computed at the end to evaluate
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/mllib-dimensionality-reduction.html
+++ b/site/docs/3.2.0/mllib-dimensionality-reduction.html
@@ -711,7 +711,7 @@ and use them to project the vectors into a low-dimensional space.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/mllib-ensembles.html
+++ b/site/docs/3.2.0/mllib-ensembles.html
@@ -1188,7 +1188,7 @@ The Mean Squared Error (MSE) is computed at the end to evaluate
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/mllib-evaluation-metrics.html
+++ b/site/docs/3.2.0/mllib-evaluation-metrics.html
@@ -1648,7 +1648,7 @@ variable from a number of independent variables.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/mllib-feature-extraction.html
+++ b/site/docs/3.2.0/mllib-feature-extraction.html
@@ -975,7 +975,7 @@ Details you can read at <a href="mllib-dimensionality-reduction.html">dimensiona
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/mllib-frequent-pattern-mining.html
+++ b/site/docs/3.2.0/mllib-frequent-pattern-mining.html
@@ -744,7 +744,7 @@ that stores the frequent sequences with their frequencies.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/mllib-guide.html
+++ b/site/docs/3.2.0/mllib-guide.html
@@ -461,7 +461,7 @@ which is now the primary API for MLlib.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/mllib-isotonic-regression.html
+++ b/site/docs/3.2.0/mllib-isotonic-regression.html
@@ -584,7 +584,7 @@ labels and real labels in the test set.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/mllib-linear-methods.html
+++ b/site/docs/3.2.0/mllib-linear-methods.html
@@ -1068,7 +1068,7 @@ inverse Hessian matrix using quasi-Newton method.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/mllib-naive-bayes.html
+++ b/site/docs/3.2.0/mllib-naive-bayes.html
@@ -531,7 +531,7 @@ used for evaluation and prediction.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/mllib-optimization.html
+++ b/site/docs/3.2.0/mllib-optimization.html
@@ -800,7 +800,7 @@ regularization and step update later.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/mllib-pmml-model-export.html
+++ b/site/docs/3.2.0/mllib-pmml-model-export.html
@@ -475,7 +475,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/mllib-statistics.html
+++ b/site/docs/3.2.0/mllib-statistics.html
@@ -1245,7 +1245,7 @@ to do so.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/monitoring.html
+++ b/site/docs/3.2.0/monitoring.html
@@ -1689,7 +1689,7 @@ plugins are ignored.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/programming-guide.html
+++ b/site/docs/3.2.0/programming-guide.html
@@ -171,7 +171,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/pyspark-migration-guide.html
+++ b/site/docs/3.2.0/pyspark-migration-guide.html
@@ -243,7 +243,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/quick-start.html
+++ b/site/docs/3.2.0/quick-start.html
@@ -576,7 +576,7 @@ You can run them as follows:</li>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/rdd-programming-guide.html
+++ b/site/docs/3.2.0/rdd-programming-guide.html
@@ -1767,7 +1767,7 @@ in distributed operation and supported cluster managers.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/running-on-kubernetes.html
+++ b/site/docs/3.2.0/running-on-kubernetes.html
@@ -1615,7 +1615,7 @@ Note, there is a difference in the way pod template resources are handled betwee
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/running-on-mesos.html
+++ b/site/docs/3.2.0/running-on-mesos.html
@@ -1104,7 +1104,7 @@ termination. To launch it, run <code class="language-plaintext highlighter-rouge
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/running-on-yarn.html
+++ b/site/docs/3.2.0/running-on-yarn.html
@@ -1075,7 +1075,7 @@ which each contain a few configurations to adjust the port number and metrics na
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/security.html
+++ b/site/docs/3.2.0/security.html
@@ -1160,7 +1160,7 @@ Spark with permissions such that only the user and group have read and write acc
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/spark-standalone.html
+++ b/site/docs/3.2.0/spark-standalone.html
@@ -704,7 +704,7 @@ For more information about these configurations please refer to the <a href="con
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sparkr-migration-guide.html
+++ b/site/docs/3.2.0/sparkr-migration-guide.html
@@ -327,7 +327,7 @@ of the same name of a DataFrame.</li>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sparkr.html
+++ b/site/docs/3.2.0/sparkr.html
@@ -974,7 +974,7 @@ function is masking another function.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-data-sources-avro.html
+++ b/site/docs/3.2.0/sql-data-sources-avro.html
@@ -913,7 +913,7 @@ All other union types are considered complex. They will be mapped to StructType 
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-data-sources-binaryFile.html
+++ b/site/docs/3.2.0/sql-data-sources-binaryFile.html
@@ -418,7 +418,7 @@ For example, the following code reads all PNG files from the input directory:</p
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-data-sources-csv.html
+++ b/site/docs/3.2.0/sql-data-sources-csv.html
@@ -789,7 +789,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-data-sources-generic-options.html
+++ b/site/docs/3.2.0/sql-data-sources-generic-options.html
@@ -682,7 +682,7 @@ to the Spark session timezone (<code class="language-plaintext highlighter-rouge
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-data-sources-hive-tables.html
+++ b/site/docs/3.2.0/sql-data-sources-hive-tables.html
@@ -855,7 +855,7 @@ will compile against built-in Hive and use those classes for internal execution 
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-data-sources-jdbc.html
+++ b/site/docs/3.2.0/sql-data-sources-jdbc.html
@@ -815,7 +815,7 @@ Before using <code>keytab</code> and <code>principal</code> configuration option
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-data-sources-json.html
+++ b/site/docs/3.2.0/sql-data-sources-json.html
@@ -758,7 +758,7 @@ line must contain a separate, self-contained valid JSON object. For more informa
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-data-sources-load-save-functions.html
+++ b/site/docs/3.2.0/sql-data-sources-load-save-functions.html
@@ -835,7 +835,7 @@ data across a fixed number of buckets and can be used when the number of unique 
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-data-sources-orc.html
+++ b/site/docs/3.2.0/sql-data-sources-orc.html
@@ -585,7 +585,7 @@ Please visit <a href="https://hadoop.apache.org/docs/current/hadoop-kms/index.ht
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-data-sources-parquet.html
+++ b/site/docs/3.2.0/sql-data-sources-parquet.html
@@ -1080,7 +1080,7 @@ metadata.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-data-sources-text.html
+++ b/site/docs/3.2.0/sql-data-sources-text.html
@@ -561,7 +561,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-data-sources-troubleshooting.html
+++ b/site/docs/3.2.0/sql-data-sources-troubleshooting.html
@@ -382,7 +382,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-data-sources.html
+++ b/site/docs/3.2.0/sql-data-sources.html
@@ -436,7 +436,7 @@ goes into specific options that are available for the built-in data sources.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-distributed-sql-engine.html
+++ b/site/docs/3.2.0/sql-distributed-sql-engine.html
@@ -361,7 +361,7 @@ You may run <code class="language-plaintext highlighter-rouge">./bin/spark-sql -
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-getting-started.html
+++ b/site/docs/3.2.0/sql-getting-started.html
@@ -1390,7 +1390,7 @@ about user defined aggregate functions, please refer to the documentation of
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-migration-guide.html
+++ b/site/docs/3.2.0/sql-migration-guide.html
@@ -1743,7 +1743,7 @@ an aggregate over a fixed window.</li>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-migration-old.html
+++ b/site/docs/3.2.0/sql-migration-old.html
@@ -253,7 +253,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-performance-tuning.html
+++ b/site/docs/3.2.0/sql-performance-tuning.html
@@ -629,7 +629,7 @@ SELECT /*+ REBALANCE(c) */ * FROM t
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-programming-guide.html
+++ b/site/docs/3.2.0/sql-programming-guide.html
@@ -294,7 +294,7 @@ While, in <a href="api/java/index.html?org/apache/spark/sql/Dataset.html">Java A
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-pyspark-pandas-with-arrow.html
+++ b/site/docs/3.2.0/sql-pyspark-pandas-with-arrow.html
@@ -252,7 +252,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-ansi-compliance.html
+++ b/site/docs/3.2.0/sql-ref-ansi-compliance.html
@@ -2564,7 +2564,7 @@ In this mode, Spark SQL has two kinds of keywords:</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-datatypes.html
+++ b/site/docs/3.2.0/sql-ref-datatypes.html
@@ -1158,7 +1158,7 @@ Specifically:</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-datetime-pattern.html
+++ b/site/docs/3.2.0/sql-ref-datetime-pattern.html
@@ -613,7 +613,7 @@ An optional section is started by <code class="language-plaintext highlighter-ro
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-functions-builtin.html
+++ b/site/docs/3.2.0/sql-ref-functions-builtin.html
@@ -2809,7 +2809,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-functions-udf-aggregate.html
+++ b/site/docs/3.2.0/sql-ref-functions-udf-aggregate.html
@@ -737,7 +737,7 @@ For example, a user-defined average for untyped DataFrames can look like:</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-functions-udf-hive.html
+++ b/site/docs/3.2.0/sql-ref-functions-udf-hive.html
@@ -420,7 +420,7 @@ An example below uses <a href="https://github.com/apache/hive/blob/master/ql/src
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-functions-udf-scalar.html
+++ b/site/docs/3.2.0/sql-ref-functions-udf-scalar.html
@@ -497,7 +497,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-functions.html
+++ b/site/docs/3.2.0/sql-ref-functions.html
@@ -368,7 +368,7 @@ This subsection presents the usages and descriptions of these functions.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-identifier.html
+++ b/site/docs/3.2.0/sql-ref-identifier.html
@@ -392,7 +392,7 @@ CREATE TABLE test (`a``b` int);
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-literals.html
+++ b/site/docs/3.2.0/sql-ref-literals.html
@@ -952,7 +952,7 @@ Mix of the YEAR[S] or MONTH[S] interval units with other units is not allowed.
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-null-semantics.html
+++ b/site/docs/3.2.0/sql-ref-null-semantics.html
@@ -1100,7 +1100,7 @@ and because NOT UNKNOWN is again UNKNOWN.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-analyze-table.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-analyze-table.html
@@ -550,7 +550,7 @@ that are to be used by the query optimizer to find a better query execution plan
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-cache-cache-table.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-cache-cache-table.html
@@ -457,7 +457,7 @@ This reduces scanning of the original files in future queries.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-cache-clear-cache.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-cache-clear-cache.html
@@ -406,7 +406,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-cache-refresh-function.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-cache-refresh-function.html
@@ -426,7 +426,7 @@ Note that <code class="language-plaintext highlighter-rouge">REFRESH FUNCTION</c
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-cache-refresh-table.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-cache-refresh-table.html
@@ -426,7 +426,7 @@ lazy manner when the cached table or the query associated with it is executed ag
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-cache-refresh.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-cache-refresh.html
@@ -423,7 +423,7 @@ invalidate everything that is cached.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-cache-uncache-table.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-cache-uncache-table.html
@@ -419,7 +419,7 @@ underlying entries should already have been brought to cache by previous <code c
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-cache.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-cache.html
@@ -391,7 +391,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-conf-mgmt-reset.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-conf-mgmt-reset.html
@@ -423,7 +423,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-conf-mgmt-set-timezone.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-conf-mgmt-set-timezone.html
@@ -435,7 +435,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-conf-mgmt-set.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-conf-mgmt-set.html
@@ -439,7 +439,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-conf-mgmt.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-conf-mgmt.html
@@ -388,7 +388,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-describe-database.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-describe-database.html
@@ -461,7 +461,7 @@ interchangeable.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-describe-function.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-describe-function.html
@@ -477,7 +477,7 @@ metadata information is returned along with the extended usage information.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-describe-query.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-describe-query.html
@@ -479,7 +479,7 @@ describe the query output.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-describe-table.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-describe-table.html
@@ -551,7 +551,7 @@ to return the metadata pertaining to a partition or column respectively.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-describe.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-describe.html
@@ -389,7 +389,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-resource-mgmt-add-archive.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-resource-mgmt-add-archive.html
@@ -420,7 +420,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-resource-mgmt-add-file.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-resource-mgmt-add-file.html
@@ -421,7 +421,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-resource-mgmt-add-jar.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-resource-mgmt-add-jar.html
@@ -437,7 +437,7 @@ ivy://group:module:version?transitive=[true|false]&amp;exclude=group:module,grou
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-resource-mgmt-list-archive.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-resource-mgmt-list-archive.html
@@ -415,7 +415,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-resource-mgmt-list-file.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-resource-mgmt-list-file.html
@@ -415,7 +415,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-resource-mgmt-list-jar.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-resource-mgmt-list-jar.html
@@ -416,7 +416,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-resource-mgmt.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-resource-mgmt.html
@@ -391,7 +391,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-show-columns.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-show-columns.html
@@ -464,7 +464,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-show-create-table.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-show-create-table.html
@@ -429,7 +429,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-show-databases.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-show-databases.html
@@ -456,7 +456,7 @@ and mean the same thing.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-show-functions.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-show-functions.html
@@ -511,7 +511,7 @@ clause is optional and supported only for compatibility with other systems.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-show-partitions.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-show-partitions.html
@@ -477,7 +477,7 @@ partition spec.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-show-table.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-show-table.html
@@ -550,7 +550,7 @@ any of which can match.</li>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-show-tables.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-show-tables.html
@@ -475,7 +475,7 @@ any of which can match.</li>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-show-tblproperties.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-show-tblproperties.html
@@ -486,7 +486,7 @@ properties are: <code class="language-plaintext highlighter-rouge">numFiles</cod
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-show-views.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-show-views.html
@@ -486,7 +486,7 @@ any of which can match.</li>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-aux-show.html
+++ b/site/docs/3.2.0/sql-ref-syntax-aux-show.html
@@ -394,7 +394,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-ddl-alter-database.html
+++ b/site/docs/3.2.0/sql-ref-syntax-ddl-alter-database.html
@@ -432,7 +432,7 @@ for a database and may be used for auditing purposes.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-ddl-alter-table.html
+++ b/site/docs/3.2.0/sql-ref-syntax-ddl-alter-table.html
@@ -832,7 +832,7 @@ existing tables.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-ddl-alter-view.html
+++ b/site/docs/3.2.0/sql-ref-syntax-ddl-alter-view.html
@@ -584,7 +584,7 @@ and the <code class="language-plaintext highlighter-rouge">view_identifier</code
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-ddl-create-database.html
+++ b/site/docs/3.2.0/sql-ref-syntax-ddl-create-database.html
@@ -457,7 +457,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-ddl-create-function.html
+++ b/site/docs/3.2.0/sql-ref-syntax-ddl-create-function.html
@@ -539,7 +539,7 @@ aggregate functions using Scala, Python and Java APIs. Please refer to
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-ddl-create-table-datasource.html
+++ b/site/docs/3.2.0/sql-ref-syntax-ddl-create-table-datasource.html
@@ -515,7 +515,7 @@ input query, to make sure the table gets created contains exactly the same data 
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-ddl-create-table-hiveformat.html
+++ b/site/docs/3.2.0/sql-ref-syntax-ddl-create-table-hiveformat.html
@@ -572,7 +572,7 @@ as any order. For example, you can write COMMENT table_comment after TBLPROPERTI
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-ddl-create-table-like.html
+++ b/site/docs/3.2.0/sql-ref-syntax-ddl-create-table-like.html
@@ -459,7 +459,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-ddl-create-table.html
+++ b/site/docs/3.2.0/sql-ref-syntax-ddl-create-table.html
@@ -401,7 +401,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-ddl-create-view.html
+++ b/site/docs/3.2.0/sql-ref-syntax-ddl-create-view.html
@@ -462,7 +462,7 @@ A <a href="sql-ref-syntax-qry-select.html">SELECT</a> statement that constructs 
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-ddl-drop-database.html
+++ b/site/docs/3.2.0/sql-ref-syntax-ddl-drop-database.html
@@ -437,7 +437,7 @@ exception will be thrown if the database does not exist in the system.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-ddl-drop-function.html
+++ b/site/docs/3.2.0/sql-ref-syntax-ddl-drop-function.html
@@ -470,7 +470,7 @@ be thrown if the function does not exist.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-ddl-drop-table.html
+++ b/site/docs/3.2.0/sql-ref-syntax-ddl-drop-table.html
@@ -440,7 +440,7 @@ if the table is not <code class="language-plaintext highlighter-rouge">EXTERNAL<
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-ddl-drop-view.html
+++ b/site/docs/3.2.0/sql-ref-syntax-ddl-drop-view.html
@@ -437,7 +437,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-ddl-repair-table.html
+++ b/site/docs/3.2.0/sql-ref-syntax-ddl-repair-table.html
@@ -447,7 +447,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-ddl-truncate-table.html
+++ b/site/docs/3.2.0/sql-ref-syntax-ddl-truncate-table.html
@@ -457,7 +457,7 @@ in <code class="language-plaintext highlighter-rouge">partition_spec</code>. If 
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-ddl-usedb.html
+++ b/site/docs/3.2.0/sql-ref-syntax-ddl-usedb.html
@@ -423,7 +423,7 @@ The default database name is &#8216;default&#8217;.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-dml-insert-into.html
+++ b/site/docs/3.2.0/sql-ref-syntax-dml-insert-into.html
@@ -622,7 +622,7 @@ SELECT * FROM students WHERE name = 'Kent Yao';
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-dml-insert-overwrite-directory-hive.html
+++ b/site/docs/3.2.0/sql-ref-syntax-dml-insert-overwrite-directory-hive.html
@@ -449,7 +449,7 @@ Hive support must be enabled to use this command. The inserted rows can be speci
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-dml-insert-overwrite-directory.html
+++ b/site/docs/3.2.0/sql-ref-syntax-dml-insert-overwrite-directory.html
@@ -451,7 +451,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-dml-insert-overwrite-table.html
+++ b/site/docs/3.2.0/sql-ref-syntax-dml-insert-overwrite-table.html
@@ -606,7 +606,7 @@ SELECT * FROM students WHERE name = 'Kent Yao';
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-dml-load.html
+++ b/site/docs/3.2.0/sql-ref-syntax-dml-load.html
@@ -483,7 +483,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-hive-format.html
+++ b/site/docs/3.2.0/sql-ref-syntax-hive-format.html
@@ -447,7 +447,7 @@ There are two ways to define a row format in <code class="language-plaintext hig
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-explain.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-explain.html
@@ -495,7 +495,7 @@ EXPLAIN FORMATTED select k, sum(v) from values (1, 2), (1, 3) t(k, v) group by k
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-case.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-case.html
@@ -477,7 +477,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-clusterby.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-clusterby.html
@@ -470,7 +470,7 @@ resultant rows are sorted within each partition and does not guarantee a total o
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-cte.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-cte.html
@@ -490,7 +490,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-distribute-by.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-distribute-by.html
@@ -465,7 +465,7 @@ clause, this does not sort the data within each partition.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-file.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-file.html
@@ -443,7 +443,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-groupby.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-groupby.html
@@ -692,7 +692,7 @@ an aggregate function, only the matching rows are passed to that function.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-having.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-having.html
@@ -498,7 +498,7 @@ clause.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-hints.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-hints.html
@@ -535,7 +535,7 @@ specified, multiple nodes are inserted into the logical plan, but the leftmost h
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-inline-table.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-inline-table.html
@@ -444,7 +444,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-join.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-join.html
@@ -606,7 +606,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-lateral-view.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-lateral-view.html
@@ -494,7 +494,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-like.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-like.html
@@ -548,7 +548,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-limit.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-limit.html
@@ -476,7 +476,7 @@ ensure that the results are deterministic.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-orderby.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-orderby.html
@@ -518,7 +518,7 @@ the sort order.</li>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-pivot.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-pivot.html
@@ -470,7 +470,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-sampling.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-sampling.html
@@ -458,7 +458,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-setops.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-setops.html
@@ -556,7 +556,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-sortby.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-sortby.html
@@ -551,7 +551,7 @@ the sort order.</li>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-subqueries.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-subqueries.html
@@ -384,7 +384,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-transform.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-transform.html
@@ -642,7 +642,7 @@ to transform the inputs by running a user-specified command or script.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-tvf.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-tvf.html
@@ -601,7 +601,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-where.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-where.html
@@ -496,7 +496,7 @@ clause of a query or a subquery based on the specified condition.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select-window.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select-window.html
@@ -568,7 +568,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax-qry-select.html
+++ b/site/docs/3.2.0/sql-ref-syntax-qry-select.html
@@ -581,7 +581,7 @@ of a query along with examples.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref-syntax.html
+++ b/site/docs/3.2.0/sql-ref-syntax.html
@@ -488,7 +488,7 @@ ability to generate logical and physical plan for a given query using
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/sql-ref.html
+++ b/site/docs/3.2.0/sql-ref.html
@@ -363,7 +363,7 @@
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/ss-migration-guide.html
+++ b/site/docs/3.2.0/ss-migration-guide.html
@@ -278,7 +278,7 @@ For further details please see <a href="structured-streaming-kafka-integration.h
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/storage-openstack-swift.html
+++ b/site/docs/3.2.0/storage-openstack-swift.html
@@ -295,7 +295,7 @@ For job submissions they should be provided via <code>sparkContext.hadoopConfigu
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/streaming-custom-receivers.html
+++ b/site/docs/3.2.0/streaming-custom-receivers.html
@@ -411,7 +411,7 @@ interval in the <a href="streaming-programming-guide.html">Spark Streaming Progr
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/streaming-kafka-0-10-integration.html
+++ b/site/docs/3.2.0/streaming-kafka-0-10-integration.html
@@ -487,7 +487,7 @@ Note that the example sets enable.auto.commit to false, for discussion see <a hr
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/streaming-kafka-integration.html
+++ b/site/docs/3.2.0/streaming-kafka-integration.html
@@ -173,7 +173,7 @@ thoroughly before starting an integration using Spark.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/streaming-kinesis-integration.html
+++ b/site/docs/3.2.0/streaming-kinesis-integration.html
@@ -488,7 +488,7 @@ de-aggregate records during consumption.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/streaming-programming-guide.html
+++ b/site/docs/3.2.0/streaming-programming-guide.html
@@ -2663,7 +2663,7 @@ and <a href="https://github.com/apache/spark/tree/master/examples/src/main/pytho
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/structured-streaming-kafka-integration.html
+++ b/site/docs/3.2.0/structured-streaming-kafka-integration.html
@@ -1307,7 +1307,7 @@ This can be done several ways. One possibility is to provide additional JVM para
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/structured-streaming-programming-guide.html
+++ b/site/docs/3.2.0/structured-streaming-programming-guide.html
@@ -3820,7 +3820,7 @@ examples.
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/submitting-applications.html
+++ b/site/docs/3.2.0/submitting-applications.html
@@ -386,7 +386,7 @@ the components involved in distributed execution, and how to monitor and debug a
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/tuning.html
+++ b/site/docs/3.2.0/tuning.html
@@ -526,7 +526,7 @@ performance issues. Feel free to ask on the
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });

--- a/site/docs/3.2.0/web-ui.html
+++ b/site/docs/3.2.0/web-ui.html
@@ -642,7 +642,7 @@ which can be useful for troubleshooting the streaming application.</p>
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,
     algoliaOptions: {
-      'facetFilters': ["version:3.2.1"]
+      'facetFilters': ["version:3.2.0"]
     },
     debug: false // Set debug to true if you want to inspect the dropdown
 });


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->

There is a bug in updating the DocSearch facet filter on https://github.com/apache/spark/blob/master/dev/create-release/release-tag.sh. The version is not updated as the release version.

This PR is to fix the search function of https://spark.apache.org/docs/3.2.0/. I will open another PR to fix the script on Spark.