### PR TITLE
Fix dead link in documentation.html and third-party-projects.html

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -77,7 +77,7 @@ navigation:
 </ul>
 
 <p>The documentation linked to above covers getting started with Spark, as well the built-in components <a href="{{site.baseurl}}/docs/latest/mllib-guide.html">MLlib</a>,
-<a href="{{site.baseurl}}/docs/latest/streaming-programming-guide.html">Spark Streaming</a>, and <a href="{{site.baseurl}}/docs/latest/graphx-guide.html">GraphX</a>.</p>
+<a href="{{site.baseurl}}/docs/latest/streaming-programming-guide.html">Spark Streaming</a>, and <a href="{{site.baseurl}}/docs/latest/graphx-programming-guide.html">GraphX</a>.</p>
 
 <p>In addition, this page lists other resources for learning Spark.</p>
 
@@ -176,7 +176,6 @@ Slides, videos and EC2-based exercises from each of these are available online:
 <h3>External Tutorials, Blog Posts, and Talks</h3>
 
 <ul>
-  <li><a href="http://engineering.ooyala.com/blog/using-parquet-and-scrooge-spark">Using Parquet and Scrooge with Spark</a> &mdash; Scala-friendly Parquet and Avro usage tutorial from Ooyala's Evan Chan</li>
   <li><a href="http://codeforhire.com/2014/02/18/using-spark-with-mongodb/">Using Spark with MongoDB</a> &mdash; by Sampo Niskanen from Wellmo</li>
   <li><a href="https://spark-summit.org/2013">Spark Summit 2013</a> &mdash; contained 30 talks about Spark use cases, available as slides and videos</li>
   <li><a href="http://zenfractal.com/2013/08/21/a-powerful-big-data-trio/">A Powerful Big Data Trio: Spark, Parquet and Avro</a> &mdash; Using Parquet in Spark by Matt Massie</li>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -192,7 +192,7 @@
 </ul>
 
 <p>The documentation linked to above covers getting started with Spark, as well the built-in components <a href="/docs/latest/mllib-guide.html">MLlib</a>,
-<a href="/docs/latest/streaming-programming-guide.html">Spark Streaming</a>, and <a href="/docs/latest/graphx-guide.html">GraphX</a>.</p>
+<a href="/docs/latest/streaming-programming-guide.html">Spark Streaming</a>, and <a href="/docs/latest/graphx-programming-guide.html">GraphX</a>.</p>
 
 <p>In addition, this page lists other resources for learning Spark.</p>
 
@@ -290,7 +290,6 @@ Slides, videos and EC2-based exercises from each of these are available online:
 <h3>External Tutorials, Blog Posts, and Talks</h3>
 
 <ul>
-  <li><a href="http://engineering.ooyala.com/blog/using-parquet-and-scrooge-spark">Using Parquet and Scrooge with Spark</a> &mdash; Scala-friendly Parquet and Avro usage tutorial from Ooyala's Evan Chan</li>
   <li><a href="http://codeforhire.com/2014/02/18/using-spark-with-mongodb/">Using Spark with MongoDB</a> &mdash; by Sampo Niskanen from Wellmo</li>
   <li><a href="https://spark-summit.org/2013">Spark Summit 2013</a> &mdash; contained 30 talks about Spark use cases, available as slides and videos</li>
   <li><a href="http://zenfractal.com/2013/08/21/a-powerful-big-data-trio/">A Powerful Big Data Trio: Spark, Parquet and Avro</a> &mdash; Using Parquet in Spark by Matt Massie</li>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -170,14 +170,12 @@ against Spark, and data scientists to use Javascript in Jupyter notebooks.</li>
 Mahout has switched to using Spark as the backend</li>
   <li><a href="https://wiki.apache.org/mrql/">Apache MRQL</a> - A query processing and optimization 
 system for large-scale, distributed data analysis, built on top of Apache Hadoop, Hama, and Spark</li>
-  <li><a href="http://blinkdb.org/">BlinkDB</a> - a massively parallel, approximate query engine built 
+  <li><a href="https://github.com/sameeragarwal/blinkdb">BlinkDB</a> - a massively parallel, approximate query engine built 
 on top of Shark and Spark</li>
   <li><a href="https://github.com/adobe-research/spindle">Spindle</a> - Spark/Parquet-based web 
 analytics query engine</li>
   <li><a href="https://github.com/thunderain-project/thunderain">Thunderain</a> - a framework 
 for combining stream processing with historical data, think Lambda architecture</li>
-  <li><a href="https://github.com/AyasdiOpenSource/df">DF</a> from Ayasdi - a Pandas-like data frame 
-implementation for Spark</li>
   <li><a href="https://github.com/OryxProject/oryx">Oryx</a> -  Lambda architecture on Apache Spark, 
 Apache Kafka for real-time large scale machine learning</li>
   <li><a href="https://github.com/bigdatagenomics/adam">ADAM</a> - A framework and CLI for loading, 

--- a/third-party-projects.md
+++ b/third-party-projects.md
@@ -52,14 +52,12 @@ against Spark, and data scientists to use Javascript in Jupyter notebooks.
 Mahout has switched to using Spark as the backend
 - <a href="https://wiki.apache.org/mrql/">Apache MRQL</a> - A query processing and optimization 
 system for large-scale, distributed data analysis, built on top of Apache Hadoop, Hama, and Spark
-- <a href="http://blinkdb.org/">BlinkDB</a> - a massively parallel, approximate query engine built 
+- <a href="https://github.com/sameeragarwal/blinkdb">BlinkDB</a> - a massively parallel, approximate query engine built 
 on top of Shark and Spark
 - <a href="https://github.com/adobe-research/spindle">Spindle</a> - Spark/Parquet-based web 
 analytics query engine
 - <a href="https://github.com/thunderain-project/thunderain">Thunderain</a> - a framework 
 for combining stream processing with historical data, think Lambda architecture
-- <a href="https://github.com/AyasdiOpenSource/df">DF</a> from Ayasdi - a Pandas-like data frame 
-implementation for Spark
 - <a href="https://github.com/OryxProject/oryx">Oryx</a> -  Lambda architecture on Apache Spark, 
 Apache Kafka for real-time large scale machine learning
 - <a href="https://github.com/bigdatagenomics/adam">ADAM</a> - A framework and CLI for loading, 


### PR DESCRIPTION
This pr is the first part of SPARK-40322, there are a total of 5 pages with dead links:

- documentation.html
- third-party-projects.html
- release-process.html
- news
- powered-by.html

This pr fix `documentation.html` and `third-party-projects.html`
