### PR TITLE
Add 3.2.3 announcement news, release note and download link

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -14,6 +14,7 @@ navigation:
 <ul>
   <li><a href="{{site.baseurl}}/docs/3.3.1/">Spark 3.3.1</a></li>
   <li><a href="{{site.baseurl}}/docs/3.3.0/">Spark 3.3.0</a></li>
+  <li><a href="{{site.baseurl}}/docs/3.2.3/">Spark 3.2.3</a></li>
   <li><a href="{{site.baseurl}}/docs/3.2.2/">Spark 3.2.2</a></li>
   <li><a href="{{site.baseurl}}/docs/3.2.1/">Spark 3.2.1</a></li>
   <li><a href="{{site.baseurl}}/docs/3.2.0/">Spark 3.2.0</a></li>

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -26,7 +26,7 @@ var packagesV12 = [hadoop3p3, hadoop3p3scala213, hadoop2p7, hadoopFree, sources]
 var packagesV13 = [hadoop3p, hadoop3pscala213, hadoop2p, hadoopFree, sources];
 
 addRelease("3.3.1", new Date("10/25/2022"), packagesV13, true);
-addRelease("3.2.2", new Date("07/17/2022"), packagesV12, true);
+addRelease("3.2.3", new Date("11/28/2022"), packagesV12, true);
 
 function append(el, contents) {
   el.innerHTML += contents;

--- a/news/_posts/2022-11-28-spark-3-2-3-released.md
+++ b/news/_posts/2022-11-28-spark-3-2-3-released.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: Spark 3.2.3 released
+categories:
+- News
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+We are happy to announce the availability of <a href="{{site.baseurl}}/releases/spark-release-3-2-3.html" title="Spark Release 3.2.3">Spark 3.2.3</a>! Visit the <a href="{{site.baseurl}}/releases/spark-release-3-2-3.html" title="Spark Release 3.2.3">release notes</a> to read about the new features, or <a href="{{site.baseurl}}/downloads.html">download</a> the release today.

--- a/releases/_posts/2022-11-28-spark-release-3-2-3.md
+++ b/releases/_posts/2022-11-28-spark-release-3-2-3.md
@@ -1,0 +1,93 @@
+---
+layout: post
+title: Spark Release 3.2.3
+categories: []
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+
+Spark 3.2.3 is a maintenance release containing stability fixes. This release is based on the branch-3.2 maintenance branch of Spark. We strongly recommend all 3.2 users to upgrade to this stable release.
+
+### Notable changes
+
+  - [[SPARK-38697]](https://issues.apache.org/jira/browse/SPARK-38697): Extend SparkSessionExtensions to inject rules into AQE Optimizer
+  - [[SPARK-39200]](https://issues.apache.org/jira/browse/SPARK-39200): Stream is corrupted Exception while fetching the blocks from fallback storage system
+  - [[SPARK-8731]](https://issues.apache.org/jira/browse/SPARK-8731): Beeline doesn't work with -e option when started in background
+  - [[SPARK-32380]](https://issues.apache.org/jira/browse/SPARK-32380): sparksql cannot access hive table while data in hbase
+  - [[SPARK-35542]](https://issues.apache.org/jira/browse/SPARK-35542): Bucketizer created for multiple columns with parameters splitsArray,  inputCols and outputCols can not be loaded after saving it.
+  - [[SPARK-39184]](https://issues.apache.org/jira/browse/SPARK-39184): ArrayIndexOutOfBoundsException for some date/time sequences in some time-zones
+  - [[SPARK-39647]](https://issues.apache.org/jira/browse/SPARK-39647): Block push fails with java.lang.IllegalArgumentException: Active local dirs list has not been updated by any executor registration even when the NodeManager hasn't been restarted
+  - [[SPARK-39775]](https://issues.apache.org/jira/browse/SPARK-39775): Regression due to AVRO-2035
+  - [[SPARK-39833]](https://issues.apache.org/jira/browse/SPARK-39833): Filtered parquet data frame count() and show() produce inconsistent results when spark.sql.parquet.filterPushdown is true
+  - [[SPARK-39835]](https://issues.apache.org/jira/browse/SPARK-39835): Fix EliminateSorts remove global sort below the local sort
+  - [[SPARK-39839]](https://issues.apache.org/jira/browse/SPARK-39839): Handle special case of null variable-length Decimal with non-zero offsetAndSize in UnsafeRow structural integrity check
+  - [[SPARK-39847]](https://issues.apache.org/jira/browse/SPARK-39847): Race condition related to interruption of task threads while they are in RocksDBLoader.loadLibrary()
+  - [[SPARK-39867]](https://issues.apache.org/jira/browse/SPARK-39867): Global limit should not inherit OrderPreservingUnaryNode
+  - [[SPARK-39887]](https://issues.apache.org/jira/browse/SPARK-39887): Expression transform error
+  - [[SPARK-39900]](https://issues.apache.org/jira/browse/SPARK-39900): Issue with querying dataframe produced by 'binaryFile' format using 'not' operator
+  - [[SPARK-39932]](https://issues.apache.org/jira/browse/SPARK-39932): WindowExec should clear the final partition buffer
+  - [[SPARK-39952]](https://issues.apache.org/jira/browse/SPARK-39952): SaveIntoDataSourceCommand should recache result relation
+  - [[SPARK-39962]](https://issues.apache.org/jira/browse/SPARK-39962): Global aggregation against pandas aggregate UDF does not take the column order into account
+  - [[SPARK-39965]](https://issues.apache.org/jira/browse/SPARK-39965): Skip PVC cleanup when driver doesn't own PVCs
+  - [[SPARK-39972]](https://issues.apache.org/jira/browse/SPARK-39972): Revert the test case of SPARK-39962 in branch-3.2 and branch-3.1
+  - [[SPARK-40002]](https://issues.apache.org/jira/browse/SPARK-40002): Limit improperly pushed down through window using ntile function
+  - [[SPARK-40065]](https://issues.apache.org/jira/browse/SPARK-40065): Executor ConfigMap is not mounted if profile is not default
+  - [[SPARK-40079]](https://issues.apache.org/jira/browse/SPARK-40079): Add Imputer inputCols validation for empty input case
+  - [[SPARK-40089]](https://issues.apache.org/jira/browse/SPARK-40089): Sorting of at least Decimal(20, 2) fails for some values near the max.
+  - [[SPARK-40117]](https://issues.apache.org/jira/browse/SPARK-40117): Convert condition to java in DataFrameWriterV2.overwrite
+  - [[SPARK-40121]](https://issues.apache.org/jira/browse/SPARK-40121): Initialize projection used for Python UDF
+  - [[SPARK-40124]](https://issues.apache.org/jira/browse/SPARK-40124): Update TPCDS v1.4 q32 for Plan Stability tests
+  - [[SPARK-40149]](https://issues.apache.org/jira/browse/SPARK-40149): Star expansion after outer join asymmetrically includes joining key
+  - [[SPARK-40169]](https://issues.apache.org/jira/browse/SPARK-40169): Fix the issue with Parquet column index and predicate pushdown in Data source V1
+  - [[SPARK-40212]](https://issues.apache.org/jira/browse/SPARK-40212): SparkSQL castPartValue does not properly handle byte & short
+  - [[SPARK-40218]](https://issues.apache.org/jira/browse/SPARK-40218): GROUPING SETS should preserve the grouping columns
+  - [[SPARK-40270]](https://issues.apache.org/jira/browse/SPARK-40270): Make compute.max_rows as None working in DataFrame.style
+  - [[SPARK-40280]](https://issues.apache.org/jira/browse/SPARK-40280): Failure to create parquet predicate push down for ints and longs on some valid files
+  - [[SPARK-40315]](https://issues.apache.org/jira/browse/SPARK-40315): Non-deterministic hashCode() calculations for ArrayBasedMapData on equal objects
+  - [[SPARK-40407]](https://issues.apache.org/jira/browse/SPARK-40407): Repartition of DataFrame can result in severe data skew in some special case
+  - [[SPARK-40459]](https://issues.apache.org/jira/browse/SPARK-40459): recoverDiskStore should not stop by existing recomputed files
+  - [[SPARK-40470]](https://issues.apache.org/jira/browse/SPARK-40470): arrays_zip output unexpected alias column names when using GetMapValue and GetArrayStructFields
+  - [[SPARK-40493]](https://issues.apache.org/jira/browse/SPARK-40493): Revert "[SPARK-33861][SQL] Simplify conditional in predicate"
+  - [[SPARK-40562]](https://issues.apache.org/jira/browse/SPARK-40562): Add spark.sql.legacy.groupingIdWithAppendedUserGroupBy
+  - [[SPARK-40583]](https://issues.apache.org/jira/browse/SPARK-40583): Documentation error in "Integration with Cloud Infrastructures"
+  - [[SPARK-40588]](https://issues.apache.org/jira/browse/SPARK-40588): Sorting issue with partitioned-writing and AQE turned on
+  - [[SPARK-40612]](https://issues.apache.org/jira/browse/SPARK-40612): On Kubernetes for long running app Spark using an invalid principal to renew the delegation token
+  - [[SPARK-40636]](https://issues.apache.org/jira/browse/SPARK-40636): Fix wrong remained shuffles log in BlockManagerDecommissioner
+  - [[SPARK-40660]](https://issues.apache.org/jira/browse/SPARK-40660): Switch to XORShiftRandom to distribute elements
+  - [[SPARK-40829]](https://issues.apache.org/jira/browse/SPARK-40829): STORED AS serde in CREATE TABLE LIKE view does not work
+  - [[SPARK-40851]](https://issues.apache.org/jira/browse/SPARK-40851): TimestampFormatter behavior changed when using the latest Java 8/11/17
+  - [[SPARK-40869]](https://issues.apache.org/jira/browse/SPARK-40869): KubernetesConf.getResourceNamePrefix creates invalid name prefixes
+  - [[SPARK-40874]](https://issues.apache.org/jira/browse/SPARK-40874): Fix broadcasts in Python UDFs when encryption is enabled
+  - [[SPARK-40902]](https://issues.apache.org/jira/browse/SPARK-40902): Quick submission of drivers in tests to mesos scheduler results in dropping drivers
+  - [[SPARK-40963]](https://issues.apache.org/jira/browse/SPARK-40963): ExtractGenerator sets incorrect nullability in new Project
+  - [[SPARK-41035]](https://issues.apache.org/jira/browse/SPARK-41035): Incorrect results or NPE when a literal is reused across distinct aggregations
+  - [[SPARK-41091]](https://issues.apache.org/jira/browse/SPARK-41091): Fix Docker release tool for branch-3.2
+  - [[SPARK-41188]](https://issues.apache.org/jira/browse/SPARK-41188): Set executorEnv OMP_NUM_THREADS to be spark.task.cpus by default for spark executor JVM processes
+  - [[SPARK-38034]](https://issues.apache.org/jira/browse/SPARK-38034): Optimize time complexity and extend applicable cases for TransposeWindow
+  - [[SPARK-39831]](https://issues.apache.org/jira/browse/SPARK-39831): R dependencies installation start to fail after devtools_2.4.4 was released
+  - [[SPARK-39879]](https://issues.apache.org/jira/browse/SPARK-39879): Reduce local-cluster memory configuration in BroadcastJoinSuite* and HiveSparkSubmitSuite
+  - [[SPARK-40022]](https://issues.apache.org/jira/browse/SPARK-40022): YarnClusterSuite should not ABORTED when there is no Python3 environment
+  - [[SPARK-40241]](https://issues.apache.org/jira/browse/SPARK-40241): Correct the link of GenericUDTF
+  - [[SPARK-40490]](https://issues.apache.org/jira/browse/SPARK-40490): `YarnShuffleIntegrationSuite` no longer verifies `registeredExecFile` reload after SPARK-17321
+  - [[SPARK-40574]](https://issues.apache.org/jira/browse/SPARK-40574): Add PURGE to DROP TABLE doc
+  - [[SPARK-40172]](https://issues.apache.org/jira/browse/SPARK-40172): Temporarily disable flaky test cases in ImageFileFormatSuite
+  - [[SPARK-40461]](https://issues.apache.org/jira/browse/SPARK-40461): Set upperbound for pyzmq 24.0.0 for Python linter
+  - [[SPARK-40213]](https://issues.apache.org/jira/browse/SPARK-40213): Incorrect ASCII value for Latin-1 Supplement characters
+  - [[SPARK-40292]](https://issues.apache.org/jira/browse/SPARK-40292): arrays_zip output unexpected alias column names
+  - [[SPARK-40043]](https://issues.apache.org/jira/browse/SPARK-40043): Document DataStreamWriter.toTable and DataStreamReader.table
+  - [[SPARK-40983]](https://issues.apache.org/jira/browse/SPARK-40983): Remove Hadoop requirements for zstd mention in Parquet compression codec
+
+### Dependency Changes
+
+While being a maintence release we did still upgrade some dependencies in this release they are:
+
+  - [[SPARK-40801]](https://issues.apache.org/jira/browse/SPARK-40801): Upgrade Apache Commons Text to 1.10
+
+You can consult JIRA for the [detailed changes](https://s.apache.org/spark-3.2.3).
+
+We would like to acknowledge all community members for contributing patches to this release.

--- a/site/committers.html
+++ b/site/committers.html
@@ -648,6 +648,9 @@ of the immediate bug being fixed.</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -656,9 +659,6 @@ of the immediate bug being fixed.</li>
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/community.html
+++ b/site/community.html
@@ -345,6 +345,9 @@ Add yours by emailing `dev@spark.apache.org`.
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -353,9 +356,6 @@ Add yours by emailing `dev@spark.apache.org`.
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -679,6 +679,9 @@ to ask on the <code class="language-plaintext highlighter-rouge">dev@spark.apach
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -687,9 +690,6 @@ to ask on the <code class="language-plaintext highlighter-rouge">dev@spark.apach
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -687,6 +687,9 @@ The platform-specific paths to the profiler agents are listed in the
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -695,9 +698,6 @@ The platform-specific paths to the profiler agents are listed in the
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -129,6 +129,7 @@
 <ul>
   <li><a href="/docs/3.3.1/">Spark 3.3.1</a></li>
   <li><a href="/docs/3.3.0/">Spark 3.3.0</a></li>
+  <li><a href="/docs/3.2.3/">Spark 3.2.3</a></li>
   <li><a href="/docs/3.2.2/">Spark 3.2.2</a></li>
   <li><a href="/docs/3.2.1/">Spark 3.2.1</a></li>
   <li><a href="/docs/3.2.0/">Spark 3.2.0</a></li>
@@ -334,6 +335,9 @@ The <a href="/research.html">research page</a> lists some of the original motiva
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -342,9 +346,6 @@ The <a href="/research.html">research page</a> lists some of the original motiva
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -186,6 +186,9 @@ before deciding to use it.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -194,9 +197,6 @@ before deciding to use it.</p>
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/error-message-guidelines.html
+++ b/site/error-message-guidelines.html
@@ -525,6 +525,9 @@ be redundant; you may skip an explicit explanation in this case.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -533,9 +536,6 @@ be redundant; you may skip an explicit explanation in this case.</p>
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/examples.html
+++ b/site/examples.html
@@ -521,6 +521,9 @@ We learn to predict the labels from feature vectors using the Logistic Regressio
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -529,9 +532,6 @@ We learn to predict the labels from feature vectors using the Logistic Regressio
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/faq.html
+++ b/site/faq.html
@@ -195,6 +195,9 @@ Please also refer to our
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -203,9 +206,6 @@ Please also refer to our
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -240,6 +240,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -248,9 +251,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/history.html
+++ b/site/history.html
@@ -149,6 +149,9 @@ You can get involved in Apache Spark development by reading
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -157,9 +160,6 @@ You can get involved in Apache Spark development by reading
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -221,6 +221,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -229,9 +232,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -26,7 +26,7 @@ var packagesV12 = [hadoop3p3, hadoop3p3scala213, hadoop2p7, hadoopFree, sources]
 var packagesV13 = [hadoop3p, hadoop3pscala213, hadoop2p, hadoopFree, sources];
 
 addRelease("3.3.1", new Date("10/25/2022"), packagesV13, true);
-addRelease("3.2.2", new Date("07/17/2022"), packagesV12, true);
+addRelease("3.2.3", new Date("11/28/2022"), packagesV12, true);
 
 function append(el, contents) {
   el.innerHTML += contents;

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -133,6 +133,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -141,9 +144,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -286,6 +286,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -294,9 +297,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/3-1-3-released.html
+++ b/site/news/3-1-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -126,6 +126,15 @@
 
 <article class="hentry">
     <header class="entry-header">
+      <h3 class="entry-title"><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a></h3>
+      <div class="entry-date">November 28, 2022</div>
+    </header>
+    <div class="entry-content"><p>We are happy to announce the availability of <a href="/releases/spark-release-3-2-3.html" title="Spark Release 3.2.3">Spark 3.2.3</a>! Visit the <a href="/releases/spark-release-3-2-3.html" title="Spark Release 3.2.3">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+</div>
+  </article>
+
+<article class="hentry">
+    <header class="entry-header">
       <h3 class="entry-title"><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a></h3>
       <div class="entry-date">October 25, 2022</div>
     </header>
@@ -1246,6 +1255,9 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -1254,9 +1266,6 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/new-repository-service.html
+++ b/site/news/new-repository-service.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/next-official-release-spark-3.1.1.html
+++ b/site/news/next-official-release-spark-3.1.1.html
@@ -151,6 +151,9 @@ are no guarantees on using it such as binary compatibility.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -159,9 +162,6 @@ are no guarantees on using it such as binary compatibility.</p>
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -145,6 +145,9 @@ online to attend in person. We hope you enjoy the event!</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -153,9 +156,6 @@ online to attend in person. We hope you enjoy the event!</p>
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/plan-for-dropping-python-2-support.html
+++ b/site/news/plan-for-dropping-python-2-support.html
@@ -155,6 +155,9 @@ Python 2. However, after Python 2 EOL, we might not take patches that are specif
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -163,9 +166,6 @@ Python 2. However, after Python 2 EOL, we might not take patches that are specif
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/sigmod-system-award.html
+++ b/site/news/sigmod-system-award.html
@@ -150,6 +150,9 @@ the whole community earned together.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -158,9 +161,6 @@ the whole community earned together.</p>
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -146,6 +146,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -154,9 +157,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -145,6 +145,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -153,9 +156,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -144,6 +144,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -152,9 +155,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -142,6 +142,9 @@ This release expands Spark&#8217;s standard libraries, introducing a new SQL pac
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -150,9 +153,6 @@ This release expands Spark&#8217;s standard libraries, introducing a new SQL pac
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -145,6 +145,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -153,9 +156,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-3-released.html
+++ b/site/news/spark-2-1-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-2-released.html
+++ b/site/news/spark-2-2-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-1-released.html
+++ b/site/news/spark-2-3-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-2-released.html
+++ b/site/news/spark-2-3-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-3-released.html
+++ b/site/news/spark-2-3-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-4-released.html
+++ b/site/news/spark-2-3-4-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-0-released.html
+++ b/site/news/spark-2-4-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-1-released.html
+++ b/site/news/spark-2-4-1-released.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-2-released.html
+++ b/site/news/spark-2-4-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-3-released.html
+++ b/site/news/spark-2-4-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-4-released.html
+++ b/site/news/spark-2-4-4-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-5-released.html
+++ b/site/news/spark-2-4-5-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-6.html
+++ b/site/news/spark-2-4-6.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-7-released.html
+++ b/site/news/spark-2-4-7-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-8-released.html
+++ b/site/news/spark-2-4-8-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-0-released.html
+++ b/site/news/spark-3-0-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-1-released.html
+++ b/site/news/spark-3-0-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-2-released.html
+++ b/site/news/spark-3-0-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-3-released.html
+++ b/site/news/spark-3-0-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-1-released.html
+++ b/site/news/spark-3-1-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-2-released.html
+++ b/site/news/spark-3-1-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-0-released.html
+++ b/site/news/spark-3-2-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-1-released.html
+++ b/site/news/spark-3-2-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-2-released.html
+++ b/site/news/spark-3-2-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-3-released.html
+++ b/site/news/spark-3-2-3-released.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark Release 2.0.1 | Apache Spark
+     Spark 3.2.3 released | Apache Spark
     
   </title>
 
@@ -122,14 +122,10 @@
 <div class="container">
   <div class="row mt-4">
     <div class="col-12 col-md-9">
-      <h2>Spark Release 2.0.1</h2>
+      <h2>Spark 3.2.3 released</h2>
 
 
-<p>Apache Spark 2.0.1 is a maintenance release containing 300 stability and bug fixes. This release is based on the branch-2.0 maintenance branch of Spark. We strongly recommend all 2.0.0 users to upgrade to this stable release.</p>
-
-<p>To download Apache Spark 2.0.1, visit the <a href="http://spark.apache.org/downloads.html">downloads</a> page. You can consult JIRA for the <a href="https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315420&amp;version=12336857">detailed changes</a>.</p>
-
-<p>We would like to acknowledge all community members for contributing patches to this release.</p>
+<p>We are happy to announce the availability of <a href="/releases/spark-release-3-2-3.html" title="Spark Release 3.2.3">Spark 3.2.3</a>! Visit the <a href="/releases/spark-release-3-2-3.html" title="Spark Release 3.2.3">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
 
 
 <p>

--- a/site/news/spark-3-3-0-released.html
+++ b/site/news/spark-3-3-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-1-released.html
+++ b/site/news/spark-3-3-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview.html
+++ b/site/news/spark-3.0.0-preview.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview2.html
+++ b/site/news/spark-3.0.0-preview2.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-apr-2019-agenda-posted.html
+++ b/site/news/spark-ai-summit-apr-2019-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-june-2020-agenda-posted.html
+++ b/site/news/spark-ai-summit-june-2020-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -149,6 +149,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -157,9 +160,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -150,6 +150,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -158,9 +161,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-release-2-2-3.html
+++ b/site/news/spark-release-2-2-3.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -145,6 +145,9 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -153,9 +156,6 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -147,6 +147,9 @@ about the latest happenings in Spark.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -155,9 +158,6 @@ about the latest happenings in Spark.</p>
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2015.html
+++ b/site/news/spark-summit-east-agenda-posted-2015.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2016.html
+++ b/site/news/spark-summit-east-agenda-posted-2016.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-oct-2018-agenda-posted.html
+++ b/site/news/spark-summit-oct-2018-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -144,6 +144,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -152,9 +155,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -146,6 +146,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -154,9 +157,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -148,6 +148,9 @@ on Spark.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -156,9 +159,6 @@ on Spark.</p>
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -149,6 +149,9 @@ online to attend in person. Otherwise, the Summit will offer a free live video s
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -157,9 +160,6 @@ online to attend in person. Otherwise, the Summit will offer a free live video s
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -489,6 +489,9 @@ to process islands identified from a search robor</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -497,9 +500,6 @@ to process islands identified from a search robor</li>
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -521,6 +521,9 @@ and then send an e-mail to the mailing list. To create an announcement, create a
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -529,9 +532,6 @@ and then send an e-mail to the mailing list. To create an announcement, create a
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -190,6 +190,9 @@ squares.saveAsSequenceFile(<span class="string">"hdfs://..."</span>)
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -198,9 +201,6 @@ squares.saveAsSequenceFile(<span class="string">"hdfs://..."</span>)
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -162,6 +162,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -170,9 +173,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -216,6 +216,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -224,9 +227,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -238,6 +238,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -246,9 +249,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -180,6 +180,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -188,9 +191,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -269,6 +269,9 @@ We’d especially like to thank Patrick Wendell for acting as the release manage
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -277,9 +280,6 @@ We’d especially like to thank Patrick Wendell for acting as the release manage
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -233,6 +233,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -241,9 +244,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -327,6 +327,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -335,9 +338,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -245,6 +245,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -253,9 +256,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -218,6 +218,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -226,9 +229,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -311,6 +311,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -319,9 +322,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -269,6 +269,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -277,9 +280,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -226,6 +226,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -234,9 +237,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -362,6 +362,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -370,9 +373,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -248,6 +248,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -256,9 +259,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -376,6 +376,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -384,9 +387,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -248,6 +248,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -256,9 +259,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -208,6 +208,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -216,9 +219,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -353,6 +353,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -361,9 +364,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -240,6 +240,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -248,9 +251,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -467,6 +467,9 @@ Python coverage. MLlib also adds several new algorithms.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -475,9 +478,6 @@ Python coverage. MLlib also adds several new algorithms.</p>
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -272,6 +272,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -280,9 +283,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -405,6 +405,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -413,9 +416,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -144,6 +144,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -152,9 +155,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -281,6 +281,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -289,9 +292,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -377,6 +377,9 @@ yzhou2001, zhonghaihua, zhuol, zlpmichelle, Örjan Lundberg, Łukasz Gieroń</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -385,9 +388,6 @@ yzhou2001, zhonghaihua, zhuol, zlpmichelle, Örjan Lundberg, Łukasz Gieroń</p>
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -289,6 +289,9 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Roberts, Adrian Petrescu, Ahmed Mahran
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -297,9 +300,6 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Roberts, Adrian Petrescu, Ahmed Mahran
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-3.html
+++ b/site/releases/spark-release-2-1-3.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -355,6 +355,9 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Budde, Adam Roberts, Adrian Ionescu, A
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -363,9 +366,6 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Budde, Adam Roberts, Adrian Ionescu, A
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -153,6 +153,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -161,9 +164,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-2.html
+++ b/site/releases/spark-release-2-2-2.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-3.html
+++ b/site/releases/spark-release-2-2-3.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -365,6 +365,9 @@ ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Albe
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -373,9 +376,6 @@ ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Albe
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-1.html
+++ b/site/releases/spark-release-2-3-1.html
@@ -153,6 +153,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -161,9 +164,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-2.html
+++ b/site/releases/spark-release-2-3-2.html
@@ -153,6 +153,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -161,9 +164,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-3.html
+++ b/site/releases/spark-release-2-3-3.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-4.html
+++ b/site/releases/spark-release-2-3-4.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-0.html
+++ b/site/releases/spark-release-2-4-0.html
@@ -371,6 +371,9 @@ Achuth17, Adam Bradbury, Adamyuanyuan, Adelbert Chang, Ala Luszczak, Aleksandr K
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -379,9 +382,6 @@ Achuth17, Adam Bradbury, Adamyuanyuan, Adelbert Chang, Ala Luszczak, Aleksandr K
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-1.html
+++ b/site/releases/spark-release-2-4-1.html
@@ -181,6 +181,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -189,9 +192,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-2.html
+++ b/site/releases/spark-release-2-4-2.html
@@ -153,6 +153,9 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -161,9 +164,6 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-3.html
+++ b/site/releases/spark-release-2-4-3.html
@@ -151,6 +151,9 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -159,9 +162,6 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-4.html
+++ b/site/releases/spark-release-2-4-4.html
@@ -157,6 +157,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -165,9 +168,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-5.html
+++ b/site/releases/spark-release-2-4-5.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-6.html
+++ b/site/releases/spark-release-2-4-6.html
@@ -179,6 +179,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -187,9 +190,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-7.html
+++ b/site/releases/spark-release-2-4-7.html
@@ -221,6 +221,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -229,9 +232,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-8.html
+++ b/site/releases/spark-release-2-4-8.html
@@ -222,6 +222,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -230,9 +233,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-0.html
+++ b/site/releases/spark-release-3-0-0.html
@@ -531,6 +531,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -539,9 +542,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-1.html
+++ b/site/releases/spark-release-3-0-1.html
@@ -180,6 +180,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -188,9 +191,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-2.html
+++ b/site/releases/spark-release-3-0-2.html
@@ -190,6 +190,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -198,9 +201,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-3.html
+++ b/site/releases/spark-release-3-0-3.html
@@ -207,6 +207,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -215,9 +218,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-1.html
+++ b/site/releases/spark-release-3-1-1.html
@@ -568,6 +568,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -576,9 +579,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-2.html
+++ b/site/releases/spark-release-3-1-2.html
@@ -255,6 +255,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -263,9 +266,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-3.html
+++ b/site/releases/spark-release-3-1-3.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-0.html
+++ b/site/releases/spark-release-3-2-0.html
@@ -541,6 +541,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -549,9 +552,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-1.html
+++ b/site/releases/spark-release-3-2-1.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-2.html
+++ b/site/releases/spark-release-3-2-2.html
@@ -249,6 +249,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -257,9 +260,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-3.html
+++ b/site/releases/spark-release-3-2-3.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark Release 3.3.1 | Apache Spark
+     Spark Release 3.2.3 | Apache Spark
     
   </title>
 
@@ -122,85 +122,80 @@
 <div class="container">
   <div class="row mt-4">
     <div class="col-12 col-md-9">
-      <h2>Spark Release 3.3.1</h2>
+      <h2>Spark Release 3.2.3</h2>
 
 
-<p>Spark 3.3.1 is a maintenance release containing stability fixes. This release is based on the branch-3.3 maintenance branch of Spark. We strongly recommend all 3.3 users to upgrade to this stable release.</p>
+<p>Spark 3.2.3 is a maintenance release containing stability fixes. This release is based on the branch-3.2 maintenance branch of Spark. We strongly recommend all 3.2 users to upgrade to this stable release.</p>
 
 <h3 id="notable-changes">Notable changes</h3>
 
 <ul>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-35542">[SPARK-35542]</a>: Fix: Bucketizer created for multiple columns with parameters splitsArray, inputCols and outputCols can not be loaded after saving it</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-36057">[SPARK-36057]</a>: SPIP: Support Customized Kubernetes Schedulers</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-38034">[SPARK-38034]</a>: Optimize TransposeWindow rule</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-38404">[SPARK-38404]</a>: Improve CTE resolution when a nested CTE references an outer CTE</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-38614">[SPARK-38614]</a>: Don&#8217;t push down limit through window that&#8217;s using percent_rank</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-38717">[SPARK-38717]</a>: Handle Hive&#8217;s bucket spec case preserving behaviour</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-38796">[SPARK-38796]</a>: Update to_number and try_to_number functions to allow PR with positive numbers</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39184">[SPARK-39184]</a>: Handle undersized result array in date and timestamp sequences</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39200">[SPARK-39200]</a>: Make Fallback Storage readFully on content</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39340">[SPARK-39340]</a>: DS v2 agg pushdown should allow dots in the name of top-level columns</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39355">[SPARK-39355]</a>: Single column uses quoted to construct UnresolvedAttribute</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39419">[SPARK-39419]</a>: Fix ArraySort to throw an exception when the comparator returns null</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39447">[SPARK-39447]</a>: Avoid AssertionError in AdaptiveSparkPlanExec.doExecuteBroadcast</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39476">[SPARK-39476]</a>: Disable Unwrap cast optimize when casting from Long to Float/ Double or from Integer to Float</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39548">[SPARK-39548]</a>: CreateView Command with a window clause query hit a wrong window definition not found issue</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39570">[SPARK-39570]</a>: Inline table should allow expressions with alias</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39614">[SPARK-39614]</a>: K8s pod name follows DNS Subdomain Names rule</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39633">[SPARK-39633]</a>: Support timestamp in seconds for TimeTravel using Dataframe options</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39647">[SPARK-39647]</a>: Register the executor with ESS before registering the BlockManager</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39650">[SPARK-39650]</a>: Fix incorrect value schema in streaming deduplication with backward compatibility</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39656">[SPARK-39656]</a>: Fix wrong namespace in DescribeNamespaceExec</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39657">[SPARK-39657]</a>: YARN AM client should call the non-static setTokensConf method</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39672">[SPARK-39672]</a>: Fix removing project before filter with correlated subquery</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39758">[SPARK-39758]</a>: Fix NPE from the regexp functions on invalid patterns</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39775">[SPARK-39775]</a>: Disable validate default values when parsing Avro schemas</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39806">[SPARK-39806]</a>: Accessing _metadata on partitioned table can crash a query</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39833">[SPARK-39833]</a>: Disable Parquet column index in DSv1 to fix a correctness issue in the case of overlapping partition and data columns</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38697">[SPARK-38697]</a>: Extend SparkSessionExtensions to inject rules into AQE Optimizer</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39200">[SPARK-39200]</a>: Stream is corrupted Exception while fetching the blocks from fallback storage system</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-8731">[SPARK-8731]</a>: Beeline doesn&#8217;t work with -e option when started in background</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32380">[SPARK-32380]</a>: sparksql cannot access hive table while data in hbase</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-35542">[SPARK-35542]</a>: Bucketizer created for multiple columns with parameters splitsArray,  inputCols and outputCols can not be loaded after saving it.</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39184">[SPARK-39184]</a>: ArrayIndexOutOfBoundsException for some date/time sequences in some time-zones</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39647">[SPARK-39647]</a>: Block push fails with java.lang.IllegalArgumentException: Active local dirs list has not been updated by any executor registration even when the NodeManager hasn&#8217;t been restarted</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39775">[SPARK-39775]</a>: Regression due to AVRO-2035</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39833">[SPARK-39833]</a>: Filtered parquet data frame count() and show() produce inconsistent results when spark.sql.parquet.filterPushdown is true</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-39835">[SPARK-39835]</a>: Fix EliminateSorts remove global sort below the local sort</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-39839">[SPARK-39839]</a>: Handle special case of null variable-length Decimal with non-zero offsetAndSize in UnsafeRow structural integrity check</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39847">[SPARK-39847]</a>: Fix race condition in RocksDBLoader.loadLibrary() if caller thread is interrupted</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39857">[SPARK-39857]</a>: V2ExpressionBuilder uses the wrong LiteralValue data type for In predicate</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39847">[SPARK-39847]</a>: Race condition related to interruption of task threads while they are in RocksDBLoader.loadLibrary()</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-39867">[SPARK-39867]</a>: Global limit should not inherit OrderPreservingUnaryNode</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39887">[SPARK-39887]</a>: RemoveRedundantAliases should keep aliases that make the output of projection nodes unique</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39896">[SPARK-39896]</a>: UnwrapCastInBinaryComparison should work when the literal of In/InSet downcast failed</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39900">[SPARK-39900]</a>: Address partial or negated condition in binary format&#8217;s predicate pushdown</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39911">[SPARK-39911]</a>: Optimize global Sort to RepartitionByExpression</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39915">[SPARK-39915]</a>: Dataset.repartition(N) may not create N partitions Non-AQE part</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39915">[SPARK-39915]</a>: Ensure the output partitioning is user-specified in AQE</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39887">[SPARK-39887]</a>: Expression transform error</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39900">[SPARK-39900]</a>: Issue with querying dataframe produced by &#8216;binaryFile&#8217; format using &#8216;not&#8217; operator</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-39932">[SPARK-39932]</a>: WindowExec should clear the final partition buffer</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39951">[SPARK-39951]</a>: Update Parquet V2 columnar check for nested fields</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-39952">[SPARK-39952]</a>: SaveIntoDataSourceCommand should recache result relation</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39962">[SPARK-39962]</a>: Apply projection when group attributes are empty</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39976">[SPARK-39976]</a>: ArrayIntersect should handle null in left expression correctly</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40002">[SPARK-40002]</a>: Don&#8217;t push down limit through window using ntile</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40065">[SPARK-40065]</a>: Mount ConfigMap on executors with non-default profile as well</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39962">[SPARK-39962]</a>: Global aggregation against pandas aggregate UDF does not take the column order into account</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39965">[SPARK-39965]</a>: Skip PVC cleanup when driver doesn&#8217;t own PVCs</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39972">[SPARK-39972]</a>: Revert the test case of SPARK-39962 in branch-3.2 and branch-3.1</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40002">[SPARK-40002]</a>: Limit improperly pushed down through window using ntile function</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40065">[SPARK-40065]</a>: Executor ConfigMap is not mounted if profile is not default</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-40079">[SPARK-40079]</a>: Add Imputer inputCols validation for empty input case</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40089">[SPARK-40089]</a>: Fix sorting for some Decimal types</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40089">[SPARK-40089]</a>: Sorting of at least Decimal(20, 2) fails for some values near the max.</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-40117">[SPARK-40117]</a>: Convert condition to java in DataFrameWriterV2.overwrite</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-40121">[SPARK-40121]</a>: Initialize projection used for Python UDF</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40132">[SPARK-40132]</a>: Restore rawPredictionCol to MultilayerPerceptronClassifier.setParams</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40149">[SPARK-40149]</a>: Propagate metadata columns through Project</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40152">[SPARK-40152]</a>: Fix split_part codegen compilation issue</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40169">[SPARK-40169]</a>: Don&#8217;t pushdown Parquet filters with no reference to data schema</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40212">[SPARK-40212]</a>: SparkSQL castPartValue does not properly handle byte, short, or float</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40213">[SPARK-40213]</a>: Support ASCII value conversion for Latin-1 characters</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40124">[SPARK-40124]</a>: Update TPCDS v1.4 q32 for Plan Stability tests</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40149">[SPARK-40149]</a>: Star expansion after outer join asymmetrically includes joining key</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40169">[SPARK-40169]</a>: Fix the issue with Parquet column index and predicate pushdown in Data source V1</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40212">[SPARK-40212]</a>: SparkSQL castPartValue does not properly handle byte &amp; short</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-40218">[SPARK-40218]</a>: GROUPING SETS should preserve the grouping columns</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40228">[SPARK-40228]</a>: Do not simplify multiLike if child is not a cheap expression</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40247">[SPARK-40247]</a>: Fix BitSet equality check</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40280">[SPARK-40280]</a>: Add support for parquet push down for annotated int and long</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40297">[SPARK-40297]</a>: CTE outer reference nested in CTE main body cannot be resolved</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40362">[SPARK-40362]</a>: Fix BinaryComparison canonicalization</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40380">[SPARK-40380]</a>: Fix constant-folding of InvokeLike to avoid non-serializable literal embedded in the plan</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40385">[SPARK-40385]</a>: Fix interpreted path for companion object constructor</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40389">[SPARK-40389]</a>: Decimals can&#8217;t upcast as integral types if the cast can overflow</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40468">[SPARK-40468]</a>: Fix column pruning in CSV when _corrupt_record is selected</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40508">[SPARK-40508]</a>: Treat unknown partitioning as UnknownPartitioning</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40535">[SPARK-40535]</a>: Fix bug the buffer of AggregatingAccumulator will not be created if the input rows is empty</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40562">[SPARK-40562]</a>: Add <code class="language-plaintext highlighter-rouge">spark.sql.legacy.groupingIdWithAppendedUserGroupBy</code></li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40612">[SPARK-40612]</a>: Fixing the principal used for delegation token renewal on non-YARN resource managers</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40270">[SPARK-40270]</a>: Make compute.max_rows as None working in DataFrame.style</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40280">[SPARK-40280]</a>: Failure to create parquet predicate push down for ints and longs on some valid files</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40315">[SPARK-40315]</a>: Non-deterministic hashCode() calculations for ArrayBasedMapData on equal objects</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40407">[SPARK-40407]</a>: Repartition of DataFrame can result in severe data skew in some special case</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40459">[SPARK-40459]</a>: recoverDiskStore should not stop by existing recomputed files</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40470">[SPARK-40470]</a>: arrays_zip output unexpected alias column names when using GetMapValue and GetArrayStructFields</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40493">[SPARK-40493]</a>: Revert &#8220;[SPARK-33861][SQL] Simplify conditional in predicate&#8221;</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40562">[SPARK-40562]</a>: Add spark.sql.legacy.groupingIdWithAppendedUserGroupBy</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40583">[SPARK-40583]</a>: Documentation error in &#8220;Integration with Cloud Infrastructures&#8221;</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40588">[SPARK-40588]</a>: Sorting issue with partitioned-writing and AQE turned on</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40612">[SPARK-40612]</a>: On Kubernetes for long running app Spark using an invalid principal to renew the delegation token</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40636">[SPARK-40636]</a>: Fix wrong remained shuffles log in BlockManagerDecommissioner</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-40660">[SPARK-40660]</a>: Switch to XORShiftRandom to distribute elements</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40703">[SPARK-40703]</a>: Introduce shuffle on SinglePartition to improve parallelism</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40829">[SPARK-40829]</a>: STORED AS serde in CREATE TABLE LIKE view does not work</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40851">[SPARK-40851]</a>: TimestampFormatter behavior changed when using the latest Java 8/11/17</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40869">[SPARK-40869]</a>: KubernetesConf.getResourceNamePrefix creates invalid name prefixes</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40874">[SPARK-40874]</a>: Fix broadcasts in Python UDFs when encryption is enabled</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40902">[SPARK-40902]</a>: Quick submission of drivers in tests to mesos scheduler results in dropping drivers</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40963">[SPARK-40963]</a>: ExtractGenerator sets incorrect nullability in new Project</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41035">[SPARK-41035]</a>: Incorrect results or NPE when a literal is reused across distinct aggregations</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41091">[SPARK-41091]</a>: Fix Docker release tool for branch-3.2</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41188">[SPARK-41188]</a>: Set executorEnv OMP_NUM_THREADS to be spark.task.cpus by default for spark executor JVM processes</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38034">[SPARK-38034]</a>: Optimize time complexity and extend applicable cases for TransposeWindow</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39831">[SPARK-39831]</a>: R dependencies installation start to fail after devtools_2.4.4 was released</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39879">[SPARK-39879]</a>: Reduce local-cluster memory configuration in BroadcastJoinSuite* and HiveSparkSubmitSuite</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40022">[SPARK-40022]</a>: YarnClusterSuite should not ABORTED when there is no Python3 environment</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40241">[SPARK-40241]</a>: Correct the link of GenericUDTF</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40490">[SPARK-40490]</a>: <code class="language-plaintext highlighter-rouge">YarnShuffleIntegrationSuite</code> no longer verifies <code class="language-plaintext highlighter-rouge">registeredExecFile</code> reload after SPARK-17321</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40574">[SPARK-40574]</a>: Add PURGE to DROP TABLE doc</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40172">[SPARK-40172]</a>: Temporarily disable flaky test cases in ImageFileFormatSuite</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40461">[SPARK-40461]</a>: Set upperbound for pyzmq 24.0.0 for Python linter</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40213">[SPARK-40213]</a>: Incorrect ASCII value for Latin-1 Supplement characters</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40292">[SPARK-40292]</a>: arrays_zip output unexpected alias column names</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40043">[SPARK-40043]</a>: Document DataStreamWriter.toTable and DataStreamReader.table</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40983">[SPARK-40983]</a>: Remove Hadoop requirements for zstd mention in Parquet compression codec</li>
 </ul>
 
 <h3 id="dependency-changes">Dependency Changes</h3>
@@ -208,14 +203,10 @@
 <p>While being a maintence release we did still upgrade some dependencies in this release they are:</p>
 
 <ul>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39947">[SPARK-39947]</a>: Upgrade Jersey to 2.36</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40134">[SPARK-40134]</a>: Update ORC to 1.7.6</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40326">[SPARK-40326]</a>: Upgrade fasterxml.jackson.version to 2.13.4</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39725">[SPARK-39725]</a>: Upgrade jetty to 9.4.48.v20220622</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40782">[SPARK-40782]</a>: Upgrade jackson-databind to 2.13.4.1</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40801">[SPARK-40801]</a>: Upgrade Apache Commons Text to 1.10</li>
 </ul>
 
-<p>You can consult JIRA for the <a href="https://s.apache.org/spark-3.3.1">detailed changes</a>.</p>
+<p>You can consult JIRA for the <a href="https://s.apache.org/spark-3.2.3">detailed changes</a>.</p>
 
 <p>We would like to acknowledge all community members for contributing patches to this release.</p>
 

--- a/site/releases/spark-release-3-3-0.html
+++ b/site/releases/spark-release-3-3-0.html
@@ -721,6 +721,9 @@ Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</sp
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -729,9 +732,6 @@ Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</sp
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/research.html
+++ b/site/research.html
@@ -187,6 +187,9 @@ Spark offers an abstraction called <a href="http://people.csail.mit.edu/matei/pa
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -195,9 +198,6 @@ Spark offers an abstraction called <a href="http://people.csail.mit.edu/matei/pa
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -149,6 +149,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -157,9 +160,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -149,6 +149,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -157,9 +160,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/security.html
+++ b/site/security.html
@@ -612,6 +612,9 @@ PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -620,9 +623,6 @@ PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -144,6 +144,14 @@
 </url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
+  <loc>https://spark.apache.org/releases/spark-release-3-2-3.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/news/spark-3-2-3-released.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/releases/spark-release-3-3-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>
@@ -965,6 +973,10 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
+  <loc>https://spark.apache.org/streaming/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/news/</loc>
   <changefreq>weekly</changefreq>
 </url>
@@ -974,10 +986,6 @@
 </url>
 <url>
   <loc>https://spark.apache.org/sql/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>https://spark.apache.org/streaming/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -285,6 +285,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -293,9 +296,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -227,6 +227,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -235,9 +238,6 @@
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -231,6 +231,9 @@ transforming, and analyzing genomic data using Apache Spark</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -239,9 +242,6 @@ transforming, and analyzing genomic data using Apache Spark</li>
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -189,6 +189,9 @@ If you have any questions about the Apache trademark policy, please email
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -197,9 +200,6 @@ If you have any questions about the Apache trademark policy, please email
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -291,6 +291,9 @@ For example, 2.4.0 was released in November 2nd 2018 and had been maintained for
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
+            <span class="small">(Nov 28, 2022)</span></li>
+          
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
           
@@ -299,9 +302,6 @@ For example, 2.4.0 was released in November 2nd 2018 and had been maintained for
           
           <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
             <span class="small">(Jun 16, 2022)</span></li>
-          
-          <li><a href="/news/sigmod-system-award.html">SIGMOD Systems Award for Apache Spark</a>
-            <span class="small">(May 13, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>


### PR DESCRIPTION
- Apache Download: https://downloads.apache.org/spark/spark-3.2.3/
- Apache Archieve: https://archive.apache.org/dist/spark/spark-3.2.3/
- Maven Central: https://repo1.maven.org/maven2/org/apache/spark/spark-core_2.12/3.2.3/
- PySpark: https://pypi.org/project/pyspark/3.2.3/

<img width="1357" alt="Screenshot 2022-11-28 at 3 27 43 PM" src="https://user-images.githubusercontent.com/506679/204448406-a58689a3-6b11-4c3b-8916-694858fff01d.png">

