### PR TITLE
fix display problem

### DIFF
--- a/releases/_posts/2022-01-26-spark-release-3-2-1.md
+++ b/releases/_posts/2022-01-26-spark-release-3-2-1.md
@@ -15,30 +15,30 @@ Spark 3.2.1 is a maintenance release containing stability fixes. This release is
 
 ### Notable changes
 
-- [[SPARK-30789]](https://issues.apache.org/jira/browse/SPARK-30789): Support (IGNORE | RESPECT) NULLS for LEAD/LAG/NTH_VALUE/FIRST_VALUE/LAST_VALUE
-- [[SPARK-33277]](https://issues.apache.org/jira/browse/SPARK-33277): Python/Pandas UDF right after off-heap vectorized reader could cause executor crash.
-- [[SPARK-34399]](https://issues.apache.org/jira/browse/SPARK-34399): Add file commit time to metrics and shown in SQL Tab UI
-- [[SPARK-35714]](https://issues.apache.org/jira/browse/SPARK-35714): Bug fix for deadlock during the executor shutdown
-- [[SPARK-36754]](https://issues.apache.org/jira/browse/SPARK-36754): array_intersect should handle Double.NaN and Float.NaN
-- [[SPARK-37001]](https://issues.apache.org/jira/browse/SPARK-37001): Disable two level of map for final hash aggregation by default
-- [[SPARK-37023]](https://issues.apache.org/jira/browse/SPARK-37023): Avoid fetching merge status when shuffleMergeEnabled is false for a shuffleDependency during retry
-- [[SPARK-37088]](https://issues.apache.org/jira/browse/SPARK-37088): Python UDF after off-heap vectorized reader can cause crash due to use-after-free in writer thread
-- [[SPARK-37202]](https://issues.apache.org/jira/browse/SPARK-37202): Temp view didn't collect temp function that registered with catalog API
-- [[SPARK-37208]](https://issues.apache.org/jira/browse/SPARK-37208): Support mapping Spark gpu/fpga resource types to custom YARN resource type
-- [[SPARK-37214]](https://issues.apache.org/jira/browse/SPARK-37214): Fail query analysis earlier with invalid identifiers
-- [[SPARK-37392]](https://issues.apache.org/jira/browse/SPARK-37392): Fix the performance bug when inferring constraints for Generate
-- [[SPARK-37695]](https://issues.apache.org/jira/browse/SPARK-37695): Skip diagnosis ob merged blocks from push-based shuffle
-- [[SPARK-37705]](https://issues.apache.org/jira/browse/SPARK-37705): Write session time zone in the Parquet file metadata so that rebase can use it instead of JVM timezone
-- [[SPARK-37957]](https://issues.apache.org/jira/browse/SPARK-37957): Deterministic flag is not handled for V2 functions
+  - [[SPARK-30789]](https://issues.apache.org/jira/browse/SPARK-30789): Support IGNORE/RESPECT NULLS for LEAD/LAG/NTH_VALUE/FIRST_VALUE/LAST_VALUE
+  - [[SPARK-33277]](https://issues.apache.org/jira/browse/SPARK-33277): Python/Pandas UDF right after off-heap vectorized reader could cause executor crash.
+  - [[SPARK-34399]](https://issues.apache.org/jira/browse/SPARK-34399): Add file commit time to metrics and shown in SQL Tab UI
+  - [[SPARK-35714]](https://issues.apache.org/jira/browse/SPARK-35714): Bug fix for deadlock during the executor shutdown
+  - [[SPARK-36754]](https://issues.apache.org/jira/browse/SPARK-36754): array_intersect should handle Double.NaN and Float.NaN
+  - [[SPARK-37001]](https://issues.apache.org/jira/browse/SPARK-37001): Disable two level of map for final hash aggregation by default
+  - [[SPARK-37023]](https://issues.apache.org/jira/browse/SPARK-37023): Avoid fetching merge status when shuffleMergeEnabled is false for a shuffleDependency during retry
+  - [[SPARK-37088]](https://issues.apache.org/jira/browse/SPARK-37088): Python UDF after off-heap vectorized reader can cause crash due to use-after-free in writer thread
+  - [[SPARK-37202]](https://issues.apache.org/jira/browse/SPARK-37202): Temp view didn't collect temp function that registered with catalog API
+  - [[SPARK-37208]](https://issues.apache.org/jira/browse/SPARK-37208): Support mapping Spark gpu/fpga resource types to custom YARN resource type
+  - [[SPARK-37214]](https://issues.apache.org/jira/browse/SPARK-37214): Fail query analysis earlier with invalid identifiers
+  - [[SPARK-37392]](https://issues.apache.org/jira/browse/SPARK-37392): Fix the performance bug when inferring constraints for Generate
+  - [[SPARK-37695]](https://issues.apache.org/jira/browse/SPARK-37695): Skip diagnosis ob merged blocks from push-based shuffle
+  - [[SPARK-37705]](https://issues.apache.org/jira/browse/SPARK-37705): Write session time zone in the Parquet file metadata so that rebase can use it instead of JVM timezone
+  - [[SPARK-37957]](https://issues.apache.org/jira/browse/SPARK-37957): Deterministic flag is not handled for V2 functions
 
 ### Dependency Changes
 
 While being a maintence release we did still upgrade some dependencies in this release they are:
 
-- [[SPARK-37113]](https://issues.apache.org/jira/browse/SPARK-37113): Upgrade Parquet to 1.12.2
-- [[SPARK-37238]](https://issues.apache.org/jira/browse/SPARK-37238): Upgrade ORC to 1.6.12
-- [[SPARK-37534]](https://issues.apache.org/jira/browse/SPARK-37534): Bump dev.ludovic.netlib to 2.2.1
-- [[SPARK-37656]](https://issues.apache.org/jira/browse/SPARK-37656): Upgrade SBT to 1.5.7
+  - [[SPARK-37113]](https://issues.apache.org/jira/browse/SPARK-37113): Upgrade Parquet to 1.12.2
+  - [[SPARK-37238]](https://issues.apache.org/jira/browse/SPARK-37238): Upgrade ORC to 1.6.12
+  - [[SPARK-37534]](https://issues.apache.org/jira/browse/SPARK-37534): Bump dev.ludovic.netlib to 2.2.1
+  - [[SPARK-37656]](https://issues.apache.org/jira/browse/SPARK-37656): Upgrade SBT to 1.5.7
 
 You can consult JIRA for the [detailed changes](https://s.apache.org/spark-3.2.1).
 

--- a/site/releases/spark-release-3-2-1.html
+++ b/site/releases/spark-release-3-2-1.html
@@ -152,16 +152,7 @@
 <h3 id="notable-changes">Notable changes</h3>
 
 <ul>
-  <li>
-    <table>
-      <tbody>
-        <tr>
-          <td><a href="https://issues.apache.org/jira/browse/SPARK-30789">[SPARK-30789]</a>: Support (IGNORE</td>
-          <td>RESPECT) NULLS for LEAD/LAG/NTH_VALUE/FIRST_VALUE/LAST_VALUE</td>
-        </tr>
-      </tbody>
-    </table>
-  </li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-30789">[SPARK-30789]</a>: Support IGNORE/RESPECT NULLS for LEAD/LAG/NTH_VALUE/FIRST_VALUE/LAST_VALUE</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-33277">[SPARK-33277]</a>: Python/Pandas UDF right after off-heap vectorized reader could cause executor crash.</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-34399">[SPARK-34399]</a>: Add file commit time to metrics and shown in SQL Tab UI</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-35714">[SPARK-35714]</a>: Bug fix for deadlock during the executor shutdown</li>


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->
I think this `|` inside ` Support (IGNORE | RESPECT) ...` caused display problem. The dot looks strange and the `|` in between of `IGNORE` and `RESPECT` is gone. 
```
- [[SPARK-30789]](https://issues.apache.org/jira/browse/SPARK-30789): Support (IGNORE | RESPECT) NULLS for LEAD/LAG/NTH_VALUE/FIRST_VALUE/LAST_VALUE
```
<img width="891" alt="Screen Shot 2022-01-28 at 2 39 37 PM" src="https://user-images.githubusercontent.com/13592258/151631202-b3219f5e-9c88-4cb9-a60d-bd2de2536f1d.png">

I will also fix the spaces in this file. All the other release md files have two spaces before each of the line for the jira list, but my intelliJ setting is not right, all the spaces are gone so I will manually add these spaces back.