### PR TITLE
Remove preview release for Spark 3.0

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -30,14 +30,6 @@ window.onload = function () {
 
 Note that, Spark 2.x is pre-built with Scala 2.11 except version 2.4.2, which is pre-built with Scala 2.12. Spark 3.0+ is pre-built with Scala 2.12.
 
-### Latest preview release
-Preview releases, as the name suggests, are releases for previewing upcoming features.
-Unlike nightly packages, preview releases have been audited by the project's management committee
-to satisfy the legal requirements of Apache Software Foundation's release policy.
-Preview releases are not meant to be functional, i.e. they can and highly likely will contain
-critical bugs or documentation errors.
-The latest preview release is Spark 3.0.0-preview2, published on Dec 23, 2019.
-
 ### Link with Spark
 Spark artifacts are [hosted in Maven Central](https://search.maven.org/search?q=g:org.apache.spark). You can add a Maven dependency with the following coordinates:
 

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -174,14 +174,6 @@ window.onload = function () {
 
 <p>Note that, Spark 2.x is pre-built with Scala 2.11 except version 2.4.2, which is pre-built with Scala 2.12. Spark 3.0+ is pre-built with Scala 2.12.</p>
 
-<h3 id="latest-preview-release">Latest preview release</h3>
-<p>Preview releases, as the name suggests, are releases for previewing upcoming features.
-Unlike nightly packages, preview releases have been audited by the project&#8217;s management committee
-to satisfy the legal requirements of Apache Software Foundation&#8217;s release policy.
-Preview releases are not meant to be functional, i.e. they can and highly likely will contain
-critical bugs or documentation errors.
-The latest preview release is Spark 3.0.0-preview2, published on Dec 23, 2019.</p>
-
 <h3 id="link-with-spark">Link with Spark</h3>
 <p>Spark artifacts are <a href="https://search.maven.org/search?q=g:org.apache.spark">hosted in Maven Central</a>. You can add a Maven dependency with the following coordinates:</p>
 


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->

Remove the preview release for Spark 3.0 since we've already released Spark 3.2.

Tested with manual build and preview.
