### PR TITLE
Update the Spark Docker container release process

### DIFF
--- a/release-process.md
+++ b/release-process.md
@@ -35,9 +35,6 @@ If you are a new Release Manager, you can read up on the process from the follow
 - gpg for signing https://www.apache.org/dev/openpgp.html
 - svn https://www.apache.org/dev/version-control.html#https-svn
 
-
-You should also get access to the ASF Dockerhub. You can get access by filing a INFRA JIRA ticket (see an example ticket https://issues.apache.org/jira/browse/INFRA-21282 ).
-
 <h3>Preparing gpg key</h3>
 
 You can skip this section if you have already uploaded your key.
@@ -178,11 +175,10 @@ To cut a release candidate, there are 4 steps:
 1. Package the release binaries & sources, and upload them to the Apache staging SVN repo.
 1. Create the release docs, and upload them to the Apache staging SVN repo.
 1. Publish a snapshot to the Apache staging Maven repo.
-1. Create a RC docker image tag (e.g. `3.4.0-rc1`)
 
-The process of cutting a release candidate has been mostly automated via the `dev/create-release/do-release-docker.sh` script.
+The process of cutting a release candidate has been automated via the `dev/create-release/do-release-docker.sh` script.
 Run this script, type information it requires, and wait until it finishes. You can also do a single step via the `-s` option.
-Please run `do-release-docker.sh -h` and see more details. It does not currently generate the RC docker image tag.
+Please run `do-release-docker.sh -h` and see more details.
 
 <h3>Call a vote on the release candidate</h3>
 
@@ -392,6 +388,9 @@ $ git log v1.1.1 --grep "$expr" --shortstat --oneline | grep -B 1 -e "[3-9][0-9]
 ```
 
 <h4>Create and upload Spark Docker Images</h4>
+
+Please contact <a href="mailto:holden@apache.org">Holden Karau</a> or <a href="mailto:gengliang@apache.org">Gengliang Wang</a> or <a href="mailto:dongjoon@apache.org">Dongjoon Hyun</a> to do this step because of the [ASF has a limited number of Docker Hub seats](https://infra.apache.org/docker-hub-policy.html).
+
 
 The Spark docker images are created using the `./bin/docker-image-tool.sh` that is included in the release artifacts.
 

--- a/release-process.md
+++ b/release-process.md
@@ -389,7 +389,7 @@ $ git log v1.1.1 --grep "$expr" --shortstat --oneline | grep -B 1 -e "[3-9][0-9]
 
 <h4>Create and upload Spark Docker Images</h4>
 
-Please contact <a href="mailto:holden@apache.org">Holden Karau</a> or <a href="mailto:gengliang@apache.org">Gengliang Wang</a> or <a href="mailto:dongjoon@apache.org">Dongjoon Hyun</a> to do this step because of the [ASF has a limited number of Docker Hub seats](https://infra.apache.org/docker-hub-policy.html).
+Please contact <a href="mailto:holden@apache.org">Holden Karau</a>, <a href="mailto:gengliang@apache.org">Gengliang Wang</a> or <a href="mailto:dongjoon@apache.org">Dongjoon Hyun</a> to do this step because of the [ASF has a limited number of Docker Hub seats](https://infra.apache.org/docker-hub-policy.html).
 
 
 The Spark docker images are created using the `./bin/docker-image-tool.sh` that is included in the release artifacts.

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -499,7 +499,7 @@ $ git log v1.1.1 --grep "$expr" --shortstat --oneline | grep -B 1 -e "[3-9][0-9]
 
 <h4>Create and upload Spark Docker Images</h4>
 
-<p>Please contact <a href="mailto:holden@apache.org">Holden Karau</a> or <a href="mailto:gengliang@apache.org">Gengliang Wang</a> or <a href="mailto:dongjoon@apache.org">Dongjoon Hyun</a> to do this step because of the <a href="https://infra.apache.org/docker-hub-policy.html">ASF has a limited number of Docker Hub seats</a>.</p>
+<p>Please contact <a href="mailto:holden@apache.org">Holden Karau</a>, <a href="mailto:gengliang@apache.org">Gengliang Wang</a> or <a href="mailto:dongjoon@apache.org">Dongjoon Hyun</a> to do this step because of the <a href="https://infra.apache.org/docker-hub-policy.html">ASF has a limited number of Docker Hub seats</a>.</p>
 
 <p>The Spark docker images are created using the <code class="language-plaintext highlighter-rouge">./bin/docker-image-tool.sh</code> that is included in the release artifacts.</p>
 

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -163,8 +163,6 @@
   <li>svn https://www.apache.org/dev/version-control.html#https-svn</li>
 </ul>
 
-<p>You should also get access to the ASF Dockerhub. You can get access by filing a INFRA JIRA ticket (see an example ticket https://issues.apache.org/jira/browse/INFRA-21282 ).</p>
-
 <h3>Preparing gpg key</h3>
 
 <p>You can skip this section if you have already uploaded your key.</p>
@@ -297,12 +295,11 @@ Note that not all permutations are run on PR therefore it is important to check 
   <li>Package the release binaries &amp; sources, and upload them to the Apache staging SVN repo.</li>
   <li>Create the release docs, and upload them to the Apache staging SVN repo.</li>
   <li>Publish a snapshot to the Apache staging Maven repo.</li>
-  <li>Create a RC docker image tag (e.g. <code class="language-plaintext highlighter-rouge">3.4.0-rc1</code>)</li>
 </ol>
 
-<p>The process of cutting a release candidate has been mostly automated via the <code class="language-plaintext highlighter-rouge">dev/create-release/do-release-docker.sh</code> script.
+<p>The process of cutting a release candidate has been automated via the <code class="language-plaintext highlighter-rouge">dev/create-release/do-release-docker.sh</code> script.
 Run this script, type information it requires, and wait until it finishes. You can also do a single step via the <code class="language-plaintext highlighter-rouge">-s</code> option.
-Please run <code class="language-plaintext highlighter-rouge">do-release-docker.sh -h</code> and see more details. It does not currently generate the RC docker image tag.</p>
+Please run <code class="language-plaintext highlighter-rouge">do-release-docker.sh -h</code> and see more details.</p>
 
 <h3>Call a vote on the release candidate</h3>
 
@@ -501,6 +498,8 @@ $ git log v1.1.1 --grep "$expr" --shortstat --oneline | grep -B 1 -e "[3-9][0-9]
 </code></pre></div></div>
 
 <h4>Create and upload Spark Docker Images</h4>
+
+<p>Please contact <a href="mailto:holden@apache.org">Holden Karau</a> or <a href="mailto:gengliang@apache.org">Gengliang Wang</a> or <a href="mailto:dongjoon@apache.org">Dongjoon Hyun</a> to do this step because of the <a href="https://infra.apache.org/docker-hub-policy.html">ASF has a limited number of Docker Hub seats</a>.</p>
 
 <p>The Spark docker images are created using the <code class="language-plaintext highlighter-rouge">./bin/docker-image-tool.sh</code> that is included in the release artifacts.</p>
 


### PR DESCRIPTION
Update the Spark Docker container release process because of the ASF has a limited number of Docker Hub seats:
1. Do not create RC docker image tag.
2. Contact [Holden Karau](mailto:holden@apache.org) or [Gengliang Wang](mailto:gengliang@apache.org) or [Dongjoon Hyun](mailto:dongjoon@apache.org) to upload Spark Docker Images after the vote passes.


Please see https://issues.apache.org/jira/browse/INFRA-23700 for more details.

Generate site HTML:
<img width="982" alt="image" src="https://user-images.githubusercontent.com/5399861/190937450-fab58692-1ad0-4316-8362-f8bcbdfac8b7.png">

