### PR TITLE
Update release process on how to modify Algolia Crawler configurations

### DIFF
--- a/release-process.md
+++ b/release-process.md
@@ -284,8 +284,8 @@ $ git tag v1.1.1 v1.1.1-rc2 # the RC that passed
 $ git push apache v1.1.1
 ```
 
-<h4>Update the version index of DocSearch</h4>
-In the repository <a href="https://github.com/algolia/docsearch-configs">algolia/docsearch-configs</a>, submit a PR to add the new Spark version in <a href="https://github.com/algolia/docsearch-configs/blob/master/configs/apache_spark.json">apache_spark.json</a>.
+<h4>Update the configuration of Algolia Crawler</h4>
+The search box on the <a href="https://spark.apache.org/docs/latest/">Spark documentation website</a> leverages the <a href="https://www.algolia.com/products/search-and-discovery/crawler/">Algolia Crawler</a>. Before a release, please update the crawler configuration for Apache Spark with the new version on the <a href="https://crawler.algolia.com/">Algolia Crawler Admin Console</a>. If you don't have access to the configuration, contact <a href="mailto:gengliang@apache.org">Gengliang Wang</a> or <a href="mailto:lixiao@apache.org">Xiao Li</a> for help.
 
 <h4>Update the Spark website</h4>
 

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -396,8 +396,8 @@ anymore, so that the correct links are generated on the site.</p>
 $ git push apache v1.1.1
 </code></pre></div></div>
 
-<h4>Update the version index of DocSearch</h4>
-<p>In the repository <a href="https://github.com/algolia/docsearch-configs">algolia/docsearch-configs</a>, submit a PR to add the new Spark version in <a href="https://github.com/algolia/docsearch-configs/blob/master/configs/apache_spark.json">apache_spark.json</a>.</p>
+<h4>Update the configuration of Algolia Crawler</h4>
+<p>The search box on the <a href="https://spark.apache.org/docs/latest/">Spark documentation website</a> leverages the <a href="https://www.algolia.com/products/search-and-discovery/crawler/">Algolia Crawler</a>. Before a release, please update the crawler configuration for Apache Spark with the new version on the <a href="https://crawler.algolia.com/">Algolia Crawler Admin Console</a>. If you don&#8217;t have access to the configuration, contact <a href="mailto:gengliang@apache.org">Gengliang Wang</a> or <a href="mailto:lixiao@apache.org">Xiao Li</a> for help.</p>
 
 <h4>Update the Spark website</h4>
 


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->
The instruction of "Update the version index of DocSearch" on https://spark.apache.org/release-process.html is out of date: the github repo https://github.com/algolia/docsearch-configs is read-only now and we need to update the configuration by ourself on https://crawler.algolia.com/.
Currently, only @gatorsmile and I have admin permission to the crawler. For the upcoming releases, we can either add the new release manager to the admins or help he/she update the configuration.

Here is a screenshot for preview:
<img width="974" alt="Screen Shot 2022-06-15 at 20 24 52" src="https://user-images.githubusercontent.com/1097932/173985982-852ac0ea-da52-44c8-ad54-60d5ff2c9e6e.png">

