### PR TITLE
Fix the link of SPARK-24554 in Spark 3.1.1 release note

### DIFF
--- a/releases/_posts/2021-03-02-spark-release-3-1-1.md
+++ b/releases/_posts/2021-03-02-spark-release-3-1-1.md
@@ -222,7 +222,7 @@ Please read the migration guides for each component: [Spark Core](https://spark.
 - Support getCheckpointDir method in PySpark SparkContext ([SPARK-33017](https://issues.apache.org/jira/browse/SPARK-33017))
 - Support to fill nulls for missing columns in unionByName ([SPARK-32798](https://issues.apache.org/jira/browse/SPARK-32798))
 - Update cloudpickle to v1.5.0 ([SPARK-32094](https://issues.apache.org/jira/browse/SPARK-32094))
-- Add MapType support for PySpark with Arrow ([SPARK-24554](https://issues.apache.org/jira/browse/SPARK-33748))
+- Add MapType support for PySpark with Arrow ([SPARK-24554](https://issues.apache.org/jira/browse/SPARK-24554))
 - DataStreamReader.table and DataStreamWriter.toTable ([SPARK-33836](https://issues.apache.org/jira/browse/SPARK-33836))
 
 **Changes of behavior**

--- a/site/releases/spark-release-3-1-1.html
+++ b/site/releases/spark-release-3-1-1.html
@@ -424,7 +424,7 @@
   <li>Support getCheckpointDir method in PySpark SparkContext (<a href="https://issues.apache.org/jira/browse/SPARK-33017">SPARK-33017</a>)</li>
   <li>Support to fill nulls for missing columns in unionByName (<a href="https://issues.apache.org/jira/browse/SPARK-32798">SPARK-32798</a>)</li>
   <li>Update cloudpickle to v1.5.0 (<a href="https://issues.apache.org/jira/browse/SPARK-32094">SPARK-32094</a>)</li>
-  <li>Add MapType support for PySpark with Arrow (<a href="https://issues.apache.org/jira/browse/SPARK-33748">SPARK-24554</a>)</li>
+  <li>Add MapType support for PySpark with Arrow (<a href="https://issues.apache.org/jira/browse/SPARK-24554">SPARK-24554</a>)</li>
   <li>DataStreamReader.table and DataStreamWriter.toTable (<a href="https://issues.apache.org/jira/browse/SPARK-33836">SPARK-33836</a>)</li>
 </ul>
 


### PR DESCRIPTION
SPARK-24554 has to link to https://issues.apache.org/jira/browse/SPARK-24554 but it's linked to https://issues.apache.org/jira/browse/SPARK-33748. This PR fixes the link.