### PR TITLE
correct typo in rdd-programming-guide

### DIFF
--- a/site/docs/2.2.0/rdd-programming-guide.html
+++ b/site/docs/2.2.0/rdd-programming-guide.html
@@ -1088,7 +1088,7 @@ for details.</p>
 </tr>
 <tr>
   <td> <b>sample</b>(<i>withReplacement</i>, <i>fraction</i>, <i>seed</i>) </td>
-  <td> Sample a fraction <i>fraction</i> of the data, with or without replacement, using a given random number generator seed. </td>
+  <td> Sample a <i>fraction</i> of the data, with or without replacement, using a given random number generator seed. </td>
 </tr>
 <tr>
   <td> <b>union</b>(<i>otherDataset</i>) </td>


### PR DESCRIPTION
Fraction was repeated twice in guide corrected it

<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->


Also corrected in  spark docs in this PR https://github.com/apache/spark/pull/37839