### PR TITLE
Add K8s IT test coverage to `GitHub Action` test coverage section and replace K8s Test doc with reference

### DIFF
--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -135,6 +135,7 @@
   <li>Java/Scala/Python/R unit tests with Java 8/Scala 2.12/SBT</li>
   <li>TPC-DS benchmark with scale factor 1</li>
   <li>JDBC Docker integration tests</li>
+  <li>Kubernetes integration tests</li>
   <li>Daily Java/Scala/Python/R unit tests with Java 11/17 and Scala 2.12/SBT</li>
 </ul>
 
@@ -296,57 +297,9 @@ Generating HTML files for PySpark coverage under /.../spark/python/test_coverage
 
 <h4>Testing K8S</h4>
 
-<p>If you have made changes to the K8S bindings in Apache Spark, it would behoove you to test locally before submitting a PR.  This is relatively simple to do, but it will require a local (to you) installation of <a href="https://kubernetes.io/docs/setup/minikube/">minikube</a>.  Due to how minikube interacts with the host system, please be sure to set things up as follows:</p>
+<p>Although GitHub Action provide both K8s unit test and integration test coverage, you can run it locally. For example, Volcano batch scheduler integration test should be done manually. Please refer the integration test documentation for the detail.</p>
 
-<ul>
-  <li>minikube version v1.18.1 (or greater)</li>
-  <li>You must use a VM driver!  Running minikube with the <code class="language-plaintext highlighter-rouge">--vm-driver=none</code> option requires that the user launching minikube/k8s have root access, which could impact how the tests are run.  Our Jenkins workers use the default <a href="https://minikube.sigs.k8s.io/docs/drivers/docker/">docker</a> drivers.  More details <a href="https://minikube.sigs.k8s.io/docs/drivers/">here</a>.</li>
-  <li>kubernetes version v1.17.3 (can be set by executing <code class="language-plaintext highlighter-rouge">minikube config set kubernetes-version v1.17.3</code>)</li>
-  <li>the current kubernetes context must be minikube&#8217;s default context (called &#8216;minikube&#8217;). This can be selected by <code class="language-plaintext highlighter-rouge">minikube kubectl -- config use-context minikube</code>. This is only needed when after minikube is started another kubernetes context is selected.</li>
-</ul>
-
-<p>Once you have minikube properly set up, and have successfully completed the <a href="https://minikube.sigs.k8s.io/docs/start/">quick start</a>, you can test your changes locally.  All subsequent commands should be run from your root spark/ repo directory:</p>
-
-<p>1) Build a tarball to test against:</p>
-
-<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>export DATE=`date "+%Y%m%d"`
-export REVISION=`git rev-parse --short HEAD`
-export ZINC_PORT=$(python -S -c "import random; print(random.randrange(3030,4030))")
-export HADOOP_PROFILE=hadoop-3.2
-
-./dev/make-distribution.sh --name ${DATE}-${REVISION} --pip --tgz -DzincPort=${ZINC_PORT} \
-     -P$HADOOP_PROFILE -Pkubernetes -Pkinesis-asl -Phive -Phive-thriftserver
-export TARBALL_TO_TEST=($(pwd)/spark-*${DATE}-${REVISION}.tgz)
-</code></pre></div></div>
-
-<p>2) Use that tarball and run the K8S integration tests:</p>
-
-<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>PVC_TMP_DIR=$(mktemp -d)
-export PVC_TESTS_HOST_PATH=$PVC_TMP_DIR
-export PVC_TESTS_VM_PATH=$PVC_TMP_DIR
-
-minikube config set kubernetes-version v1.17.3
-minikube --vm-driver=&lt;YOUR VM DRIVER HERE&gt; start --memory 6000 --cpus 8
-
-# for macos only (see https://github.com/apache/spark/pull/32793):
-# minikube ssh "sudo useradd spark -u 185 -g 0 -m -s /bin/bash"
-
-minikube mount ${PVC_TESTS_HOST_PATH}:${PVC_TESTS_VM_PATH} --9p-version=9p2000.L --gid=0 --uid=185 &amp;; MOUNT_PID=$!
-
-kubectl create clusterrolebinding serviceaccounts-cluster-admin --clusterrole=cluster-admin --group=system:serviceaccounts || true
-
-./resource-managers/kubernetes/integration-tests/dev/dev-run-integration-tests.sh \
-    --spark-tgz $TARBALL_TO_TEST --hadoop-profile $HADOOP_PROFILE --exclude-tags r
-
-kill -9 $MOUNT_PID
-minikube stop
-</code></pre></div></div>
-
-<p>After the run is completed, the integration test logs are saved here: <code class="language-plaintext highlighter-rouge">./resource-managers/kubernetes/integration-tests/target/integration-tests.log</code>.</p>
-
-<p>In case of a failure the POD logs (driver and executors) can be found at the end of the failed test (within <code class="language-plaintext highlighter-rouge">integration-tests.log</code>) in the <code class="language-plaintext highlighter-rouge">EXTRA LOGS FOR THE FAILED TEST</code> section.</p>
-
-<p>Kubernetes, and more importantly, minikube have rapid release cycles, and point releases have been found to be buggy and/or break older and existing functionality.  If you are having trouble getting tests to pass on Jenkins, but locally things work, don&#8217;t hesitate to file a Jira issue.</p>
+<p>https://github.com/apache/spark/blob/master/resource-managers/kubernetes/integration-tests/README.md</p>
 
 <h3>Testing with GitHub actions workflow</h3>
 


### PR DESCRIPTION
[SPARK-38597](https://issues.apache.org/jira/browse/SPARK-38597) added K8s integration test coverage to GitHub Action.

This PR aims to add it to `GitHub Action` test coverage section. Also, since it's automated now, this PR replaces the outdated K8s testing guide with the link to the latest K8s `README.md` file which including additional `DockerDesktop` test instruction and `Volcano` test instruction.