### PR TITLE
Add Apple Silicon CI link

### DIFF
--- a/developer-tools.md
+++ b/developer-tools.md
@@ -29,7 +29,7 @@ Apache Spark community uses various resources to maintain the community test cov
 <h3 id="scaleway">Scaleway</h3>
 
 [Scaleway](https://www.scaleway.com) provides the following on MacOS and Apple Silicon.
-- Java/Scala/Python/R unit tests with Java 17/Scala 2.12/Maven
+- [Java/Scala/Python/R unit tests with Java 17/Scala 2.12/SBT](https://apache-spark.s3.fr-par.scw.cloud/index.html)
 - K8s integration tests (TBD)
 
 <h2>Useful developer tools</h2>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -171,7 +171,7 @@
 
 <p><a href="https://www.scaleway.com">Scaleway</a> provides the following on MacOS and Apple Silicon.</p>
 <ul>
-  <li>Java/Scala/Python/R unit tests with Java 17/Scala 2.12/Maven</li>
+  <li><a href="https://apache-spark.s3.fr-par.scw.cloud/index.html">Java/Scala/Python/R unit tests with Java 17/Scala 2.12/SBT</a></li>
   <li>K8s integration tests (TBD)</li>
 </ul>
 


### PR DESCRIPTION
This PR aims to add `Apple Silicon CI` status link. To parallelize CI, I used SBT instead of Maven.

![Screen Shot 2022-04-19 at 3 41 54 PM](https://user-images.githubusercontent.com/9700541/164113213-32b10528-fd4c-4c5e-b836-b71c9b16e994.png)

