### PR TITLE
Remove Spark 2.x description from downloads page

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -28,7 +28,7 @@ window.onload = function () {
 
 4. Verify this release using the <span id="sparkDownloadVerify"></span> and [project release KEYS](https://downloads.apache.org/spark/KEYS).
 
-Note that, Spark 2.x is pre-built with Scala 2.11 except version 2.4.2, which is pre-built with Scala 2.12. Spark 3.0+ is pre-built with Scala 2.12.
+Note that Spark 3 is pre-built with Scala 2.12 in general and Spark 3.2+ provides additional pre-built distribution with Scala 2.13.
 
 ### Link with Spark
 Spark artifacts are [hosted in Maven Central](https://search.maven.org/search?q=g:org.apache.spark). You can add a Maven dependency with the following coordinates:

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -172,7 +172,7 @@ window.onload = function () {
   </li>
 </ol>
 
-<p>Note that, Spark 2.x is pre-built with Scala 2.11 except version 2.4.2, which is pre-built with Scala 2.12. Spark 3.0+ is pre-built with Scala 2.12.</p>
+<p>Note that Spark 3 is pre-built with Scala 2.12 in general and Spark 3.2+ provides additional pre-built distribution with Scala 2.13.</p>
 
 <h3 id="link-with-spark">Link with Spark</h3>
 <p>Spark artifacts are <a href="https://search.maven.org/search?q=g:org.apache.spark">hosted in Maven Central</a>. You can add a Maven dependency with the following coordinates:</p>


### PR DESCRIPTION
This PR aims to remove Spark 2 description from the download page and mention Scala 2.13 pre-built distribution.