### PR TITLE
Fix formatting of the release notes for 3.3.0

### DIFF
--- a/releases/_posts/2022-06-16-spark-release-3-3-0.md
+++ b/releases/_posts/2022-06-16-spark-release-3-3-0.md
@@ -86,15 +86,15 @@ To download Apache Spark 3.3.0, visit the [downloads](https://spark.apache.org/d
     * Datetime
         * Add the <span style="text-decoration:underline;">TIMESTAMPADD</span>() function ([SPARK-38195](https://issues.apache.org/jira/browse/SPARK-38195))
         * Add the <span style="text-decoration:underline;">TIMESTAMPDIFF</span>() function ([SPARK-38284](https://issues.apache.org/jira/browse/SPARK-38284))
-        * Add the `<span style="text-decoration:underline;">DATEDIFF</span>()` alias for `TIMESTAMPDIFF()` ([SPARK-38389](https://issues.apache.org/jira/browse/SPARK-38389))
-        * Add the `<span style="text-decoration:underline;">DATEADD</span>()` alias for `TIMESTAMPADD()` ([SPARK-38332](https://issues.apache.org/jira/browse/SPARK-38332))
-        * Add the `<span style="text-decoration:underline;">convert_timezone</span>()` function ([SPARK-37552](https://issues.apache.org/jira/browse/SPARK-37552), [SPARK-37568](https://issues.apache.org/jira/browse/SPARK-37568))
+        * Add the <span style="text-decoration:underline;">DATEDIFF</span>() alias for `TIMESTAMPDIFF()` ([SPARK-38389](https://issues.apache.org/jira/browse/SPARK-38389))
+        * Add the <span style="text-decoration:underline;">DATEADD</span>() alias for `TIMESTAMPADD()` ([SPARK-38332](https://issues.apache.org/jira/browse/SPARK-38332))
+        * Add the <span style="text-decoration:underline;">convert_timezone</span>() function ([SPARK-37552](https://issues.apache.org/jira/browse/SPARK-37552), [SPARK-37568](https://issues.apache.org/jira/browse/SPARK-37568))
         * Expose <span style="text-decoration:underline;">make_date</span> expression in functions.scala ([SPARK-36554](https://issues.apache.org/jira/browse/SPARK-36554))
     * AES functions ([SPARK-12567](https://issues.apache.org/jira/browse/SPARK-12567))
         * Add <span style="text-decoration:underline;">aes_encrypt</span> and <span style="text-decoration:underline;">aes_decrypt</span> builtin functions ([SPARK-12567](https://issues.apache.org/jira/browse/SPARK-12567)) \
-Support the GCM mode by `<span style="text-decoration:underline;">aes_encrypt</span>()`/`<span style="text-decoration:underline;">aes_decrypt</span>()` ([SPARK-37591](https://issues.apache.org/jira/browse/SPARK-37591))
-        * Set `GCM` as the default mode in `<span style="text-decoration:underline;">aes_encrypt</span>()`/`<span style="text-decoration:underline;">aes_decrypt</span>()` ([SPARK-37666](https://issues.apache.org/jira/browse/SPARK-37666))
-        * Add the `mode` and `padding` args to `<span style="text-decoration:underline;">aes_encrypt</span>()`/`<span style="text-decoration:underline;">aes_decrypt</span>()` ([SPARK-37586](https://issues.apache.org/jira/browse/SPARK-37586))
+Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</span>()/<span style="text-decoration:underline;">aes_decrypt</span>() ([SPARK-37591](https://issues.apache.org/jira/browse/SPARK-37591))
+        * Set `GCM` as the default mode in <span style="text-decoration:underline;">aes_encrypt</span>()/<span style="text-decoration:underline;">aes_decrypt</span>() ([SPARK-37666](https://issues.apache.org/jira/browse/SPARK-37666))
+        * Add the `mode` and `padding` args to <span style="text-decoration:underline;">aes_encrypt</span>()/<span style="text-decoration:underline;">aes_decrypt</span>() ([SPARK-37586](https://issues.apache.org/jira/browse/SPARK-37586))
     * ANSI Aggregation Function ([SPARK-37671](https://issues.apache.org/jira/browse/SPARK-37671))
         * Support ANSI Aggregate Function: <span style="text-decoration:underline;">regr_count</span> ([SPARK-37613](https://issues.apache.org/jira/browse/SPARK-37613))
         * Support ANSI Aggregate Function: <span style="text-decoration:underline;">regr_avgx</span> & <span style="text-decoration:underline;">regr_avgy</span> ([SPARK-37614](https://issues.apache.org/jira/browse/SPARK-37614))
@@ -112,10 +112,10 @@ Support the GCM mode by `<span style="text-decoration:underline;">aes_encrypt</s
     * Format
         * Add a new SQL function <span style="text-decoration:underline;">to_binary</span> ([SPARK-37507](https://issues.apache.org/jira/browse/SPARK-37507), [SPARK-38796](https://issues.apache.org/jira/browse/SPARK-38796))
         * New SQL function: <span style="text-decoration:underline;">try_to_binary</span> ([SPARK-38590](https://issues.apache.org/jira/browse/SPARK-38590), [SPARK-38796](https://issues.apache.org/jira/browse/SPARK-38796))
-        * Data Type Formatting Functions: `<span style="text-decoration:underline;">to_number</span>` ([SPARK-28137](https://issues.apache.org/jira/browse/SPARK-28137))
+        * Data Type Formatting Functions: <span style="text-decoration:underline;">to_number</span> ([SPARK-28137](https://issues.apache.org/jira/browse/SPARK-28137))
     * String/Binary
         * Add <span style="text-decoration:underline;">CONTAINS</span>() string function ([SPARK-37508](https://issues.apache.org/jira/browse/SPARK-37508))
-        * Add the `<span style="text-decoration:underline;">startswith</span>()` and `<span style="text-decoration:underline;">endswith</span>()` string functions ([SPARK-37520](https://issues.apache.org/jira/browse/SPARK-37520))
+        * Add the <span style="text-decoration:underline;">startswith</span>() and <span style="text-decoration:underline;">endswith</span>() string functions ([SPARK-37520](https://issues.apache.org/jira/browse/SPARK-37520))
         * Add lpad and rpad functions for binary strings ([SPARK-37047](https://issues.apache.org/jira/browse/SPARK-37047))
         * Support split_part Function ([SPARK-38063](https://issues.apache.org/jira/browse/SPARK-38063))
     * Add scale parameter to <span style="text-decoration:underline;">floor</span> and <span style="text-decoration:underline;">ceil</span> functions ([SPARK-37475](https://issues.apache.org/jira/browse/SPARK-37475))
@@ -353,7 +353,7 @@ Support the GCM mode by `<span style="text-decoration:underline;">aes_encrypt</s
 
 
 * Major improvement
-    * **'distributed-sequence' index **optimization with being **default** ([SPARK-37649](https://issues.apache.org/jira/browse/SPARK-37649), [SPARK-36559](https://issues.apache.org/jira/browse/SPARK-36559), [SPARK-36338](https://issues.apache.org/jira/browse/SPARK-36338))
+    * 'distributed-sequence' index optimization with being **default** ([SPARK-37649](https://issues.apache.org/jira/browse/SPARK-37649), [SPARK-36559](https://issues.apache.org/jira/browse/SPARK-36559), [SPARK-36338](https://issues.apache.org/jira/browse/SPARK-36338))
     * Support to specify index type and name in pandas API on Spark ([SPARK-36709](https://issues.apache.org/jira/browse/SPARK-36709))
     * Show default index type in SQL plans for pandas API on Spark ([SPARK-38654](https://issues.apache.org/jira/browse/SPARK-38654))
 * Major feature

--- a/site/releases/spark-release-3-3-0.html
+++ b/site/releases/spark-release-3-3-0.html
@@ -235,18 +235,18 @@
         <ul>
           <li>Add the <span style="text-decoration:underline;">TIMESTAMPADD</span>() function (<a href="https://issues.apache.org/jira/browse/SPARK-38195">SPARK-38195</a>)</li>
           <li>Add the <span style="text-decoration:underline;">TIMESTAMPDIFF</span>() function (<a href="https://issues.apache.org/jira/browse/SPARK-38284">SPARK-38284</a>)</li>
-          <li>Add the <code class="language-plaintext highlighter-rouge">&lt;span style="text-decoration:underline;"&gt;DATEDIFF&lt;/span&gt;()</code> alias for <code class="language-plaintext highlighter-rouge">TIMESTAMPDIFF()</code> (<a href="https://issues.apache.org/jira/browse/SPARK-38389">SPARK-38389</a>)</li>
-          <li>Add the <code class="language-plaintext highlighter-rouge">&lt;span style="text-decoration:underline;"&gt;DATEADD&lt;/span&gt;()</code> alias for <code class="language-plaintext highlighter-rouge">TIMESTAMPADD()</code> (<a href="https://issues.apache.org/jira/browse/SPARK-38332">SPARK-38332</a>)</li>
-          <li>Add the <code class="language-plaintext highlighter-rouge">&lt;span style="text-decoration:underline;"&gt;convert_timezone&lt;/span&gt;()</code> function (<a href="https://issues.apache.org/jira/browse/SPARK-37552">SPARK-37552</a>, <a href="https://issues.apache.org/jira/browse/SPARK-37568">SPARK-37568</a>)</li>
+          <li>Add the <span style="text-decoration:underline;">DATEDIFF</span>() alias for <code class="language-plaintext highlighter-rouge">TIMESTAMPDIFF()</code> (<a href="https://issues.apache.org/jira/browse/SPARK-38389">SPARK-38389</a>)</li>
+          <li>Add the <span style="text-decoration:underline;">DATEADD</span>() alias for <code class="language-plaintext highlighter-rouge">TIMESTAMPADD()</code> (<a href="https://issues.apache.org/jira/browse/SPARK-38332">SPARK-38332</a>)</li>
+          <li>Add the <span style="text-decoration:underline;">convert_timezone</span>() function (<a href="https://issues.apache.org/jira/browse/SPARK-37552">SPARK-37552</a>, <a href="https://issues.apache.org/jira/browse/SPARK-37568">SPARK-37568</a>)</li>
           <li>Expose <span style="text-decoration:underline;">make_date</span> expression in functions.scala (<a href="https://issues.apache.org/jira/browse/SPARK-36554">SPARK-36554</a>)</li>
         </ul>
       </li>
       <li>AES functions (<a href="https://issues.apache.org/jira/browse/SPARK-12567">SPARK-12567</a>)
         <ul>
           <li>Add <span style="text-decoration:underline;">aes_encrypt</span> and <span style="text-decoration:underline;">aes_decrypt</span> builtin functions (<a href="https://issues.apache.org/jira/browse/SPARK-12567">SPARK-12567</a>) <br />
-Support the GCM mode by <code class="language-plaintext highlighter-rouge">&lt;span style="text-decoration:underline;"&gt;aes_encrypt&lt;/span&gt;()</code>/<code class="language-plaintext highlighter-rouge">&lt;span style="text-decoration:underline;"&gt;aes_decrypt&lt;/span&gt;()</code> (<a href="https://issues.apache.org/jira/browse/SPARK-37591">SPARK-37591</a>)</li>
-          <li>Set <code class="language-plaintext highlighter-rouge">GCM</code> as the default mode in <code class="language-plaintext highlighter-rouge">&lt;span style="text-decoration:underline;"&gt;aes_encrypt&lt;/span&gt;()</code>/<code class="language-plaintext highlighter-rouge">&lt;span style="text-decoration:underline;"&gt;aes_decrypt&lt;/span&gt;()</code> (<a href="https://issues.apache.org/jira/browse/SPARK-37666">SPARK-37666</a>)</li>
-          <li>Add the <code class="language-plaintext highlighter-rouge">mode</code> and <code class="language-plaintext highlighter-rouge">padding</code> args to <code class="language-plaintext highlighter-rouge">&lt;span style="text-decoration:underline;"&gt;aes_encrypt&lt;/span&gt;()</code>/<code class="language-plaintext highlighter-rouge">&lt;span style="text-decoration:underline;"&gt;aes_decrypt&lt;/span&gt;()</code> (<a href="https://issues.apache.org/jira/browse/SPARK-37586">SPARK-37586</a>)</li>
+Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</span>()/<span style="text-decoration:underline;">aes_decrypt</span>() (<a href="https://issues.apache.org/jira/browse/SPARK-37591">SPARK-37591</a>)</li>
+          <li>Set <code class="language-plaintext highlighter-rouge">GCM</code> as the default mode in <span style="text-decoration:underline;">aes_encrypt</span>()/<span style="text-decoration:underline;">aes_decrypt</span>() (<a href="https://issues.apache.org/jira/browse/SPARK-37666">SPARK-37666</a>)</li>
+          <li>Add the <code class="language-plaintext highlighter-rouge">mode</code> and <code class="language-plaintext highlighter-rouge">padding</code> args to <span style="text-decoration:underline;">aes_encrypt</span>()/<span style="text-decoration:underline;">aes_decrypt</span>() (<a href="https://issues.apache.org/jira/browse/SPARK-37586">SPARK-37586</a>)</li>
         </ul>
       </li>
       <li>ANSI Aggregation Function (<a href="https://issues.apache.org/jira/browse/SPARK-37671">SPARK-37671</a>)
@@ -273,13 +273,13 @@ Support the GCM mode by <code class="language-plaintext highlighter-rouge">&lt;s
         <ul>
           <li>Add a new SQL function <span style="text-decoration:underline;">to_binary</span> (<a href="https://issues.apache.org/jira/browse/SPARK-37507">SPARK-37507</a>, <a href="https://issues.apache.org/jira/browse/SPARK-38796">SPARK-38796</a>)</li>
           <li>New SQL function: <span style="text-decoration:underline;">try_to_binary</span> (<a href="https://issues.apache.org/jira/browse/SPARK-38590">SPARK-38590</a>, <a href="https://issues.apache.org/jira/browse/SPARK-38796">SPARK-38796</a>)</li>
-          <li>Data Type Formatting Functions: <code class="language-plaintext highlighter-rouge">&lt;span style="text-decoration:underline;"&gt;to_number&lt;/span&gt;</code> (<a href="https://issues.apache.org/jira/browse/SPARK-28137">SPARK-28137</a>)</li>
+          <li>Data Type Formatting Functions: <span style="text-decoration:underline;">to_number</span> (<a href="https://issues.apache.org/jira/browse/SPARK-28137">SPARK-28137</a>)</li>
         </ul>
       </li>
       <li>String/Binary
         <ul>
           <li>Add <span style="text-decoration:underline;">CONTAINS</span>() string function (<a href="https://issues.apache.org/jira/browse/SPARK-37508">SPARK-37508</a>)</li>
-          <li>Add the <code class="language-plaintext highlighter-rouge">&lt;span style="text-decoration:underline;"&gt;startswith&lt;/span&gt;()</code> and <code class="language-plaintext highlighter-rouge">&lt;span style="text-decoration:underline;"&gt;endswith&lt;/span&gt;()</code> string functions (<a href="https://issues.apache.org/jira/browse/SPARK-37520">SPARK-37520</a>)</li>
+          <li>Add the <span style="text-decoration:underline;">startswith</span>() and <span style="text-decoration:underline;">endswith</span>() string functions (<a href="https://issues.apache.org/jira/browse/SPARK-37520">SPARK-37520</a>)</li>
           <li>Add lpad and rpad functions for binary strings (<a href="https://issues.apache.org/jira/browse/SPARK-37047">SPARK-37047</a>)</li>
           <li>Support split_part Function (<a href="https://issues.apache.org/jira/browse/SPARK-38063">SPARK-38063</a>)</li>
         </ul>
@@ -564,7 +564,7 @@ Support the GCM mode by <code class="language-plaintext highlighter-rouge">&lt;s
 <ul>
   <li>Major improvement
     <ul>
-      <li><strong>&#8216;distributed-sequence&#8217; index **optimization with being **default</strong> (<a href="https://issues.apache.org/jira/browse/SPARK-37649">SPARK-37649</a>, <a href="https://issues.apache.org/jira/browse/SPARK-36559">SPARK-36559</a>, <a href="https://issues.apache.org/jira/browse/SPARK-36338">SPARK-36338</a>)</li>
+      <li>&#8216;distributed-sequence&#8217; index optimization with being <strong>default</strong> (<a href="https://issues.apache.org/jira/browse/SPARK-37649">SPARK-37649</a>, <a href="https://issues.apache.org/jira/browse/SPARK-36559">SPARK-36559</a>, <a href="https://issues.apache.org/jira/browse/SPARK-36338">SPARK-36338</a>)</li>
       <li>Support to specify index type and name in pandas API on Spark (<a href="https://issues.apache.org/jira/browse/SPARK-36709">SPARK-36709</a>)</li>
       <li>Show default index type in SQL plans for pandas API on Spark (<a href="https://issues.apache.org/jira/browse/SPARK-38654">SPARK-38654</a>)</li>
     </ul>


### PR DESCRIPTION
Fix formatting of the release notes.

Before:
<img width="905" alt="Screenshot 2022-06-16 at 22 14 27" src="https://user-images.githubusercontent.com/1580697/174149444-5c9c7ed1-bae6-486c-9f8a-87a8de4965bc.png">

After:
<img width="527" alt="Screenshot 2022-06-16 at 22 21 34" src="https://user-images.githubusercontent.com/1580697/174149468-d0c1eb8f-fdf4-4e67-ad2e-a65d85576b9b.png">

