### PR TITLE
Add 3.2.2 announcement news, release note and download link

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -13,6 +13,7 @@ navigation:
 
 <ul>
   <li><a href="{{site.baseurl}}/docs/3.3.0/">Spark 3.3.0</a></li>
+  <li><a href="{{site.baseurl}}/docs/3.2.2/">Spark 3.2.2</a></li>
   <li><a href="{{site.baseurl}}/docs/3.2.1/">Spark 3.2.1</a></li>
   <li><a href="{{site.baseurl}}/docs/3.2.0/">Spark 3.2.0</a></li>
   <li><a href="{{site.baseurl}}/docs/3.1.3/">Spark 3.1.3</a></li>

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -29,7 +29,7 @@ var packagesV12 = [hadoop3p3, hadoop3p3scala213, hadoop2p7, hadoopFree, sources]
 var packagesV13 = [hadoop3p, hadoop3pscala213, hadoop2p, hadoopFree, sources];
 
 addRelease("3.3.0", new Date("06/16/2022"), packagesV13, true);
-addRelease("3.2.1", new Date("01/26/2022"), packagesV12, true);
+addRelease("3.2.2", new Date("07/17/2022"), packagesV12, true);
 addRelease("3.1.3", new Date("02/18/2022"), packagesV11, true);
 
 function append(el, contents) {

--- a/news/_posts/2022-07-17-spark-3-2-2-released.md
+++ b/news/_posts/2022-07-17-spark-3-2-2-released.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: Spark 3.2.2 released
+categories:
+- News
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+We are happy to announce the availability of <a href="{{site.baseurl}}/releases/spark-release-3-2-2.html" title="Spark Release 3.2.2">Spark 3.2.2</a>! Visit the <a href="{{site.baseurl}}/releases/spark-release-3-2-2.html" title="Spark Release 3.2.2">release notes</a> to read about the new features, or <a href="{{site.baseurl}}/downloads.html">download</a> the release today.

--- a/releases/_posts/2022-07-17-spark-release-3-2-2.md
+++ b/releases/_posts/2022-07-17-spark-release-3-2-2.md
@@ -1,0 +1,120 @@
+---
+layout: post
+title: Spark Release 3.2.2
+categories: []
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+
+Spark 3.2.2 is a maintenance release containing stability fixes. This release is based on the branch-3.2 maintenance branch of Spark. We strongly recommend all 3.2 users to upgrade to this stable release.
+
+### Notable changes
+
+  - [[SPARK-37290]](https://issues.apache.org/jira/browse/SPARK-37290): Exponential planning time in case of non-deterministic function
+  - [[SPARK-37544]](https://issues.apache.org/jira/browse/SPARK-37544): sequence over dates with month interval is producing incorrect results
+  - [[SPARK-37643]](https://issues.apache.org/jira/browse/SPARK-37643): When charVarcharAsString is true, char datatype partition table query incorrect
+  - [[SPARK-37670]](https://issues.apache.org/jira/browse/SPARK-37670): Support predicate pushdown and column pruning for de-duped CTEs
+  - [[SPARK-37675]](https://issues.apache.org/jira/browse/SPARK-37675): Prevent overwriting of push shuffle merged files once the shuffle is finalized
+  - [[SPARK-37793]](https://issues.apache.org/jira/browse/SPARK-37793): Invalid LocalMergedBlockData cause task hang
+  - [[SPARK-37865]](https://issues.apache.org/jira/browse/SPARK-37865): Spark should not dedup the groupingExpressions when the first child of Union has duplicate columns
+  - [[SPARK-37963]](https://issues.apache.org/jira/browse/SPARK-37963): Need to update Partition URI after renaming table in InMemoryCatalog
+  - [[SPARK-37995]](https://issues.apache.org/jira/browse/SPARK-37995): TPCDS 1TB q72 fails when spark.sql.optimizer.dynamicPartitionPruning.reuseBroadcastOnly is false
+  - [[SPARK-38018]](https://issues.apache.org/jira/browse/SPARK-38018): Fix ColumnVectorUtils.populate to handle CalendarIntervalType correctly
+  - [[SPARK-38019]](https://issues.apache.org/jira/browse/SPARK-38019): ExecutorMonitor.timedOutExecutors should be deterministic
+  - [[SPARK-38023]](https://issues.apache.org/jira/browse/SPARK-38023): ExecutorMonitor.onExecutorRemoved should handle ExecutorDecommission as finished
+  - [[SPARK-38030]](https://issues.apache.org/jira/browse/SPARK-38030): Query with cast containing non-nullable columns fails with AQE on Spark 3.1.1
+  - [[SPARK-38042]](https://issues.apache.org/jira/browse/SPARK-38042): Encoder cannot be found when a tuple component is a type alias for an Array
+  - [[SPARK-38056]](https://issues.apache.org/jira/browse/SPARK-38056): Structured streaming not working in history server when using LevelDB
+  - [[SPARK-38073]](https://issues.apache.org/jira/browse/SPARK-38073): Update atexit function to avoid issues with late binding
+  - [[SPARK-38075]](https://issues.apache.org/jira/browse/SPARK-38075): Hive script transform with order by and limit will return fake rows
+  - [[SPARK-38120]](https://issues.apache.org/jira/browse/SPARK-38120): HiveExternalCatalog.listPartitions is failing when partition column name is upper case and dot in partition value
+  - [[SPARK-38178]](https://issues.apache.org/jira/browse/SPARK-38178): Correct the logic to measure the memory usage of RocksDB
+  - [[SPARK-38180]](https://issues.apache.org/jira/browse/SPARK-38180): Allow safe up-cast expressions in correlated equality predicates
+  - [[SPARK-38185]](https://issues.apache.org/jira/browse/SPARK-38185): Fix data incorrect if aggregate function is empty
+  - [[SPARK-38204]](https://issues.apache.org/jira/browse/SPARK-38204): All state operators are at a risk of inconsistency between state partitioning and operator partitioning
+  - [[SPARK-38221]](https://issues.apache.org/jira/browse/SPARK-38221): Group by a stream of complex expressions fails
+  - [[SPARK-38236]](https://issues.apache.org/jira/browse/SPARK-38236): Absolute file paths specified in create/alter table are treated as relative
+  - [[SPARK-38271]](https://issues.apache.org/jira/browse/SPARK-38271): PoissonSampler may output more rows than MaxRows
+  - [[SPARK-38273]](https://issues.apache.org/jira/browse/SPARK-38273): decodeUnsafeRows's iterators should close underlying input streams
+  - [[SPARK-38285]](https://issues.apache.org/jira/browse/SPARK-38285): ClassCastException: GenericArrayData cannot be cast to InternalRow
+  - [[SPARK-38286]](https://issues.apache.org/jira/browse/SPARK-38286): Union's maxRows and maxRowsPerPartition may overflow
+  - [[SPARK-38304]](https://issues.apache.org/jira/browse/SPARK-38304): Elt() should return null if index is null under ANSI mode
+  - [[SPARK-38309]](https://issues.apache.org/jira/browse/SPARK-38309): SHS has incorrect percentiles for shuffle read bytes and shuffle total blocks metrics
+  - [[SPARK-38320]](https://issues.apache.org/jira/browse/SPARK-38320): (flat)MapGroupsWithState can timeout groups which just received inputs in the same microbatch
+  - [[SPARK-38325]](https://issues.apache.org/jira/browse/SPARK-38325): ANSI mode: avoid potential runtime error in HashJoin.extractKeyExprAt()
+  - [[SPARK-38333]](https://issues.apache.org/jira/browse/SPARK-38333): DPP cause DataSourceScanExec java.lang.NullPointerException
+  - [[SPARK-38347]](https://issues.apache.org/jira/browse/SPARK-38347): Nullability propagation in transformUpWithNewOutput
+  - [[SPARK-38363]](https://issues.apache.org/jira/browse/SPARK-38363): Avoid runtime error in Dataset.summary() when ANSI mode is on
+  - [[SPARK-38379]](https://issues.apache.org/jira/browse/SPARK-38379): Fix Kubernetes Client mode when mounting persistent volume with storage class
+  - [[SPARK-38407]](https://issues.apache.org/jira/browse/SPARK-38407): ANSI Cast: loosen the limitation of casting non-null complex types
+  - [[SPARK-38411]](https://issues.apache.org/jira/browse/SPARK-38411): Use UTF-8 when doMergeApplicationListingInternal reads event logs
+  - [[SPARK-38412]](https://issues.apache.org/jira/browse/SPARK-38412): `from` and `to` is swapped in the StateSchemaCompatibilityChecker
+  - [[SPARK-38446]](https://issues.apache.org/jira/browse/SPARK-38446): Deadlock between ExecutorClassLoader and FileDownloadCallback caused by Log4j
+  - [[SPARK-38528]](https://issues.apache.org/jira/browse/SPARK-38528): NullPointerException when selecting a generator in a Stream of aggregate expressions
+  - [[SPARK-38542]](https://issues.apache.org/jira/browse/SPARK-38542): UnsafeHashedRelation should serialize numKeys out
+  - [[SPARK-38570]](https://issues.apache.org/jira/browse/SPARK-38570): Incorrect DynamicPartitionPruning caused by Literal
+  - [[SPARK-38579]](https://issues.apache.org/jira/browse/SPARK-38579): Requesting Restful API can cause NullPointerException
+  - [[SPARK-38587]](https://issues.apache.org/jira/browse/SPARK-38587): Validating new location for rename command should use formatted names
+  - [[SPARK-38614]](https://issues.apache.org/jira/browse/SPARK-38614): Don't push down limit through window that's using percent_rank
+  - [[SPARK-38631]](https://issues.apache.org/jira/browse/SPARK-38631): Arbitrary shell command injection via Utils.unpack()
+  - [[SPARK-38652]](https://issues.apache.org/jira/browse/SPARK-38652): uploadFileUri should preserve file scheme
+  - [[SPARK-38655]](https://issues.apache.org/jira/browse/SPARK-38655): OffsetWindowFunctionFrameBase cannot find the offset row whose input is not null
+  - [[SPARK-38677]](https://issues.apache.org/jira/browse/SPARK-38677): pyspark hangs in local mode running rdd map operation
+  - [[SPARK-38684]](https://issues.apache.org/jira/browse/SPARK-38684): Stream-stream outer join has a possible correctness issue due to weakly read consistent on outer iterators
+  - [[SPARK-38787]](https://issues.apache.org/jira/browse/SPARK-38787): Possible correctness issue on stream-stream join when handling edge case
+  - [[SPARK-38809]](https://issues.apache.org/jira/browse/SPARK-38809): Implement option to skip null values in symmetric hash impl of stream-stream joins
+  - [[SPARK-38868]](https://issues.apache.org/jira/browse/SPARK-38868): `assert_true` fails unconditionnaly after `left_outer` joins
+  - [[SPARK-38916]](https://issues.apache.org/jira/browse/SPARK-38916): Tasks not killed caused by race conditions between killTask() and launchTask()
+  - [[SPARK-38922]](https://issues.apache.org/jira/browse/SPARK-38922): TaskLocation.apply throw NullPointerException
+  - [[SPARK-38931]](https://issues.apache.org/jira/browse/SPARK-38931): RocksDB File manager would not create initial dfs directory with unknown number of keys on 1st empty checkpoint
+  - [[SPARK-38936]](https://issues.apache.org/jira/browse/SPARK-38936): Script transform feed thread should have name
+  - [[SPARK-38955]](https://issues.apache.org/jira/browse/SPARK-38955): Disable lineSep option in 'from_csv' and 'schema_of_csv'
+  - [[SPARK-38977]](https://issues.apache.org/jira/browse/SPARK-38977): Fix schema pruning with correlated subqueries
+  - [[SPARK-38990]](https://issues.apache.org/jira/browse/SPARK-38990): date_trunc and trunc both fail with format from column in inline table
+  - [[SPARK-38992]](https://issues.apache.org/jira/browse/SPARK-38992): Avoid using bash -c in ShellBasedGroupsMappingProvider
+  - [[SPARK-39030]](https://issues.apache.org/jira/browse/SPARK-39030): Rename sum to avoid shading the builtin Python function
+  - [[SPARK-39061]](https://issues.apache.org/jira/browse/SPARK-39061): Incorrect results or NPE when using Inline function against an array of dynamically created structs
+  - [[SPARK-39083]](https://issues.apache.org/jira/browse/SPARK-39083): Fix FsHistoryProvider race condition between update and clean app data
+  - [[SPARK-39084]](https://issues.apache.org/jira/browse/SPARK-39084): df.rdd.isEmpty() results in unexpected executor failure and JVM crash
+  - [[SPARK-39104]](https://issues.apache.org/jira/browse/SPARK-39104): Null Pointer Exeption on unpersist call
+  - [[SPARK-39107]](https://issues.apache.org/jira/browse/SPARK-39107): Silent change in regexp_replace's handling of empty strings
+  - [[SPARK-39174]](https://issues.apache.org/jira/browse/SPARK-39174): Catalogs loading swallows missing classname for ClassNotFoundException
+  - [[SPARK-39259]](https://issues.apache.org/jira/browse/SPARK-39259): Timestamps returned by now() and equivalent functions are not consistent in subqueries
+  - [[SPARK-39283]](https://issues.apache.org/jira/browse/SPARK-39283): Spark tasks stuck forever due to deadlock between TaskMemoryManager and UnsafeExternalSorter
+  - [[SPARK-39293]](https://issues.apache.org/jira/browse/SPARK-39293): The accumulator of ArrayAggregate should copy the intermediate result if string, struct, array, or map
+  - [[SPARK-39340]](https://issues.apache.org/jira/browse/SPARK-39340): DS v2 agg pushdown should allow dots in the name of top-level columns
+  - [[SPARK-39376]](https://issues.apache.org/jira/browse/SPARK-39376): Do not output duplicated columns in star expansion of subquery alias of NATURAL/USING JOIN
+  - [[SPARK-39393]](https://issues.apache.org/jira/browse/SPARK-39393): Parquet data source only supports push-down predicate filters for non-repeated primitive types
+  - [[SPARK-39419]](https://issues.apache.org/jira/browse/SPARK-39419): When the comparator of ArraySort returns null, it should fail.
+  - [[SPARK-39422]](https://issues.apache.org/jira/browse/SPARK-39422): SHOW CREATE TABLE should suggest 'AS SERDE' for Hive tables with unsupported serde configurations
+  - [[SPARK-39447]](https://issues.apache.org/jira/browse/SPARK-39447): Only non-broadcast query stage can propagate empty relation
+  - [[SPARK-39476]](https://issues.apache.org/jira/browse/SPARK-39476): Disable Unwrap cast optimize when casting from Long to Float/ Double or from Integer to Float
+  - [[SPARK-39496]](https://issues.apache.org/jira/browse/SPARK-39496): Inline eval path cannot handle null structs
+  - [[SPARK-39505]](https://issues.apache.org/jira/browse/SPARK-39505): Escape log content rendered in UI
+  - [[SPARK-39543]](https://issues.apache.org/jira/browse/SPARK-39543): The option of DataFrameWriterV2 should be passed to storage properties if fallback to v1
+  - [[SPARK-39548]](https://issues.apache.org/jira/browse/SPARK-39548): CreateView Command with a window clause query hit a wrong window definition not found issue
+  - [[SPARK-39570]](https://issues.apache.org/jira/browse/SPARK-39570): inline table should allow expressions with alias
+  - [[SPARK-39575]](https://issues.apache.org/jira/browse/SPARK-39575): ByteBuffer forget to rewind after get in AvroDeserializer
+  - [[SPARK-39650]](https://issues.apache.org/jira/browse/SPARK-39650): Streaming Deduplication should not check the schema of "value"
+  - [[SPARK-39672]](https://issues.apache.org/jira/browse/SPARK-39672): NotExists subquery failed with conflicting attributes
+  - [[SPARK-39758]](https://issues.apache.org/jira/browse/SPARK-39758): NPE on invalid patterns from the regexp functions
+
+### Dependency Changes
+
+While being a maintence release we did still upgrade some dependencies in this release they are:
+
+  - [[SPARK-36808]](https://issues.apache.org/jira/browse/SPARK-36808): Upgrade Kafka to 2.8.1
+  - [[SPARK-37934]](https://issues.apache.org/jira/browse/SPARK-37934): Upgrade Jetty version to 9.4.44
+  - [[SPARK-38563]](https://issues.apache.org/jira/browse/SPARK-38563): Upgrade Py4J to 0.10.9.5
+  - [[SPARK-37977]](https://issues.apache.org/jira/browse/SPARK-37977): Upgrade ORC to 1.6.13
+  - [[SPARK-38905]](https://issues.apache.org/jira/browse/SPARK-38905): Upgrade ORC to 1.6.14
+  - [[SPARK-39183]](https://issues.apache.org/jira/browse/SPARK-39183): Upgrade Apache Xerces Java to 2.12.2
+
+You can consult JIRA for the [detailed changes](https://s.apache.org/spark-3.2.2).
+
+We would like to acknowledge all community members for contributing patches to this release.

--- a/site/committers.html
+++ b/site/committers.html
@@ -644,6 +644,9 @@ of the immediate bug being fixed.</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -652,9 +655,6 @@ of the immediate bug being fixed.</li>
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/community.html
+++ b/site/community.html
@@ -345,6 +345,9 @@ Add yours by emailing `dev@spark.apache.org`.
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -353,9 +356,6 @@ Add yours by emailing `dev@spark.apache.org`.
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -679,6 +679,9 @@ to ask on the <code class="language-plaintext highlighter-rouge">dev@spark.apach
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -687,9 +690,6 @@ to ask on the <code class="language-plaintext highlighter-rouge">dev@spark.apach
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -734,6 +734,9 @@ The platform-specific paths to the profiler agents are listed in the
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -742,9 +745,6 @@ The platform-specific paths to the profiler agents are listed in the
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -128,6 +128,7 @@
 
 <ul>
   <li><a href="/docs/3.3.0/">Spark 3.3.0</a></li>
+  <li><a href="/docs/3.2.2/">Spark 3.2.2</a></li>
   <li><a href="/docs/3.2.1/">Spark 3.2.1</a></li>
   <li><a href="/docs/3.2.0/">Spark 3.2.0</a></li>
   <li><a href="/docs/3.1.3/">Spark 3.1.3</a></li>
@@ -333,6 +334,9 @@ The <a href="/research.html">research page</a> lists some of the original motiva
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -341,9 +345,6 @@ The <a href="/research.html">research page</a> lists some of the original motiva
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -186,6 +186,9 @@ before deciding to use it.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -194,9 +197,6 @@ before deciding to use it.</p>
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/error-message-guidelines.html
+++ b/site/error-message-guidelines.html
@@ -525,6 +525,9 @@ be redundant; you may skip an explicit explanation in this case.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -533,9 +536,6 @@ be redundant; you may skip an explicit explanation in this case.</p>
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/examples.html
+++ b/site/examples.html
@@ -521,6 +521,9 @@ We learn to predict the labels from feature vectors using the Logistic Regressio
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -529,9 +532,6 @@ We learn to predict the labels from feature vectors using the Logistic Regressio
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/faq.html
+++ b/site/faq.html
@@ -195,6 +195,9 @@ Please also refer to our
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -203,9 +206,6 @@ Please also refer to our
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -240,6 +240,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -248,9 +251,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/history.html
+++ b/site/history.html
@@ -149,6 +149,9 @@ You can get involved in Apache Spark development by reading
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -157,9 +160,6 @@ You can get involved in Apache Spark development by reading
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -221,6 +221,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -229,9 +232,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -29,7 +29,7 @@ var packagesV12 = [hadoop3p3, hadoop3p3scala213, hadoop2p7, hadoopFree, sources]
 var packagesV13 = [hadoop3p, hadoop3pscala213, hadoop2p, hadoopFree, sources];
 
 addRelease("3.3.0", new Date("06/16/2022"), packagesV13, true);
-addRelease("3.2.1", new Date("01/26/2022"), packagesV12, true);
+addRelease("3.2.2", new Date("07/17/2022"), packagesV12, true);
 addRelease("3.1.3", new Date("02/18/2022"), packagesV11, true);
 
 function append(el, contents) {

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -133,6 +133,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -141,9 +144,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -286,6 +286,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -294,9 +297,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/3-1-3-released.html
+++ b/site/news/3-1-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -126,6 +126,15 @@
 
 <article class="hentry">
     <header class="entry-header">
+      <h3 class="entry-title"><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a></h3>
+      <div class="entry-date">July 17, 2022</div>
+    </header>
+    <div class="entry-content"><p>We are happy to announce the availability of <a href="/releases/spark-release-3-2-2.html" title="Spark Release 3.2.2">Spark 3.2.2</a>! Visit the <a href="/releases/spark-release-3-2-2.html" title="Spark Release 3.2.2">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+</div>
+  </article>
+
+<article class="hentry">
+    <header class="entry-header">
       <h3 class="entry-title"><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a></h3>
       <div class="entry-date">June 16, 2022</div>
     </header>
@@ -1228,6 +1237,9 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -1236,9 +1248,6 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/new-repository-service.html
+++ b/site/news/new-repository-service.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/next-official-release-spark-3.1.1.html
+++ b/site/news/next-official-release-spark-3.1.1.html
@@ -151,6 +151,9 @@ are no guarantees on using it such as binary compatibility.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -159,9 +162,6 @@ are no guarantees on using it such as binary compatibility.</p>
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -145,6 +145,9 @@ online to attend in person. We hope you enjoy the event!</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -153,9 +156,6 @@ online to attend in person. We hope you enjoy the event!</p>
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/plan-for-dropping-python-2-support.html
+++ b/site/news/plan-for-dropping-python-2-support.html
@@ -155,6 +155,9 @@ Python 2. However, after Python 2 EOL, we might not take patches that are specif
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -163,9 +166,6 @@ Python 2. However, after Python 2 EOL, we might not take patches that are specif
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/sigmod-system-award.html
+++ b/site/news/sigmod-system-award.html
@@ -150,6 +150,9 @@ the whole community earned together.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -158,9 +161,6 @@ the whole community earned together.</p>
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -146,6 +146,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -154,9 +157,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -145,6 +145,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -153,9 +156,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -144,6 +144,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -152,9 +155,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -142,6 +142,9 @@ This release expands Spark&#8217;s standard libraries, introducing a new SQL pac
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -150,9 +153,6 @@ This release expands Spark&#8217;s standard libraries, introducing a new SQL pac
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -145,6 +145,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -153,9 +156,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-3-released.html
+++ b/site/news/spark-2-1-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-2-released.html
+++ b/site/news/spark-2-2-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-1-released.html
+++ b/site/news/spark-2-3-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-2-released.html
+++ b/site/news/spark-2-3-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-3-released.html
+++ b/site/news/spark-2-3-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-4-released.html
+++ b/site/news/spark-2-3-4-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-0-released.html
+++ b/site/news/spark-2-4-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-1-released.html
+++ b/site/news/spark-2-4-1-released.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-2-released.html
+++ b/site/news/spark-2-4-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-3-released.html
+++ b/site/news/spark-2-4-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-4-released.html
+++ b/site/news/spark-2-4-4-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-5-released.html
+++ b/site/news/spark-2-4-5-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-6.html
+++ b/site/news/spark-2-4-6.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-7-released.html
+++ b/site/news/spark-2-4-7-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-8-released.html
+++ b/site/news/spark-2-4-8-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-0-released.html
+++ b/site/news/spark-3-0-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-1-released.html
+++ b/site/news/spark-3-0-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-2-released.html
+++ b/site/news/spark-3-0-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-3-released.html
+++ b/site/news/spark-3-0-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-1-released.html
+++ b/site/news/spark-3-1-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-2-released.html
+++ b/site/news/spark-3-1-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-0-released.html
+++ b/site/news/spark-3-2-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-1-released.html
+++ b/site/news/spark-3-2-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-2-released.html
+++ b/site/news/spark-3-2-2-released.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Preview release of Spark 3.0 | Apache Spark
+     Spark 3.2.2 released | Apache Spark
     
   </title>
 
@@ -122,12 +122,10 @@
 <div class="container">
   <div class="row mt-4">
     <div class="col-12 col-md-9">
-      <h2>Preview release of Spark 3.0</h2>
+      <h2>Spark 3.2.2 released</h2>
 
 
-<p>To enable wide-scale community testing of the upcoming Spark 3.0 release, the Apache Spark community has posted a <a href="https://archive.apache.org/dist/spark/spark-3.0.0-preview/">preview release of Spark 3.0</a>. This preview is <b>not a stable release in terms of either API or functionality</b>, but it is meant to give the community early access to try the code that will become Spark 3.0. If you would like to test the release, please download it, and send feedback using either the <a href="https://spark.apache.org/community.html">mailing lists</a> or <a href="https://issues.apache.org/jira/browse/SPARK/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel">JIRA</a>.</p>
-
-<p>The Spark issue tracker already contains a list of <a href="https://issues.apache.org/jira/browse/SPARK-26078?jql=statusCategory%20%3D%20done%20AND%20project%20%3D%2012315420%20AND%20fixVersion%20%3D%2012339177%20ORDER%20BY%20priority%20DESC%2C%20key%20ASC">features in 3.0</a>.</p>
+<p>We are happy to announce the availability of <a href="/releases/spark-release-3-2-2.html" title="Spark Release 3.2.2">Spark 3.2.2</a>! Visit the <a href="/releases/spark-release-3-2-2.html" title="Spark Release 3.2.2">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
 
 
 <p>

--- a/site/news/spark-3-3-0-released.html
+++ b/site/news/spark-3-3-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview2.html
+++ b/site/news/spark-3.0.0-preview2.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-apr-2019-agenda-posted.html
+++ b/site/news/spark-ai-summit-apr-2019-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-june-2020-agenda-posted.html
+++ b/site/news/spark-ai-summit-june-2020-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -149,6 +149,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -157,9 +160,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -150,6 +150,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -158,9 +161,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-release-2-2-3.html
+++ b/site/news/spark-release-2-2-3.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -145,6 +145,9 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -153,9 +156,6 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -147,6 +147,9 @@ about the latest happenings in Spark.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -155,9 +158,6 @@ about the latest happenings in Spark.</p>
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2015.html
+++ b/site/news/spark-summit-east-agenda-posted-2015.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2016.html
+++ b/site/news/spark-summit-east-agenda-posted-2016.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-oct-2018-agenda-posted.html
+++ b/site/news/spark-summit-oct-2018-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -144,6 +144,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -152,9 +155,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -146,6 +146,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -154,9 +157,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -148,6 +148,9 @@ on Spark.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -156,9 +159,6 @@ on Spark.</p>
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -149,6 +149,9 @@ online to attend in person. Otherwise, the Summit will offer a free live video s
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -157,9 +160,6 @@ online to attend in person. Otherwise, the Summit will offer a free live video s
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -483,6 +483,9 @@ to process islands identified from a search robor</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -491,9 +494,6 @@ to process islands identified from a search robor</li>
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -511,6 +511,9 @@ and then send an e-mail to the mailing list. To create an announcement, create a
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -519,9 +522,6 @@ and then send an e-mail to the mailing list. To create an announcement, create a
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -190,6 +190,9 @@ squares.saveAsSequenceFile(<span class="string">"hdfs://..."</span>)
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -198,9 +201,6 @@ squares.saveAsSequenceFile(<span class="string">"hdfs://..."</span>)
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -162,6 +162,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -170,9 +173,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -216,6 +216,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -224,9 +227,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -238,6 +238,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -246,9 +249,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -180,6 +180,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -188,9 +191,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -269,6 +269,9 @@ We’d especially like to thank Patrick Wendell for acting as the release manage
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -277,9 +280,6 @@ We’d especially like to thank Patrick Wendell for acting as the release manage
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -233,6 +233,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -241,9 +244,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -327,6 +327,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -335,9 +338,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -245,6 +245,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -253,9 +256,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -218,6 +218,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -226,9 +229,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -311,6 +311,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -319,9 +322,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -269,6 +269,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -277,9 +280,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -226,6 +226,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -234,9 +237,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -362,6 +362,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -370,9 +373,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -248,6 +248,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -256,9 +259,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -376,6 +376,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -384,9 +387,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -248,6 +248,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -256,9 +259,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -208,6 +208,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -216,9 +219,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -353,6 +353,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -361,9 +364,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -240,6 +240,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -248,9 +251,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -467,6 +467,9 @@ Python coverage. MLlib also adds several new algorithms.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -475,9 +478,6 @@ Python coverage. MLlib also adds several new algorithms.</p>
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -272,6 +272,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -280,9 +283,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -405,6 +405,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -413,9 +416,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -144,6 +144,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -152,9 +155,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -281,6 +281,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -289,9 +292,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -377,6 +377,9 @@ yzhou2001, zhonghaihua, zhuol, zlpmichelle, Örjan Lundberg, Łukasz Gieroń</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -385,9 +388,6 @@ yzhou2001, zhonghaihua, zhuol, zlpmichelle, Örjan Lundberg, Łukasz Gieroń</p>
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -289,6 +289,9 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Roberts, Adrian Petrescu, Ahmed Mahran
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -297,9 +300,6 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Roberts, Adrian Petrescu, Ahmed Mahran
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-3.html
+++ b/site/releases/spark-release-2-1-3.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -355,6 +355,9 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Budde, Adam Roberts, Adrian Ionescu, A
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -363,9 +366,6 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Budde, Adam Roberts, Adrian Ionescu, A
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -153,6 +153,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -161,9 +164,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-2.html
+++ b/site/releases/spark-release-2-2-2.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-3.html
+++ b/site/releases/spark-release-2-2-3.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -365,6 +365,9 @@ ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Albe
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -373,9 +376,6 @@ ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Albe
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-1.html
+++ b/site/releases/spark-release-2-3-1.html
@@ -153,6 +153,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -161,9 +164,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-2.html
+++ b/site/releases/spark-release-2-3-2.html
@@ -153,6 +153,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -161,9 +164,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-3.html
+++ b/site/releases/spark-release-2-3-3.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-4.html
+++ b/site/releases/spark-release-2-3-4.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-0.html
+++ b/site/releases/spark-release-2-4-0.html
@@ -371,6 +371,9 @@ Achuth17, Adam Bradbury, Adamyuanyuan, Adelbert Chang, Ala Luszczak, Aleksandr K
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -379,9 +382,6 @@ Achuth17, Adam Bradbury, Adamyuanyuan, Adelbert Chang, Ala Luszczak, Aleksandr K
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-1.html
+++ b/site/releases/spark-release-2-4-1.html
@@ -181,6 +181,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -189,9 +192,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-2.html
+++ b/site/releases/spark-release-2-4-2.html
@@ -153,6 +153,9 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -161,9 +164,6 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-3.html
+++ b/site/releases/spark-release-2-4-3.html
@@ -151,6 +151,9 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -159,9 +162,6 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-4.html
+++ b/site/releases/spark-release-2-4-4.html
@@ -157,6 +157,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -165,9 +168,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-5.html
+++ b/site/releases/spark-release-2-4-5.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-6.html
+++ b/site/releases/spark-release-2-4-6.html
@@ -179,6 +179,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -187,9 +190,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-7.html
+++ b/site/releases/spark-release-2-4-7.html
@@ -221,6 +221,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -229,9 +232,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-8.html
+++ b/site/releases/spark-release-2-4-8.html
@@ -222,6 +222,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -230,9 +233,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-0.html
+++ b/site/releases/spark-release-3-0-0.html
@@ -531,6 +531,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -539,9 +542,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-1.html
+++ b/site/releases/spark-release-3-0-1.html
@@ -180,6 +180,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -188,9 +191,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-2.html
+++ b/site/releases/spark-release-3-0-2.html
@@ -190,6 +190,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -198,9 +201,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-3.html
+++ b/site/releases/spark-release-3-0-3.html
@@ -207,6 +207,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -215,9 +218,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-1.html
+++ b/site/releases/spark-release-3-1-1.html
@@ -568,6 +568,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -576,9 +579,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-2.html
+++ b/site/releases/spark-release-3-1-2.html
@@ -255,6 +255,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -263,9 +266,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-3.html
+++ b/site/releases/spark-release-3-1-3.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-0.html
+++ b/site/releases/spark-release-3-2-0.html
@@ -541,6 +541,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -549,9 +552,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-1.html
+++ b/site/releases/spark-release-3-2-1.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-2.html
+++ b/site/releases/spark-release-3-2-2.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>
+     Spark Release 3.2.2 | Apache Spark
+    
+  </title>
+
+  
+
+  
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
+  <link href="/css/custom.css" rel="stylesheet">
+  <!-- Code highlighter CSS -->
+  <link href="/css/pygments-default.css" rel="stylesheet">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+</head>
+<body class="global">
+<nav class="navbar navbar-expand-lg navbar-dark p-0 px-4" style="background: #1D6890;">
+  <a class="navbar-brand" href="/">
+    <img src="/images/spark-logo-rev.svg" alt="" width="141" height="72">
+  </a>
+  <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent"
+          aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse col-md-12 col-lg-auto pt-4" id="navbarContent">
+
+    <ul class="navbar-nav me-auto">
+      <li class="nav-item">
+        <a class="nav-link active" aria-current="page" href="/downloads.html">Download</a>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="libraries" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Libraries
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="libraries">
+          <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
+          <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
+          <li>
+            <hr class="dropdown-divider">
+          </li>
+          <li><a class="dropdown-item" href="/third-party-projects.html">Third-Party Projects</a></li>
+        </ul>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="documentation" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Documentation
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="documentation">
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.0)</a></li>
+          <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
+          <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
+        </ul>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link active" aria-current="page" href="/examples.html">Examples</a>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="community" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Community
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="community">
+          <li><a class="dropdown-item" href="/community.html">Mailing Lists &amp; Resources</a></li>
+          <li><a class="dropdown-item" href="/contributing.html">Contributing to Spark</a></li>
+          <li><a class="dropdown-item" href="/improvement-proposals.html">Improvement Proposals (SPIP)</a>
+          </li>
+          <li><a class="dropdown-item" href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a>
+          </li>
+          <li><a class="dropdown-item" href="/powered-by.html">Powered By</a></li>
+          <li><a class="dropdown-item" href="/committers.html">Project Committers</a></li>
+          <li><a class="dropdown-item" href="/history.html">Project History</a></li>
+        </ul>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="developers" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Developers
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="developers">
+          <li><a class="dropdown-item" href="/developer-tools.html">Useful Developer Tools</a></li>
+          <li><a class="dropdown-item" href="/versioning-policy.html">Versioning Policy</a></li>
+          <li><a class="dropdown-item" href="/release-process.html">Release Process</a></li>
+          <li><a class="dropdown-item" href="/security.html">Security</a></li>
+        </ul>
+      </li>
+    </ul>
+    <ul class="navbar-nav ml-auto">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="apacheFoundation" role="button"
+           data-bs-toggle="dropdown" aria-expanded="false">
+          Apache Software Foundation
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="apacheFoundation">
+          <li><a class="dropdown-item" href="https://www.apache.org/">Apache Homepage</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/licenses/">License</a></li>
+          <li><a class="dropdown-item"
+                 href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/security/">Security</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/events/current-event">Event</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</nav>
+
+<div class="container">
+  <div class="row mt-4">
+    <div class="col-12 col-md-9">
+      <h2>Spark Release 3.2.2</h2>
+
+
+<p>Spark 3.2.2 is a maintenance release containing stability fixes. This release is based on the branch-3.2 maintenance branch of Spark. We strongly recommend all 3.2 users to upgrade to this stable release.</p>
+
+<h3 id="notable-changes">Notable changes</h3>
+
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-37290">[SPARK-37290]</a>: Exponential planning time in case of non-deterministic function</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-37544">[SPARK-37544]</a>: sequence over dates with month interval is producing incorrect results</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-37643">[SPARK-37643]</a>: When charVarcharAsString is true, char datatype partition table query incorrect</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-37670">[SPARK-37670]</a>: Support predicate pushdown and column pruning for de-duped CTEs</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-37675">[SPARK-37675]</a>: Prevent overwriting of push shuffle merged files once the shuffle is finalized</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-37793">[SPARK-37793]</a>: Invalid LocalMergedBlockData cause task hang</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-37865">[SPARK-37865]</a>: Spark should not dedup the groupingExpressions when the first child of Union has duplicate columns</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-37963">[SPARK-37963]</a>: Need to update Partition URI after renaming table in InMemoryCatalog</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-37995">[SPARK-37995]</a>: TPCDS 1TB q72 fails when spark.sql.optimizer.dynamicPartitionPruning.reuseBroadcastOnly is false</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38018">[SPARK-38018]</a>: Fix ColumnVectorUtils.populate to handle CalendarIntervalType correctly</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38019">[SPARK-38019]</a>: ExecutorMonitor.timedOutExecutors should be deterministic</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38023">[SPARK-38023]</a>: ExecutorMonitor.onExecutorRemoved should handle ExecutorDecommission as finished</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38030">[SPARK-38030]</a>: Query with cast containing non-nullable columns fails with AQE on Spark 3.1.1</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38042">[SPARK-38042]</a>: Encoder cannot be found when a tuple component is a type alias for an Array</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38056">[SPARK-38056]</a>: Structured streaming not working in history server when using LevelDB</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38073">[SPARK-38073]</a>: Update atexit function to avoid issues with late binding</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38075">[SPARK-38075]</a>: Hive script transform with order by and limit will return fake rows</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38120">[SPARK-38120]</a>: HiveExternalCatalog.listPartitions is failing when partition column name is upper case and dot in partition value</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38178">[SPARK-38178]</a>: Correct the logic to measure the memory usage of RocksDB</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38180">[SPARK-38180]</a>: Allow safe up-cast expressions in correlated equality predicates</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38185">[SPARK-38185]</a>: Fix data incorrect if aggregate function is empty</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38204">[SPARK-38204]</a>: All state operators are at a risk of inconsistency between state partitioning and operator partitioning</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38221">[SPARK-38221]</a>: Group by a stream of complex expressions fails</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38236">[SPARK-38236]</a>: Absolute file paths specified in create/alter table are treated as relative</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38271">[SPARK-38271]</a>: PoissonSampler may output more rows than MaxRows</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38273">[SPARK-38273]</a>: decodeUnsafeRows&#8217;s iterators should close underlying input streams</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38285">[SPARK-38285]</a>: ClassCastException: GenericArrayData cannot be cast to InternalRow</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38286">[SPARK-38286]</a>: Union&#8217;s maxRows and maxRowsPerPartition may overflow</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38304">[SPARK-38304]</a>: Elt() should return null if index is null under ANSI mode</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38309">[SPARK-38309]</a>: SHS has incorrect percentiles for shuffle read bytes and shuffle total blocks metrics</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38320">[SPARK-38320]</a>: (flat)MapGroupsWithState can timeout groups which just received inputs in the same microbatch</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38325">[SPARK-38325]</a>: ANSI mode: avoid potential runtime error in HashJoin.extractKeyExprAt()</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38333">[SPARK-38333]</a>: DPP cause DataSourceScanExec java.lang.NullPointerException</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38347">[SPARK-38347]</a>: Nullability propagation in transformUpWithNewOutput</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38363">[SPARK-38363]</a>: Avoid runtime error in Dataset.summary() when ANSI mode is on</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38379">[SPARK-38379]</a>: Fix Kubernetes Client mode when mounting persistent volume with storage class</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38407">[SPARK-38407]</a>: ANSI Cast: loosen the limitation of casting non-null complex types</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38411">[SPARK-38411]</a>: Use UTF-8 when doMergeApplicationListingInternal reads event logs</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38412">[SPARK-38412]</a>: <code class="language-plaintext highlighter-rouge">from</code> and <code class="language-plaintext highlighter-rouge">to</code> is swapped in the StateSchemaCompatibilityChecker</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38446">[SPARK-38446]</a>: Deadlock between ExecutorClassLoader and FileDownloadCallback caused by Log4j</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38528">[SPARK-38528]</a>: NullPointerException when selecting a generator in a Stream of aggregate expressions</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38542">[SPARK-38542]</a>: UnsafeHashedRelation should serialize numKeys out</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38570">[SPARK-38570]</a>: Incorrect DynamicPartitionPruning caused by Literal</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38579">[SPARK-38579]</a>: Requesting Restful API can cause NullPointerException</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38587">[SPARK-38587]</a>: Validating new location for rename command should use formatted names</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38614">[SPARK-38614]</a>: Don&#8217;t push down limit through window that&#8217;s using percent_rank</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38631">[SPARK-38631]</a>: Arbitrary shell command injection via Utils.unpack()</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38652">[SPARK-38652]</a>: uploadFileUri should preserve file scheme</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38655">[SPARK-38655]</a>: OffsetWindowFunctionFrameBase cannot find the offset row whose input is not null</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38677">[SPARK-38677]</a>: pyspark hangs in local mode running rdd map operation</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38684">[SPARK-38684]</a>: Stream-stream outer join has a possible correctness issue due to weakly read consistent on outer iterators</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38787">[SPARK-38787]</a>: Possible correctness issue on stream-stream join when handling edge case</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38809">[SPARK-38809]</a>: Implement option to skip null values in symmetric hash impl of stream-stream joins</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38868">[SPARK-38868]</a>: <code class="language-plaintext highlighter-rouge">assert_true</code> fails unconditionnaly after <code class="language-plaintext highlighter-rouge">left_outer</code> joins</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38916">[SPARK-38916]</a>: Tasks not killed caused by race conditions between killTask() and launchTask()</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38922">[SPARK-38922]</a>: TaskLocation.apply throw NullPointerException</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38931">[SPARK-38931]</a>: RocksDB File manager would not create initial dfs directory with unknown number of keys on 1st empty checkpoint</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38936">[SPARK-38936]</a>: Script transform feed thread should have name</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38955">[SPARK-38955]</a>: Disable lineSep option in &#8216;from_csv&#8217; and &#8216;schema_of_csv&#8217;</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38977">[SPARK-38977]</a>: Fix schema pruning with correlated subqueries</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38990">[SPARK-38990]</a>: date_trunc and trunc both fail with format from column in inline table</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38992">[SPARK-38992]</a>: Avoid using bash -c in ShellBasedGroupsMappingProvider</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39030">[SPARK-39030]</a>: Rename sum to avoid shading the builtin Python function</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39061">[SPARK-39061]</a>: Incorrect results or NPE when using Inline function against an array of dynamically created structs</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39083">[SPARK-39083]</a>: Fix FsHistoryProvider race condition between update and clean app data</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39084">[SPARK-39084]</a>: df.rdd.isEmpty() results in unexpected executor failure and JVM crash</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39104">[SPARK-39104]</a>: Null Pointer Exeption on unpersist call</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39107">[SPARK-39107]</a>: Silent change in regexp_replace&#8217;s handling of empty strings</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39174">[SPARK-39174]</a>: Catalogs loading swallows missing classname for ClassNotFoundException</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39259">[SPARK-39259]</a>: Timestamps returned by now() and equivalent functions are not consistent in subqueries</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39283">[SPARK-39283]</a>: Spark tasks stuck forever due to deadlock between TaskMemoryManager and UnsafeExternalSorter</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39293">[SPARK-39293]</a>: The accumulator of ArrayAggregate should copy the intermediate result if string, struct, array, or map</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39340">[SPARK-39340]</a>: DS v2 agg pushdown should allow dots in the name of top-level columns</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39376">[SPARK-39376]</a>: Do not output duplicated columns in star expansion of subquery alias of NATURAL/USING JOIN</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39393">[SPARK-39393]</a>: Parquet data source only supports push-down predicate filters for non-repeated primitive types</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39419">[SPARK-39419]</a>: When the comparator of ArraySort returns null, it should fail.</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39422">[SPARK-39422]</a>: SHOW CREATE TABLE should suggest &#8216;AS SERDE&#8217; for Hive tables with unsupported serde configurations</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39447">[SPARK-39447]</a>: Only non-broadcast query stage can propagate empty relation</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39476">[SPARK-39476]</a>: Disable Unwrap cast optimize when casting from Long to Float/ Double or from Integer to Float</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39496">[SPARK-39496]</a>: Inline eval path cannot handle null structs</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39505">[SPARK-39505]</a>: Escape log content rendered in UI</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39543">[SPARK-39543]</a>: The option of DataFrameWriterV2 should be passed to storage properties if fallback to v1</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39548">[SPARK-39548]</a>: CreateView Command with a window clause query hit a wrong window definition not found issue</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39570">[SPARK-39570]</a>: inline table should allow expressions with alias</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39575">[SPARK-39575]</a>: ByteBuffer forget to rewind after get in AvroDeserializer</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39650">[SPARK-39650]</a>: Streaming Deduplication should not check the schema of &#8220;value&#8221;</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39672">[SPARK-39672]</a>: NotExists subquery failed with conflicting attributes</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39758">[SPARK-39758]</a>: NPE on invalid patterns from the regexp functions</li>
+</ul>
+
+<h3 id="dependency-changes">Dependency Changes</h3>
+
+<p>While being a maintence release we did still upgrade some dependencies in this release they are:</p>
+
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-36808">[SPARK-36808]</a>: Upgrade Kafka to 2.8.1</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-37934">[SPARK-37934]</a>: Upgrade Jetty version to 9.4.44</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38563">[SPARK-38563]</a>: Upgrade Py4J to 0.10.9.5</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-37977">[SPARK-37977]</a>: Upgrade ORC to 1.6.13</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38905">[SPARK-38905]</a>: Upgrade ORC to 1.6.14</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39183">[SPARK-39183]</a>: Upgrade Apache Xerces Java to 2.12.2</li>
+</ul>
+
+<p>You can consult JIRA for the <a href="https://s.apache.org/spark-3.2.2">detailed changes</a>.</p>
+
+<p>We would like to acknowledge all community members for contributing patches to this release.</p>
+
+
+<p>
+<br/>
+<a href="/news/">Spark News Archive</a>
+</p>
+
+    </div>
+    <div class="col-12 col-md-3">
+      <div class="news" style="margin-bottom: 20px;">
+        <h5>Latest News</h5>
+        <ul class="list-unstyled">
+          
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
+          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
+            <span class="small">(Jun 16, 2022)</span></li>
+          
+          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
+            <span class="small">(May 13, 2022)</span></li>
+          
+          <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
+            <span class="small">(Feb 18, 2022)</span></li>
+          
+        </ul>
+        <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
+      </div>
+      <div style="text-align:center; margin-bottom: 20px;">
+        <a href="https://www.apache.org/events/current-event.html">
+          <img src="https://www.apache.org/events/current-event-234x60.png" style="max-width: 100%;"/>
+        </a>
+      </div>
+      <div class="hidden-xs hidden-sm">
+        <a href="/downloads.html" class="btn btn-cta btn-lg d-grid" style="margin-bottom: 30px;">
+          Download Spark
+        </a>
+        <p style="font-size: 16px; font-weight: 500; color: #555;">
+          Built-in Libraries:
+        </p>
+        <ul class="list-none">
+          <li><a href="/sql/">SQL and DataFrames</a></li>
+          <li><a href="/streaming/">Spark Streaming</a></li>
+          <li><a href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a href="/graphx/">GraphX (graph)</a></li>
+        </ul>
+        <a href="/third-party-projects.html">Third-Party Projects</a>
+      </div>
+    </div>
+  </div>
+
+  
+
+  <footer class="small">
+    <hr>
+    Apache Spark, Spark, Apache, the Apache feather logo, and the Apache Spark project logo are either registered
+    trademarks or trademarks of The Apache Software Foundation in the United States and other countries.
+    See guidance on use of Apache Spark <a href="/trademarks.html">trademarks</a>.
+    All other marks mentioned may be trademarks or registered trademarks of their respective owners.
+    Copyright &copy; 2018 The Apache Software Foundation, Licensed under the
+    <a href="https://www.apache.org/licenses/">Apache License, Version 2.0</a>.
+  </footer>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+        crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery.js"></script>
+<script src="/js/lang-tabs.js"></script>
+<script src="/js/downloads.js"></script>
+</body>
+</html>

--- a/site/releases/spark-release-3-3-0.html
+++ b/site/releases/spark-release-3-3-0.html
@@ -721,6 +721,9 @@ Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</sp
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -729,9 +732,6 @@ Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</sp
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/research.html
+++ b/site/research.html
@@ -187,6 +187,9 @@ Spark offers an abstraction called <a href="http://people.csail.mit.edu/matei/pa
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -195,9 +198,6 @@ Spark offers an abstraction called <a href="http://people.csail.mit.edu/matei/pa
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -149,6 +149,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -157,9 +160,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -149,6 +149,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -157,9 +160,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/security.html
+++ b/site/security.html
@@ -544,6 +544,9 @@ PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -552,9 +555,6 @@ PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -144,6 +144,14 @@
 </url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
+  <loc>https://spark.apache.org/releases/spark-release-3-2-2.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/news/spark-3-2-2-released.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/releases/spark-release-3-3-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -285,6 +285,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -293,9 +296,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -227,6 +227,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -235,9 +238,6 @@
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -233,6 +233,9 @@ transforming, and analyzing genomic data using Apache Spark</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -241,9 +244,6 @@ transforming, and analyzing genomic data using Apache Spark</li>
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -189,6 +189,9 @@ If you have any questions about the Apache trademark policy, please email
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -197,9 +200,6 @@ If you have any questions about the Apache trademark policy, please email
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -291,6 +291,9 @@ For example, 2.4.0 was released in November 2nd 2018 and had been maintained for
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
+            <span class="small">(Jul 17, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
           
@@ -299,9 +302,6 @@ For example, 2.4.0 was released in November 2nd 2018 and had been maintained for
           
           <li><a href="/news/3-1-3-released.html">Spark 3.1.3 released</a>
             <span class="small">(Feb 18, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-1-released.html">Spark 3.2.1 released</a>
-            <span class="small">(Jan 26, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>


### PR DESCRIPTION
- Apache Download: https://downloads.apache.org/spark/spark-3.2.2/
- Apache Archieve: https://archive.apache.org/dist/spark/spark-3.2.2/
- Maven Central: https://repo1.maven.org/maven2/org/apache/spark/spark-core_2.13/3.2.2/
- PySpark: https://pypi.org/project/pyspark/3.2.2/
- SparkR: Skip

![Screen Shot 2022-07-17 at 11 28 20 PM](https://user-images.githubusercontent.com/9700541/179386847-bc95379f-d3c5-49c9-a157-d2741d634226.png)

![Screen Shot 2022-07-17 at 11 26 37 PM](https://user-images.githubusercontent.com/9700541/179386851-9757c559-f77a-4604-a73b-e3f88da8a086.png)

