### PR TITLE
Add SQL API homepage into sitemap.xml

### DIFF
--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -137,6 +137,11 @@
   <changefreq>weekly</changefreq>
   <priority>1.0</priority>
 </url>
+<url>
+  <loc>https://spark.apache.org/docs/latest/api/sql/index.html</loc>
+  <changefreq>weekly</changefreq>
+  <priority>1.0</priority>
+</url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
   <loc>https://spark.apache.org/releases/spark-release-3-1-3.html</loc>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -140,6 +140,11 @@ sitemap: false
   <changefreq>weekly</changefreq>
   <priority>1.0</priority>
 </url>
+<url>
+  <loc>https://spark.apache.org/docs/latest/api/sql/index.html</loc>
+  <changefreq>weekly</changefreq>
+  <priority>1.0</priority>
+</url>
 <!-- Auto-generate sitemap for rest of site content -->
 {% for post in site.posts %}<url>
   <loc>{{ site.url }}{{ post.url }}</loc>


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->
Currently, Google search shows outdated result for Spark SQL functions. For example, searching `date_trunc spark` will show the result https://spark.apache.org/docs/2.3.0/api/sql/index.html. Note that the example of `date_trunc` is wrong. The latest example is correct but it is not shown in google search.

This doesn't happen to other APIs. For example, search `spark rdd scala api` will show the latest API page.


I think the problem is on the sitemap.xml. We should include SQL API homepage. 