### PR TITLE
Fix Doc Search of 3.2.1

### DIFF
--- a/site/docs/3.2.1/building-spark.html
+++ b/site/docs/3.2.1/building-spark.html
@@ -518,7 +518,8 @@ Change the major Scala version using (e.g. 2.13):</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/cloud-integration.html
+++ b/site/docs/3.2.1/cloud-integration.html
@@ -484,7 +484,8 @@ under-reported with Hadoop versions before 3.3.1.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/cluster-overview.html
+++ b/site/docs/3.2.1/cluster-overview.html
@@ -295,7 +295,8 @@ The <a href="job-scheduling.html">job scheduling overview</a> describes this in 
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/configuration.html
+++ b/site/docs/3.2.1/configuration.html
@@ -4552,7 +4552,8 @@ This is only available for the RDD API in Scala, Java, and Python.  It is availa
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/core-migration-guide.html
+++ b/site/docs/3.2.1/core-migration-guide.html
@@ -311,7 +311,8 @@ interface must be modified to extend the new interfaces. Check the
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/graphx-programming-guide.html
+++ b/site/docs/3.2.1/graphx-programming-guide.html
@@ -1192,7 +1192,8 @@ all of this in just a few lines with GraphX:</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/hadoop-provided.html
+++ b/site/docs/3.2.1/hadoop-provided.html
@@ -200,7 +200,8 @@ ENTRYPOINT <span class="o">[</span> <span class="s2">"/opt/entrypoint.sh"</span>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/hardware-provisioning.html
+++ b/site/docs/3.2.1/hardware-provisioning.html
@@ -232,7 +232,8 @@ either CPU- or network-bound.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/index.html
+++ b/site/docs/3.2.1/index.html
@@ -329,7 +329,8 @@ available online for free.</li>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/job-scheduling.html
+++ b/site/docs/3.2.1/job-scheduling.html
@@ -459,7 +459,8 @@ later.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/migration-guide.html
+++ b/site/docs/3.2.1/migration-guide.html
@@ -248,7 +248,8 @@ for users to migrate effectively.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-advanced.html
+++ b/site/docs/3.2.1/ml-advanced.html
@@ -492,7 +492,8 @@ Currently IRLS is used as the default solver of <a href="api/scala/org/apache/sp
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-ann.html
+++ b/site/docs/3.2.1/ml-ann.html
@@ -396,7 +396,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-classification-regression.html
+++ b/site/docs/3.2.1/ml-classification-regression.html
@@ -4391,7 +4391,8 @@ All output columns are optional; to exclude an output column, set its correspond
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-clustering.html
+++ b/site/docs/3.2.1/ml-clustering.html
@@ -1126,7 +1126,8 @@ using truncated power iteration on a normalized pair-wise similarity matrix of t
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-collaborative-filtering.html
+++ b/site/docs/3.2.1/ml-collaborative-filtering.html
@@ -768,7 +768,8 @@ better results:</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-datasource.html
+++ b/site/docs/3.2.1/ml-datasource.html
@@ -602,7 +602,8 @@ only showing top 10 rows
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-decision-tree.html
+++ b/site/docs/3.2.1/ml-decision-tree.html
@@ -396,7 +396,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-ensembles.html
+++ b/site/docs/3.2.1/ml-ensembles.html
@@ -396,7 +396,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-features.html
+++ b/site/docs/3.2.1/ml-features.html
@@ -5123,7 +5123,8 @@ for more details on the API.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-frequent-pattern-mining.html
+++ b/site/docs/3.2.1/ml-frequent-pattern-mining.html
@@ -693,7 +693,8 @@ nulls in this column are ignored.</li>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-guide.html
+++ b/site/docs/3.2.1/ml-guide.html
@@ -493,7 +493,8 @@ watch Sam Halliday&#8217;s ScalaX talk on <a href="http://fommil.github.io/scala
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-linalg-guide.html
+++ b/site/docs/3.2.1/ml-linalg-guide.html
@@ -472,7 +472,8 @@ java.lang.RuntimeException: Unable to load native implementation
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-linear-methods.html
+++ b/site/docs/3.2.1/ml-linear-methods.html
@@ -396,7 +396,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-migration-guide.html
+++ b/site/docs/3.2.1/ml-migration-guide.html
@@ -770,7 +770,8 @@ take advantage of sparsity in both storage and computation. Details are describe
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-pipeline.html
+++ b/site/docs/3.2.1/ml-pipeline.html
@@ -1061,7 +1061,8 @@ the <a href="api/python/reference/api/pyspark.ml.param.Params.html"><code class=
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-statistics.html
+++ b/site/docs/3.2.1/ml-statistics.html
@@ -713,7 +713,8 @@ to compute the mean and variance for a vector column of the input dataframe, wit
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-survival-regression.html
+++ b/site/docs/3.2.1/ml-survival-regression.html
@@ -396,7 +396,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ml-tuning.html
+++ b/site/docs/3.2.1/ml-tuning.html
@@ -874,7 +874,8 @@ It splits the dataset into these two parts using the <code class="language-plain
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/mllib-classification-regression.html
+++ b/site/docs/3.2.1/mllib-classification-regression.html
@@ -491,7 +491,8 @@ the supported algorithms for each type of problem.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/mllib-clustering.html
+++ b/site/docs/3.2.1/mllib-clustering.html
@@ -1349,7 +1349,8 @@ you will see predictions. With new data, the cluster centers will change!</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/mllib-collaborative-filtering.html
+++ b/site/docs/3.2.1/mllib-collaborative-filtering.html
@@ -635,7 +635,8 @@ a dependency.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/mllib-data-types.html
+++ b/site/docs/3.2.1/mllib-data-types.html
@@ -1130,7 +1130,8 @@ can be created from an <code class="language-plaintext highlighter-rouge">RDD</c
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/mllib-decision-tree.html
+++ b/site/docs/3.2.1/mllib-decision-tree.html
@@ -896,7 +896,8 @@ depth of 5. The Mean Squared Error (MSE) is computed at the end to evaluate
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/mllib-dimensionality-reduction.html
+++ b/site/docs/3.2.1/mllib-dimensionality-reduction.html
@@ -706,7 +706,8 @@ and use them to project the vectors into a low-dimensional space.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/mllib-ensembles.html
+++ b/site/docs/3.2.1/mllib-ensembles.html
@@ -1183,7 +1183,8 @@ The Mean Squared Error (MSE) is computed at the end to evaluate
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/mllib-evaluation-metrics.html
+++ b/site/docs/3.2.1/mllib-evaluation-metrics.html
@@ -1643,7 +1643,8 @@ variable from a number of independent variables.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/mllib-feature-extraction.html
+++ b/site/docs/3.2.1/mllib-feature-extraction.html
@@ -970,7 +970,8 @@ Details you can read at <a href="mllib-dimensionality-reduction.html">dimensiona
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/mllib-frequent-pattern-mining.html
+++ b/site/docs/3.2.1/mllib-frequent-pattern-mining.html
@@ -739,7 +739,8 @@ that stores the frequent sequences with their frequencies.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/mllib-guide.html
+++ b/site/docs/3.2.1/mllib-guide.html
@@ -456,7 +456,8 @@ which is now the primary API for MLlib.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/mllib-isotonic-regression.html
+++ b/site/docs/3.2.1/mllib-isotonic-regression.html
@@ -579,7 +579,8 @@ labels and real labels in the test set.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/mllib-linear-methods.html
+++ b/site/docs/3.2.1/mllib-linear-methods.html
@@ -1063,7 +1063,8 @@ inverse Hessian matrix using quasi-Newton method.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/mllib-naive-bayes.html
+++ b/site/docs/3.2.1/mllib-naive-bayes.html
@@ -526,7 +526,8 @@ used for evaluation and prediction.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/mllib-optimization.html
+++ b/site/docs/3.2.1/mllib-optimization.html
@@ -795,7 +795,8 @@ regularization and step update later.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/mllib-pmml-model-export.html
+++ b/site/docs/3.2.1/mllib-pmml-model-export.html
@@ -470,7 +470,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/mllib-statistics.html
+++ b/site/docs/3.2.1/mllib-statistics.html
@@ -1240,7 +1240,8 @@ to do so.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/monitoring.html
+++ b/site/docs/3.2.1/monitoring.html
@@ -1684,7 +1684,8 @@ plugins are ignored.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/programming-guide.html
+++ b/site/docs/3.2.1/programming-guide.html
@@ -166,7 +166,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/pyspark-migration-guide.html
+++ b/site/docs/3.2.1/pyspark-migration-guide.html
@@ -238,7 +238,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/quick-start.html
+++ b/site/docs/3.2.1/quick-start.html
@@ -571,7 +571,8 @@ You can run them as follows:</li>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/rdd-programming-guide.html
+++ b/site/docs/3.2.1/rdd-programming-guide.html
@@ -1762,7 +1762,8 @@ in distributed operation and supported cluster managers.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/running-on-kubernetes.html
+++ b/site/docs/3.2.1/running-on-kubernetes.html
@@ -1757,7 +1757,8 @@ Note, there is a difference in the way pod template resources are handled betwee
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/running-on-mesos.html
+++ b/site/docs/3.2.1/running-on-mesos.html
@@ -1099,7 +1099,8 @@ termination. To launch it, run <code class="language-plaintext highlighter-rouge
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/running-on-yarn.html
+++ b/site/docs/3.2.1/running-on-yarn.html
@@ -1093,7 +1093,8 @@ which each contain a few configurations to adjust the port number and metrics na
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/security.html
+++ b/site/docs/3.2.1/security.html
@@ -1155,7 +1155,8 @@ Spark with permissions such that only the user and group have read and write acc
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/spark-standalone.html
+++ b/site/docs/3.2.1/spark-standalone.html
@@ -699,7 +699,8 @@ For more information about these configurations please refer to the <a href="con
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sparkr-migration-guide.html
+++ b/site/docs/3.2.1/sparkr-migration-guide.html
@@ -322,7 +322,8 @@ of the same name of a DataFrame.</li>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sparkr.html
+++ b/site/docs/3.2.1/sparkr.html
@@ -969,7 +969,8 @@ function is masking another function.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-data-sources-avro.html
+++ b/site/docs/3.2.1/sql-data-sources-avro.html
@@ -908,7 +908,8 @@ All other union types are considered complex. They will be mapped to StructType 
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-data-sources-binaryFile.html
+++ b/site/docs/3.2.1/sql-data-sources-binaryFile.html
@@ -413,7 +413,8 @@ For example, the following code reads all PNG files from the input directory:</p
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-data-sources-csv.html
+++ b/site/docs/3.2.1/sql-data-sources-csv.html
@@ -784,7 +784,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-data-sources-generic-options.html
+++ b/site/docs/3.2.1/sql-data-sources-generic-options.html
@@ -677,7 +677,8 @@ to the Spark session timezone (<code class="language-plaintext highlighter-rouge
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-data-sources-hive-tables.html
+++ b/site/docs/3.2.1/sql-data-sources-hive-tables.html
@@ -850,7 +850,8 @@ will compile against built-in Hive and use those classes for internal execution 
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-data-sources-jdbc.html
+++ b/site/docs/3.2.1/sql-data-sources-jdbc.html
@@ -810,7 +810,8 @@ Before using <code>keytab</code> and <code>principal</code> configuration option
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-data-sources-json.html
+++ b/site/docs/3.2.1/sql-data-sources-json.html
@@ -753,7 +753,8 @@ line must contain a separate, self-contained valid JSON object. For more informa
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-data-sources-load-save-functions.html
+++ b/site/docs/3.2.1/sql-data-sources-load-save-functions.html
@@ -830,7 +830,8 @@ data across a fixed number of buckets and can be used when the number of unique 
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-data-sources-orc.html
+++ b/site/docs/3.2.1/sql-data-sources-orc.html
@@ -580,7 +580,8 @@ Please visit <a href="https://hadoop.apache.org/docs/current/hadoop-kms/index.ht
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-data-sources-parquet.html
+++ b/site/docs/3.2.1/sql-data-sources-parquet.html
@@ -1075,7 +1075,8 @@ metadata.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-data-sources-text.html
+++ b/site/docs/3.2.1/sql-data-sources-text.html
@@ -556,7 +556,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-data-sources-troubleshooting.html
+++ b/site/docs/3.2.1/sql-data-sources-troubleshooting.html
@@ -377,7 +377,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-data-sources.html
+++ b/site/docs/3.2.1/sql-data-sources.html
@@ -431,7 +431,8 @@ goes into specific options that are available for the built-in data sources.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-distributed-sql-engine.html
+++ b/site/docs/3.2.1/sql-distributed-sql-engine.html
@@ -356,7 +356,8 @@ You may run <code class="language-plaintext highlighter-rouge">./bin/spark-sql -
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-getting-started.html
+++ b/site/docs/3.2.1/sql-getting-started.html
@@ -1385,7 +1385,8 @@ about user defined aggregate functions, please refer to the documentation of
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-migration-guide.html
+++ b/site/docs/3.2.1/sql-migration-guide.html
@@ -1741,7 +1741,8 @@ an aggregate over a fixed window.</li>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-migration-old.html
+++ b/site/docs/3.2.1/sql-migration-old.html
@@ -248,7 +248,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-performance-tuning.html
+++ b/site/docs/3.2.1/sql-performance-tuning.html
@@ -624,7 +624,8 @@ SELECT /*+ REBALANCE(c) */ * FROM t
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-programming-guide.html
+++ b/site/docs/3.2.1/sql-programming-guide.html
@@ -289,7 +289,8 @@ While, in <a href="api/java/index.html?org/apache/spark/sql/Dataset.html">Java A
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-pyspark-pandas-with-arrow.html
+++ b/site/docs/3.2.1/sql-pyspark-pandas-with-arrow.html
@@ -247,7 +247,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-ansi-compliance.html
+++ b/site/docs/3.2.1/sql-ref-ansi-compliance.html
@@ -2559,7 +2559,8 @@ In this mode, Spark SQL has two kinds of keywords:</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-datatypes.html
+++ b/site/docs/3.2.1/sql-ref-datatypes.html
@@ -1153,7 +1153,8 @@ Specifically:</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-datetime-pattern.html
+++ b/site/docs/3.2.1/sql-ref-datetime-pattern.html
@@ -608,7 +608,8 @@ An optional section is started by <code class="language-plaintext highlighter-ro
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-functions-builtin.html
+++ b/site/docs/3.2.1/sql-ref-functions-builtin.html
@@ -2804,7 +2804,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-functions-udf-aggregate.html
+++ b/site/docs/3.2.1/sql-ref-functions-udf-aggregate.html
@@ -732,7 +732,8 @@ For example, a user-defined average for untyped DataFrames can look like:</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-functions-udf-hive.html
+++ b/site/docs/3.2.1/sql-ref-functions-udf-hive.html
@@ -415,7 +415,8 @@ An example below uses <a href="https://github.com/apache/hive/blob/master/ql/src
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-functions-udf-scalar.html
+++ b/site/docs/3.2.1/sql-ref-functions-udf-scalar.html
@@ -492,7 +492,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-functions.html
+++ b/site/docs/3.2.1/sql-ref-functions.html
@@ -363,7 +363,8 @@ This subsection presents the usages and descriptions of these functions.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-identifier.html
+++ b/site/docs/3.2.1/sql-ref-identifier.html
@@ -387,7 +387,8 @@ CREATE TABLE test (`a``b` int);
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-literals.html
+++ b/site/docs/3.2.1/sql-ref-literals.html
@@ -947,7 +947,8 @@ Mix of the YEAR[S] or MONTH[S] interval units with other units is not allowed.
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-null-semantics.html
+++ b/site/docs/3.2.1/sql-ref-null-semantics.html
@@ -1095,7 +1095,8 @@ and because NOT UNKNOWN is again UNKNOWN.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-analyze-table.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-analyze-table.html
@@ -545,7 +545,8 @@ that are to be used by the query optimizer to find a better query execution plan
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-cache-cache-table.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-cache-cache-table.html
@@ -452,7 +452,8 @@ This reduces scanning of the original files in future queries.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-cache-clear-cache.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-cache-clear-cache.html
@@ -401,7 +401,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-cache-refresh-function.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-cache-refresh-function.html
@@ -421,7 +421,8 @@ Note that <code class="language-plaintext highlighter-rouge">REFRESH FUNCTION</c
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-cache-refresh-table.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-cache-refresh-table.html
@@ -421,7 +421,8 @@ lazy manner when the cached table or the query associated with it is executed ag
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-cache-refresh.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-cache-refresh.html
@@ -418,7 +418,8 @@ invalidate everything that is cached.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-cache-uncache-table.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-cache-uncache-table.html
@@ -414,7 +414,8 @@ underlying entries should already have been brought to cache by previous <code c
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-cache.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-cache.html
@@ -386,7 +386,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-conf-mgmt-reset.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-conf-mgmt-reset.html
@@ -418,7 +418,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-conf-mgmt-set-timezone.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-conf-mgmt-set-timezone.html
@@ -430,7 +430,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-conf-mgmt-set.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-conf-mgmt-set.html
@@ -434,7 +434,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-conf-mgmt.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-conf-mgmt.html
@@ -383,7 +383,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-describe-database.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-describe-database.html
@@ -456,7 +456,8 @@ interchangeable.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-describe-function.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-describe-function.html
@@ -472,7 +472,8 @@ metadata information is returned along with the extended usage information.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-describe-query.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-describe-query.html
@@ -474,7 +474,8 @@ describe the query output.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-describe-table.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-describe-table.html
@@ -546,7 +546,8 @@ to return the metadata pertaining to a partition or column respectively.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-describe.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-describe.html
@@ -384,7 +384,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-resource-mgmt-add-archive.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-resource-mgmt-add-archive.html
@@ -415,7 +415,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-resource-mgmt-add-file.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-resource-mgmt-add-file.html
@@ -416,7 +416,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-resource-mgmt-add-jar.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-resource-mgmt-add-jar.html
@@ -432,7 +432,8 @@ ivy://group:module:version?transitive=[true|false]&amp;exclude=group:module,grou
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-resource-mgmt-list-archive.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-resource-mgmt-list-archive.html
@@ -410,7 +410,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-resource-mgmt-list-file.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-resource-mgmt-list-file.html
@@ -410,7 +410,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-resource-mgmt-list-jar.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-resource-mgmt-list-jar.html
@@ -411,7 +411,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-resource-mgmt.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-resource-mgmt.html
@@ -386,7 +386,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-show-columns.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-show-columns.html
@@ -459,7 +459,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-show-create-table.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-show-create-table.html
@@ -448,7 +448,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-show-databases.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-show-databases.html
@@ -451,7 +451,8 @@ and mean the same thing.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-show-functions.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-show-functions.html
@@ -506,7 +506,8 @@ clause is optional and supported only for compatibility with other systems.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-show-partitions.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-show-partitions.html
@@ -472,7 +472,8 @@ partition spec.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-show-table.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-show-table.html
@@ -545,7 +545,8 @@ any of which can match.</li>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-show-tables.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-show-tables.html
@@ -470,7 +470,8 @@ any of which can match.</li>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-show-tblproperties.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-show-tblproperties.html
@@ -481,7 +481,8 @@ properties are: <code class="language-plaintext highlighter-rouge">numFiles</cod
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-show-views.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-show-views.html
@@ -481,7 +481,8 @@ any of which can match.</li>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-aux-show.html
+++ b/site/docs/3.2.1/sql-ref-syntax-aux-show.html
@@ -389,7 +389,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-ddl-alter-database.html
+++ b/site/docs/3.2.1/sql-ref-syntax-ddl-alter-database.html
@@ -466,7 +466,8 @@ specified location or change the locations associated with any tables/partitions
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-ddl-alter-table.html
+++ b/site/docs/3.2.1/sql-ref-syntax-ddl-alter-table.html
@@ -827,7 +827,8 @@ existing tables.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-ddl-alter-view.html
+++ b/site/docs/3.2.1/sql-ref-syntax-ddl-alter-view.html
@@ -579,7 +579,8 @@ and the <code class="language-plaintext highlighter-rouge">view_identifier</code
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-ddl-create-database.html
+++ b/site/docs/3.2.1/sql-ref-syntax-ddl-create-database.html
@@ -452,7 +452,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-ddl-create-function.html
+++ b/site/docs/3.2.1/sql-ref-syntax-ddl-create-function.html
@@ -534,7 +534,8 @@ aggregate functions using Scala, Python and Java APIs. Please refer to
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-ddl-create-table-datasource.html
+++ b/site/docs/3.2.1/sql-ref-syntax-ddl-create-table-datasource.html
@@ -510,7 +510,8 @@ input query, to make sure the table gets created contains exactly the same data 
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-ddl-create-table-hiveformat.html
+++ b/site/docs/3.2.1/sql-ref-syntax-ddl-create-table-hiveformat.html
@@ -567,7 +567,8 @@ as any order. For example, you can write COMMENT table_comment after TBLPROPERTI
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-ddl-create-table-like.html
+++ b/site/docs/3.2.1/sql-ref-syntax-ddl-create-table-like.html
@@ -454,7 +454,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-ddl-create-table.html
+++ b/site/docs/3.2.1/sql-ref-syntax-ddl-create-table.html
@@ -396,7 +396,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-ddl-create-view.html
+++ b/site/docs/3.2.1/sql-ref-syntax-ddl-create-view.html
@@ -457,7 +457,8 @@ A <a href="sql-ref-syntax-qry-select.html">SELECT</a> statement that constructs 
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-ddl-drop-database.html
+++ b/site/docs/3.2.1/sql-ref-syntax-ddl-drop-database.html
@@ -432,7 +432,8 @@ exception will be thrown if the database does not exist in the system.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-ddl-drop-function.html
+++ b/site/docs/3.2.1/sql-ref-syntax-ddl-drop-function.html
@@ -465,7 +465,8 @@ be thrown if the function does not exist.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-ddl-drop-table.html
+++ b/site/docs/3.2.1/sql-ref-syntax-ddl-drop-table.html
@@ -435,7 +435,8 @@ if the table is not <code class="language-plaintext highlighter-rouge">EXTERNAL<
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-ddl-drop-view.html
+++ b/site/docs/3.2.1/sql-ref-syntax-ddl-drop-view.html
@@ -432,7 +432,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-ddl-repair-table.html
+++ b/site/docs/3.2.1/sql-ref-syntax-ddl-repair-table.html
@@ -442,7 +442,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-ddl-truncate-table.html
+++ b/site/docs/3.2.1/sql-ref-syntax-ddl-truncate-table.html
@@ -452,7 +452,8 @@ in <code class="language-plaintext highlighter-rouge">partition_spec</code>. If 
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-ddl-usedb.html
+++ b/site/docs/3.2.1/sql-ref-syntax-ddl-usedb.html
@@ -418,7 +418,8 @@ The default database name is &#8216;default&#8217;.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-dml-insert-into.html
+++ b/site/docs/3.2.1/sql-ref-syntax-dml-insert-into.html
@@ -617,7 +617,8 @@ SELECT * FROM students WHERE name = 'Kent Yao';
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-dml-insert-overwrite-directory-hive.html
+++ b/site/docs/3.2.1/sql-ref-syntax-dml-insert-overwrite-directory-hive.html
@@ -444,7 +444,8 @@ Hive support must be enabled to use this command. The inserted rows can be speci
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-dml-insert-overwrite-directory.html
+++ b/site/docs/3.2.1/sql-ref-syntax-dml-insert-overwrite-directory.html
@@ -446,7 +446,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-dml-insert-overwrite-table.html
+++ b/site/docs/3.2.1/sql-ref-syntax-dml-insert-overwrite-table.html
@@ -601,7 +601,8 @@ SELECT * FROM students WHERE name = 'Kent Yao';
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-dml-load.html
+++ b/site/docs/3.2.1/sql-ref-syntax-dml-load.html
@@ -478,7 +478,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-hive-format.html
+++ b/site/docs/3.2.1/sql-ref-syntax-hive-format.html
@@ -442,7 +442,8 @@ There are two ways to define a row format in <code class="language-plaintext hig
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-explain.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-explain.html
@@ -490,7 +490,8 @@ EXPLAIN FORMATTED select k, sum(v) from values (1, 2), (1, 3) t(k, v) group by k
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-case.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-case.html
@@ -472,7 +472,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-clusterby.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-clusterby.html
@@ -465,7 +465,8 @@ resultant rows are sorted within each partition and does not guarantee a total o
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-cte.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-cte.html
@@ -485,7 +485,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-distribute-by.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-distribute-by.html
@@ -460,7 +460,8 @@ clause, this does not sort the data within each partition.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-file.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-file.html
@@ -438,7 +438,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-groupby.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-groupby.html
@@ -687,7 +687,8 @@ an aggregate function, only the matching rows are passed to that function.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-having.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-having.html
@@ -493,7 +493,8 @@ clause.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-hints.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-hints.html
@@ -530,7 +530,8 @@ specified, multiple nodes are inserted into the logical plan, but the leftmost h
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-inline-table.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-inline-table.html
@@ -439,7 +439,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-join.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-join.html
@@ -601,7 +601,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-lateral-view.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-lateral-view.html
@@ -489,7 +489,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-like.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-like.html
@@ -543,7 +543,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-limit.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-limit.html
@@ -471,7 +471,8 @@ ensure that the results are deterministic.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-orderby.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-orderby.html
@@ -513,7 +513,8 @@ the sort order.</li>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-pivot.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-pivot.html
@@ -465,7 +465,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-sampling.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-sampling.html
@@ -453,7 +453,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-setops.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-setops.html
@@ -551,7 +551,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-sortby.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-sortby.html
@@ -546,7 +546,8 @@ the sort order.</li>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-subqueries.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-subqueries.html
@@ -379,7 +379,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-transform.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-transform.html
@@ -637,7 +637,8 @@ to transform the inputs by running a user-specified command or script.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-tvf.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-tvf.html
@@ -596,7 +596,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-where.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-where.html
@@ -491,7 +491,8 @@ clause of a query or a subquery based on the specified condition.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select-window.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select-window.html
@@ -597,7 +597,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax-qry-select.html
+++ b/site/docs/3.2.1/sql-ref-syntax-qry-select.html
@@ -576,7 +576,8 @@ of a query along with examples.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref-syntax.html
+++ b/site/docs/3.2.1/sql-ref-syntax.html
@@ -483,7 +483,8 @@ ability to generate logical and physical plan for a given query using
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/sql-ref.html
+++ b/site/docs/3.2.1/sql-ref.html
@@ -358,7 +358,8 @@
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/ss-migration-guide.html
+++ b/site/docs/3.2.1/ss-migration-guide.html
@@ -273,7 +273,8 @@ For further details please see <a href="structured-streaming-kafka-integration.h
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/storage-openstack-swift.html
+++ b/site/docs/3.2.1/storage-openstack-swift.html
@@ -290,7 +290,8 @@ For job submissions they should be provided via <code>sparkContext.hadoopConfigu
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/streaming-custom-receivers.html
+++ b/site/docs/3.2.1/streaming-custom-receivers.html
@@ -406,7 +406,8 @@ interval in the <a href="streaming-programming-guide.html">Spark Streaming Progr
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/streaming-kafka-0-10-integration.html
+++ b/site/docs/3.2.1/streaming-kafka-0-10-integration.html
@@ -482,7 +482,8 @@ Note that the example sets enable.auto.commit to false, for discussion see <a hr
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/streaming-kafka-integration.html
+++ b/site/docs/3.2.1/streaming-kafka-integration.html
@@ -168,7 +168,8 @@ thoroughly before starting an integration using Spark.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/streaming-kinesis-integration.html
+++ b/site/docs/3.2.1/streaming-kinesis-integration.html
@@ -483,7 +483,8 @@ de-aggregate records during consumption.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/streaming-programming-guide.html
+++ b/site/docs/3.2.1/streaming-programming-guide.html
@@ -2658,7 +2658,8 @@ and <a href="https://github.com/apache/spark/tree/master/examples/src/main/pytho
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/structured-streaming-kafka-integration.html
+++ b/site/docs/3.2.1/structured-streaming-kafka-integration.html
@@ -1302,7 +1302,8 @@ This can be done several ways. One possibility is to provide additional JVM para
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/structured-streaming-programming-guide.html
+++ b/site/docs/3.2.1/structured-streaming-programming-guide.html
@@ -3819,7 +3819,8 @@ examples.
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/submitting-applications.html
+++ b/site/docs/3.2.1/submitting-applications.html
@@ -381,7 +381,8 @@ the components involved in distributed execution, and how to monitor and debug a
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/tuning.html
+++ b/site/docs/3.2.1/tuning.html
@@ -521,7 +521,8 @@ performance issues. Feel free to ask on the
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,

--- a/site/docs/3.2.1/web-ui.html
+++ b/site/docs/3.2.1/web-ui.html
@@ -637,7 +637,8 @@ which can be useful for troubleshooting the streaming application.</p>
             //    to your search input and display its results in a dropdown UI. If you want to find more
             //    details on how works DocSearch, check the docs of DocSearch.
             docsearch({
-    apiKey: 'b18ca3732c502995563043aa17bc6ecb',
+    apiKey: 'd62f962a82bc9abb53471cb7b89da35e',
+    appId: 'RAI69RXRSK',
     indexName: 'apache_spark',
     inputSelector: '#docsearch-input',
     enhancedSearchInput: true,


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->

DocSearch uses new infra now: https://docsearch.algolia.com/docs/migrating-from-legacy/
The new version allows us to manage indexes, but we have to update the Api Key and App id in configuration to make it work.
This PR is to update the API Key of DocSearch as per the comment https://github.com/algolia/docsearch-configs/pull/5054#issuecomment-1025483446