### PR TITLE
Add 3.3.2 release note, news and document link

### DIFF
--- a/_layouts/global.html
+++ b/_layouts/global.html
@@ -67,7 +67,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="{{site.baseurl}}/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="{{site.baseurl}}/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="{{site.baseurl}}/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="{{site.baseurl}}/faq.html">Frequently Asked Questions</a></li>
         </ul>

--- a/documentation.md
+++ b/documentation.md
@@ -12,6 +12,7 @@ navigation:
 <p>Setup instructions, programming guides, and other documentation are available for each stable version of Spark below:</p>
 
 <ul>
+  <li><a href="{{site.baseurl}}/docs/3.3.2/">Spark 3.3.2</a></li>
   <li><a href="{{site.baseurl}}/docs/3.3.1/">Spark 3.3.1</a></li>
   <li><a href="{{site.baseurl}}/docs/3.3.0/">Spark 3.3.0</a></li>
   <li><a href="{{site.baseurl}}/docs/3.2.3/">Spark 3.2.3</a></li>

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -25,7 +25,7 @@ var packagesV12 = [hadoop3p3, hadoop3p3scala213, hadoop2p7, hadoopFree, sources]
 // 3.3.0+
 var packagesV13 = [hadoop3p, hadoop3pscala213, hadoop2p, hadoopFree, sources];
 
-addRelease("3.3.1", new Date("10/25/2022"), packagesV13, true);
+addRelease("3.3.2", new Date("02/17/2023"), packagesV13, true);
 addRelease("3.2.3", new Date("11/28/2022"), packagesV12, true);
 
 function append(el, contents) {

--- a/news/_posts/2023-02-17-spark-3-3-2-released.md
+++ b/news/_posts/2023-02-17-spark-3-3-2-released.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: Spark 3.3.2 released
+categories:
+- News
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+We are happy to announce the availability of <a href="{{site.baseurl}}/releases/spark-release-3-3-2.html" title="Spark Release 3.3.2">Spark 3.3.2</a>! Visit the <a href="{{site.baseurl}}/releases/spark-release-3-3-2.html" title="Spark Release 3.3.2">release notes</a> to read about the new features, or <a href="{{site.baseurl}}/downloads.html">download</a> the release today.

--- a/releases/_posts/2023-02-17-spark-release-3-3-2.md
+++ b/releases/_posts/2023-02-17-spark-release-3-3-2.md
@@ -1,0 +1,179 @@
+---
+layout: post
+title: Spark Release 3.3.2
+categories: []
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+
+Spark 3.3.2 is a maintenance release containing stability fixes. This release is based on the branch-3.3 maintenance branch of Spark. We strongly recommend all 3.3 users to upgrade to this stable release.
+
+### Notable changes
+
+  - [[SPARK-38697]](https://issues.apache.org/jira/browse/SPARK-38697): Extend SparkSessionExtensions to inject rules into AQE Optimizer
+  - [[SPARK-40872]](https://issues.apache.org/jira/browse/SPARK-40872): Fallback to original shuffle block when a push-merged shuffle chunk is zero-size
+  - [[SPARK-41388]](https://issues.apache.org/jira/browse/SPARK-41388): getReusablePVCs should ignore recently created PVCs in the previous batch
+  - [[SPARK-42071]](https://issues.apache.org/jira/browse/SPARK-42071): Register scala.math.Ordering$Reverse to KyroSerializer
+  - [[SPARK-32380]](https://issues.apache.org/jira/browse/SPARK-32380): sparksql cannot access hive table while data in hbase
+  - [[SPARK-39404]](https://issues.apache.org/jira/browse/SPARK-39404): Unable to query _metadata in streaming if getBatch returns multiple logical nodes in the DataFrame
+  - [[SPARK-40493]](https://issues.apache.org/jira/browse/SPARK-40493): Revert "[SPARK-33861][SQL] Simplify conditional in predicate"
+  - [[SPARK-40588]](https://issues.apache.org/jira/browse/SPARK-40588): Sorting issue with partitioned-writing and AQE turned on
+  - [[SPARK-40817]](https://issues.apache.org/jira/browse/SPARK-40817): Remote spark.jars URIs ignored for Spark on Kubernetes in cluster mode
+  - [[SPARK-40819]](https://issues.apache.org/jira/browse/SPARK-40819): Parquet INT64 (TIMESTAMP(NANOS,true)) now throwing Illegal Parquet type instead of automatically converting to LongType
+  - [[SPARK-40829]](https://issues.apache.org/jira/browse/SPARK-40829): STORED AS serde in CREATE TABLE LIKE view does not work
+  - [[SPARK-40851]](https://issues.apache.org/jira/browse/SPARK-40851): TimestampFormatter behavior changed when using the latest Java 8/11/17
+  - [[SPARK-40869]](https://issues.apache.org/jira/browse/SPARK-40869): KubernetesConf.getResourceNamePrefix creates invalid name prefixes
+  - [[SPARK-40874]](https://issues.apache.org/jira/browse/SPARK-40874): Fix broadcasts in Python UDFs when encryption is enabled
+  - [[SPARK-40902]](https://issues.apache.org/jira/browse/SPARK-40902): Quick submission of drivers in tests to mesos scheduler results in dropping drivers
+  - [[SPARK-40918]](https://issues.apache.org/jira/browse/SPARK-40918): Mismatch between ParquetFileFormat and FileSourceScanExec in # columns for WSCG.isTooManyFields when using _metadata
+  - [[SPARK-40924]](https://issues.apache.org/jira/browse/SPARK-40924): Unhex function works incorrectly when input has uneven number of symbols
+  - [[SPARK-40932]](https://issues.apache.org/jira/browse/SPARK-40932): Barrier: messages for allGather will be overridden by the following barrier APIs
+  - [[SPARK-40963]](https://issues.apache.org/jira/browse/SPARK-40963): ExtractGenerator sets incorrect nullability in new Project
+  - [[SPARK-40987]](https://issues.apache.org/jira/browse/SPARK-40987): Avoid creating a directory when deleting a block, causing DAGScheduler to not work
+  - [[SPARK-41035]](https://issues.apache.org/jira/browse/SPARK-41035): Incorrect results or NPE when a literal is reused across distinct aggregations
+  - [[SPARK-41118]](https://issues.apache.org/jira/browse/SPARK-41118): to_number/try_to_number throws NullPointerException when format is null
+  - [[SPARK-41144]](https://issues.apache.org/jira/browse/SPARK-41144): UnresolvedHint should not cause query failure
+  - [[SPARK-41151]](https://issues.apache.org/jira/browse/SPARK-41151): Keep built-in file _metadata column nullable value consistent
+  - [[SPARK-41154]](https://issues.apache.org/jira/browse/SPARK-41154): Incorrect relation caching for queries with time travel spec
+  - [[SPARK-41162]](https://issues.apache.org/jira/browse/SPARK-41162): Anti-join must not be pushed below aggregation with ambiguous predicates
+  - [[SPARK-41187]](https://issues.apache.org/jira/browse/SPARK-41187): [Core] LiveExecutor MemoryLeak in AppStatusListener when ExecutorLost happen
+  - [[SPARK-41188]](https://issues.apache.org/jira/browse/SPARK-41188): Set executorEnv OMP_NUM_THREADS to be spark.task.cpus by default for spark executor JVM processes
+  - [[SPARK-41254]](https://issues.apache.org/jira/browse/SPARK-41254): YarnAllocator.rpIdToYarnResource map is not properly updated
+  - [[SPARK-41327]](https://issues.apache.org/jira/browse/SPARK-41327): Fix SparkStatusTracker.getExecutorInfos by switch On/OffHeapStorageMemory info
+  - [[SPARK-41339]](https://issues.apache.org/jira/browse/SPARK-41339): RocksDB state store WriteBatch doesn't clean up native memory
+  - [[SPARK-41350]](https://issues.apache.org/jira/browse/SPARK-41350): allow simple name access of using join hidden columns after subquery alias
+  - [[SPARK-41365]](https://issues.apache.org/jira/browse/SPARK-41365): Stages UI page fails to load for proxy in some yarn versions
+  - [[SPARK-41375]](https://issues.apache.org/jira/browse/SPARK-41375): Avoid empty latest KafkaSourceOffset:
+  - [[SPARK-41376]](https://issues.apache.org/jira/browse/SPARK-41376): Executor netty direct memory check should respect spark.shuffle.io.preferDirectBufs
+  - [[SPARK-41379]](https://issues.apache.org/jira/browse/SPARK-41379): Inconsistency of spark session in DataFrame in user function for foreachBatch sink in PySpark
+  - [[SPARK-41385]](https://issues.apache.org/jira/browse/SPARK-41385): Replace deprecated `.newInstance()` in K8s module
+  - [[SPARK-41395]](https://issues.apache.org/jira/browse/SPARK-41395): InterpretedMutableProjection can corrupt unsafe buffer when used with decimal data
+  - [[SPARK-41448]](https://issues.apache.org/jira/browse/SPARK-41448): Make consistent MR job IDs in FileBatchWriter and FileFormatWriter
+  - [[SPARK-41458]](https://issues.apache.org/jira/browse/SPARK-41458): Correctly transform the SPI services for Yarn Shuffle Service
+  - [[SPARK-41468]](https://issues.apache.org/jira/browse/SPARK-41468): Fix PlanExpression handling in EquivalentExpressions
+  - [[SPARK-41522]](https://issues.apache.org/jira/browse/SPARK-41522): GA dependencies test faild
+  - [[SPARK-41535]](https://issues.apache.org/jira/browse/SPARK-41535): InterpretedUnsafeProjection and InterpretedMutableProjection can corrupt unsafe buffer when used with calendar interval data
+  - [[SPARK-41554]](https://issues.apache.org/jira/browse/SPARK-41554): Decimal.changePrecision produces ArrayIndexOutOfBoundsException
+  - [[SPARK-41668]](https://issues.apache.org/jira/browse/SPARK-41668): DECODE function returns wrong results when passed NULL
+  - [[SPARK-41732]](https://issues.apache.org/jira/browse/SPARK-41732): Session window: analysis rule "SessionWindowing" does not apply tree-pattern based pruning
+  - [[SPARK-41989]](https://issues.apache.org/jira/browse/SPARK-41989): PYARROW_IGNORE_TIMEZONE warning can break application logging setup
+  - [[SPARK-42084]](https://issues.apache.org/jira/browse/SPARK-42084): Avoid leaking the qualified-access-only restriction
+  - [[SPARK-42090]](https://issues.apache.org/jira/browse/SPARK-42090): Introduce sasl retry count in RetryingBlockTransferor
+  - [[SPARK-42134]](https://issues.apache.org/jira/browse/SPARK-42134): Fix getPartitionFiltersAndDataFilters() to handle filters without referenced attributes
+  - [[SPARK-42157]](https://issues.apache.org/jira/browse/SPARK-42157): `spark.scheduler.mode=FAIR` should provide FAIR scheduler
+  - [[SPARK-42176]](https://issues.apache.org/jira/browse/SPARK-42176): Cast boolean to timestamp fails with ClassCastException
+  - [[SPARK-42188]](https://issues.apache.org/jira/browse/SPARK-42188): Force SBT protobuf version to match Maven on branch 3.2 and 3.3
+  - [[SPARK-42201]](https://issues.apache.org/jira/browse/SPARK-42201): `build/sbt` should allow SBT_OPTS to override JVM memory setting
+  - [[SPARK-42222]](https://issues.apache.org/jira/browse/SPARK-42222): Spark 3.3 Backport: SPARK-41344 Reading V2 datasource masks underlying error
+  - [[SPARK-42259]](https://issues.apache.org/jira/browse/SPARK-42259): ResolveGroupingAnalytics should take care of Python UDAF
+  - [[SPARK-42344]](https://issues.apache.org/jira/browse/SPARK-42344): The default size of the CONFIG_MAP_MAXSIZE should not be greater than 1048576
+  - [[SPARK-42346]](https://issues.apache.org/jira/browse/SPARK-42346): distinct(count colname) with UNION ALL causes query analyzer bug
+  - [[SPARK-38277]](https://issues.apache.org/jira/browse/SPARK-38277): Clear write batch after RocksDB state store's commit
+  - [[SPARK-40913]](https://issues.apache.org/jira/browse/SPARK-40913): Pin `pytest==7.1.3`
+  - [[SPARK-41089]](https://issues.apache.org/jira/browse/SPARK-41089): Relocate Netty native arm64 libs
+  - [[SPARK-41360]](https://issues.apache.org/jira/browse/SPARK-41360): Avoid BlockManager re-registration if the executor has been lost
+  - [[SPARK-41476]](https://issues.apache.org/jira/browse/SPARK-41476): Prevent `README.md` from triggering CIs
+  - [[SPARK-41541]](https://issues.apache.org/jira/browse/SPARK-41541): Fix wrong child call in SQLShuffleWriteMetricsReporter.decRecordsWritten()
+  - [[SPARK-41962]](https://issues.apache.org/jira/browse/SPARK-41962): Update the import order of scala package in class SpecificParquetRecordReaderBase
+  - [[SPARK-42230]](https://issues.apache.org/jira/browse/SPARK-42230): Improve `lint` job by skipping PySpark and SparkR docs if unchanged
+  - [[SPARK-41863]](https://issues.apache.org/jira/browse/SPARK-41863): Skip `flake8` tests if the command is not available
+  - [[SPARK-41864]](https://issues.apache.org/jira/browse/SPARK-41864): Fix mypy linter errors
+  - [[SPARK-42110]](https://issues.apache.org/jira/browse/SPARK-42110): Reduce the number of repetition in ParquetDeltaEncodingSuite.`random data test`
+  - [[SPARK-41415]](https://issues.apache.org/jira/browse/SPARK-41415): SASL Request Retries
+  - [[SPARK-41538]](https://issues.apache.org/jira/browse/SPARK-41538): Metadata column should be appended at the end of project list
+  - [[SPARK-40983]](https://issues.apache.org/jira/browse/SPARK-40983): Remove Hadoop requirements for zstd mention in Parquet compression codec
+  - [[SPARK-41185]](https://issues.apache.org/jira/browse/SPARK-41185): Remove ARM limitation for YuniKorn from docs
+
+  - [[SPARK-35542]](https://issues.apache.org/jira/browse/SPARK-35542): Fix: Bucketizer created for multiple columns with parameters splitsArray, inputCols and outputCols can not be loaded after saving it
+  - [[SPARK-36057]](https://issues.apache.org/jira/browse/SPARK-36057): SPIP: Support Customized Kubernetes Schedulers
+  - [[SPARK-38034]](https://issues.apache.org/jira/browse/SPARK-38034): Optimize TransposeWindow rule
+  - [[SPARK-38404]](https://issues.apache.org/jira/browse/SPARK-38404): Improve CTE resolution when a nested CTE references an outer CTE
+  - [[SPARK-38614]](https://issues.apache.org/jira/browse/SPARK-38614): Don't push down limit through window that's using percent_rank
+  - [[SPARK-38717]](https://issues.apache.org/jira/browse/SPARK-38717): Handle Hive's bucket spec case preserving behaviour
+  - [[SPARK-38796]](https://issues.apache.org/jira/browse/SPARK-38796): Update to_number and try_to_number functions to allow PR with positive numbers
+  - [[SPARK-39184]](https://issues.apache.org/jira/browse/SPARK-39184): Handle undersized result array in date and timestamp sequences
+  - [[SPARK-39200]](https://issues.apache.org/jira/browse/SPARK-39200): Make Fallback Storage readFully on content
+  - [[SPARK-39340]](https://issues.apache.org/jira/browse/SPARK-39340): DS v2 agg pushdown should allow dots in the name of top-level columns
+  - [[SPARK-39355]](https://issues.apache.org/jira/browse/SPARK-39355): Single column uses quoted to construct UnresolvedAttribute
+  - [[SPARK-39419]](https://issues.apache.org/jira/browse/SPARK-39419): Fix ArraySort to throw an exception when the comparator returns null
+  - [[SPARK-39447]](https://issues.apache.org/jira/browse/SPARK-39447): Avoid AssertionError in AdaptiveSparkPlanExec.doExecuteBroadcast
+  - [[SPARK-39476]](https://issues.apache.org/jira/browse/SPARK-39476): Disable Unwrap cast optimize when casting from Long to Float/ Double or from Integer to Float
+  - [[SPARK-39548]](https://issues.apache.org/jira/browse/SPARK-39548): CreateView Command with a window clause query hit a wrong window definition not found issue
+  - [[SPARK-39570]](https://issues.apache.org/jira/browse/SPARK-39570): Inline table should allow expressions with alias
+  - [[SPARK-39614]](https://issues.apache.org/jira/browse/SPARK-39614): K8s pod name follows DNS Subdomain Names rule
+  - [[SPARK-39633]](https://issues.apache.org/jira/browse/SPARK-39633): Support timestamp in seconds for TimeTravel using Dataframe options
+  - [[SPARK-39647]](https://issues.apache.org/jira/browse/SPARK-39647): Register the executor with ESS before registering the BlockManager
+  - [[SPARK-39650]](https://issues.apache.org/jira/browse/SPARK-39650): Fix incorrect value schema in streaming deduplication with backward compatibility
+  - [[SPARK-39656]](https://issues.apache.org/jira/browse/SPARK-39656): Fix wrong namespace in DescribeNamespaceExec
+  - [[SPARK-39657]](https://issues.apache.org/jira/browse/SPARK-39657): YARN AM client should call the non-static setTokensConf method
+  - [[SPARK-39672]](https://issues.apache.org/jira/browse/SPARK-39672): Fix removing project before filter with correlated subquery
+  - [[SPARK-39758]](https://issues.apache.org/jira/browse/SPARK-39758): Fix NPE from the regexp functions on invalid patterns
+  - [[SPARK-39775]](https://issues.apache.org/jira/browse/SPARK-39775): Disable validate default values when parsing Avro schemas
+  - [[SPARK-39806]](https://issues.apache.org/jira/browse/SPARK-39806): Accessing _metadata on partitioned table can crash a query
+  - [[SPARK-39833]](https://issues.apache.org/jira/browse/SPARK-39833): Disable Parquet column index in DSv1 to fix a correctness issue in the case of overlapping partition and data columns
+  - [[SPARK-39835]](https://issues.apache.org/jira/browse/SPARK-39835): Fix EliminateSorts remove global sort below the local sort
+  - [[SPARK-39839]](https://issues.apache.org/jira/browse/SPARK-39839): Handle special case of null variable-length Decimal with non-zero offsetAndSize in UnsafeRow structural integrity check
+  - [[SPARK-39847]](https://issues.apache.org/jira/browse/SPARK-39847): Fix race condition in RocksDBLoader.loadLibrary() if caller thread is interrupted
+  - [[SPARK-39857]](https://issues.apache.org/jira/browse/SPARK-39857): V2ExpressionBuilder uses the wrong LiteralValue data type for In predicate
+  - [[SPARK-39867]](https://issues.apache.org/jira/browse/SPARK-39867): Global limit should not inherit OrderPreservingUnaryNode
+  - [[SPARK-39887]](https://issues.apache.org/jira/browse/SPARK-39887): RemoveRedundantAliases should keep aliases that make the output of projection nodes unique
+  - [[SPARK-39896]](https://issues.apache.org/jira/browse/SPARK-39896): UnwrapCastInBinaryComparison should work when the literal of In/InSet downcast failed
+  - [[SPARK-39900]](https://issues.apache.org/jira/browse/SPARK-39900): Address partial or negated condition in binary format's predicate pushdown
+  - [[SPARK-39911]](https://issues.apache.org/jira/browse/SPARK-39911): Optimize global Sort to RepartitionByExpression
+  - [[SPARK-39915]](https://issues.apache.org/jira/browse/SPARK-39915): Dataset.repartition(N) may not create N partitions Non-AQE part
+  - [[SPARK-39915]](https://issues.apache.org/jira/browse/SPARK-39915): Ensure the output partitioning is user-specified in AQE
+  - [[SPARK-39932]](https://issues.apache.org/jira/browse/SPARK-39932): WindowExec should clear the final partition buffer
+  - [[SPARK-39951]](https://issues.apache.org/jira/browse/SPARK-39951): Update Parquet V2 columnar check for nested fields
+  - [[SPARK-39952]](https://issues.apache.org/jira/browse/SPARK-39952): SaveIntoDataSourceCommand should recache result relation
+  - [[SPARK-39962]](https://issues.apache.org/jira/browse/SPARK-39962): Apply projection when group attributes are empty
+  - [[SPARK-39976]](https://issues.apache.org/jira/browse/SPARK-39976): ArrayIntersect should handle null in left expression correctly
+  - [[SPARK-40002]](https://issues.apache.org/jira/browse/SPARK-40002): Don't push down limit through window using ntile
+  - [[SPARK-40065]](https://issues.apache.org/jira/browse/SPARK-40065): Mount ConfigMap on executors with non-default profile as well
+  - [[SPARK-40079]](https://issues.apache.org/jira/browse/SPARK-40079): Add Imputer inputCols validation for empty input case
+  - [[SPARK-40089]](https://issues.apache.org/jira/browse/SPARK-40089): Fix sorting for some Decimal types
+  - [[SPARK-40117]](https://issues.apache.org/jira/browse/SPARK-40117): Convert condition to java in DataFrameWriterV2.overwrite
+  - [[SPARK-40121]](https://issues.apache.org/jira/browse/SPARK-40121): Initialize projection used for Python UDF
+  - [[SPARK-40132]](https://issues.apache.org/jira/browse/SPARK-40132): Restore rawPredictionCol to MultilayerPerceptronClassifier.setParams
+  - [[SPARK-40149]](https://issues.apache.org/jira/browse/SPARK-40149): Propagate metadata columns through Project
+  - [[SPARK-40152]](https://issues.apache.org/jira/browse/SPARK-40152): Fix split_part codegen compilation issue
+  - [[SPARK-40169]](https://issues.apache.org/jira/browse/SPARK-40169): Don't pushdown Parquet filters with no reference to data schema
+  - [[SPARK-40212]](https://issues.apache.org/jira/browse/SPARK-40212): SparkSQL castPartValue does not properly handle byte, short, or float
+  - [[SPARK-40213]](https://issues.apache.org/jira/browse/SPARK-40213): Support ASCII value conversion for Latin-1 characters
+  - [[SPARK-40218]](https://issues.apache.org/jira/browse/SPARK-40218): GROUPING SETS should preserve the grouping columns
+  - [[SPARK-40228]](https://issues.apache.org/jira/browse/SPARK-40228): Do not simplify multiLike if child is not a cheap expression
+  - [[SPARK-40247]](https://issues.apache.org/jira/browse/SPARK-40247): Fix BitSet equality check
+  - [[SPARK-40280]](https://issues.apache.org/jira/browse/SPARK-40280): Add support for parquet push down for annotated int and long
+  - [[SPARK-40297]](https://issues.apache.org/jira/browse/SPARK-40297): CTE outer reference nested in CTE main body cannot be resolved
+  - [[SPARK-40362]](https://issues.apache.org/jira/browse/SPARK-40362): Fix BinaryComparison canonicalization
+  - [[SPARK-40380]](https://issues.apache.org/jira/browse/SPARK-40380): Fix constant-folding of InvokeLike to avoid non-serializable literal embedded in the plan
+  - [[SPARK-40385]](https://issues.apache.org/jira/browse/SPARK-40385): Fix interpreted path for companion object constructor
+  - [[SPARK-40389]](https://issues.apache.org/jira/browse/SPARK-40389): Decimals can't upcast as integral types if the cast can overflow
+  - [[SPARK-40468]](https://issues.apache.org/jira/browse/SPARK-40468): Fix column pruning in CSV when _corrupt_record is selected
+  - [[SPARK-40508]](https://issues.apache.org/jira/browse/SPARK-40508): Treat unknown partitioning as UnknownPartitioning
+  - [[SPARK-40535]](https://issues.apache.org/jira/browse/SPARK-40535): Fix bug the buffer of AggregatingAccumulator will not be created if the input rows is empty
+  - [[SPARK-40562]](https://issues.apache.org/jira/browse/SPARK-40562): Add `spark.sql.legacy.groupingIdWithAppendedUserGroupBy`
+  - [[SPARK-40612]](https://issues.apache.org/jira/browse/SPARK-40612): Fixing the principal used for delegation token renewal on non-YARN resource managers
+  - [[SPARK-40660]](https://issues.apache.org/jira/browse/SPARK-40660): Switch to XORShiftRandom to distribute elements
+  - [[SPARK-40703]](https://issues.apache.org/jira/browse/SPARK-40703): Introduce shuffle on SinglePartition to improve parallelism
+
+### Dependency Changes
+
+While being a maintenance release we did still upgrade some dependencies in this release they are:
+
+  - [[SPARK-40801]](https://issues.apache.org/jira/browse/SPARK-40801): Upgrade Apache Commons Text to 1.10
+  - [[SPARK-40886]](https://issues.apache.org/jira/browse/SPARK-40886): Bump Jackson Databind 2.13.4.2
+  - [[SPARK-41030]](https://issues.apache.org/jira/browse/SPARK-41030): Upgrade Apache Ivy to 2.5.1
+  - [[SPARK-41031]](https://issues.apache.org/jira/browse/SPARK-41031): Upgrade `org.tukaani:xz` to 1.9
+  - [[SPARK-41202]](https://issues.apache.org/jira/browse/SPARK-41202): Update ORC to 1.7.7
+  - [[SPARK-41686]](https://issues.apache.org/jira/browse/SPARK-41686): Upgrade Apache Ivy to 2.5.1
+  - [[SPARK-42179]](https://issues.apache.org/jira/browse/SPARK-42179): Upgrade ORC to 1.7.8
+
+
+You can consult JIRA for the [detailed changes](https://s.apache.org/spark-3.3.2).
+
+We would like to acknowledge all community members for contributing patches to this release.

--- a/site/committers.html
+++ b/site/committers.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -648,6 +648,9 @@ of the immediate bug being fixed.</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -656,9 +659,6 @@ of the immediate bug being fixed.</li>
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/community.html
+++ b/site/community.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -345,6 +345,9 @@ Add yours by emailing `dev@spark.apache.org`.
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -353,9 +356,6 @@ Add yours by emailing `dev@spark.apache.org`.
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -679,6 +679,9 @@ to ask on the <code class="language-plaintext highlighter-rouge">dev@spark.apach
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -687,9 +690,6 @@ to ask on the <code class="language-plaintext highlighter-rouge">dev@spark.apach
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -687,6 +687,9 @@ The platform-specific paths to the profiler agents are listed in the
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -695,9 +698,6 @@ The platform-specific paths to the profiler agents are listed in the
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -127,6 +127,7 @@
 <p>Setup instructions, programming guides, and other documentation are available for each stable version of Spark below:</p>
 
 <ul>
+  <li><a href="/docs/3.3.2/">Spark 3.3.2</a></li>
   <li><a href="/docs/3.3.1/">Spark 3.3.1</a></li>
   <li><a href="/docs/3.3.0/">Spark 3.3.0</a></li>
   <li><a href="/docs/3.2.3/">Spark 3.2.3</a></li>
@@ -335,6 +336,9 @@ The <a href="/research.html">research page</a> lists some of the original motiva
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -343,9 +347,6 @@ The <a href="/research.html">research page</a> lists some of the original motiva
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -186,6 +186,9 @@ before deciding to use it.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -194,9 +197,6 @@ before deciding to use it.</p>
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/error-message-guidelines.html
+++ b/site/error-message-guidelines.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -525,6 +525,9 @@ be redundant; you may skip an explicit explanation in this case.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -533,9 +536,6 @@ be redundant; you may skip an explicit explanation in this case.</p>
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/examples.html
+++ b/site/examples.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -527,6 +527,9 @@ We learn to predict the labels from feature vectors using the Logistic Regressio
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -535,9 +538,6 @@ We learn to predict the labels from feature vectors using the Logistic Regressio
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/faq.html
+++ b/site/faq.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -195,6 +195,9 @@ Please also refer to our
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -203,9 +206,6 @@ Please also refer to our
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -63,7 +63,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -240,6 +240,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -248,9 +251,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/history.html
+++ b/site/history.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -149,6 +149,9 @@ You can get involved in Apache Spark development by reading
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -157,9 +160,6 @@ You can get involved in Apache Spark development by reading
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -221,6 +221,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -229,9 +232,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -25,7 +25,7 @@ var packagesV12 = [hadoop3p3, hadoop3p3scala213, hadoop2p7, hadoopFree, sources]
 // 3.3.0+
 var packagesV13 = [hadoop3p, hadoop3pscala213, hadoop2p, hadoopFree, sources];
 
-addRelease("3.3.1", new Date("10/25/2022"), packagesV13, true);
+addRelease("3.3.2", new Date("02/17/2023"), packagesV13, true);
 addRelease("3.2.3", new Date("11/28/2022"), packagesV12, true);
 
 function append(el, contents) {

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -64,7 +64,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -133,6 +133,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -141,9 +144,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -63,7 +63,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -286,6 +286,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -294,9 +297,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/3-1-3-released.html
+++ b/site/news/3-1-3-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -123,6 +123,15 @@
   <div class="row mt-4">
     <div class="col-12 col-md-9">
       <h2 id="spark-news">Spark News</h2>
+
+<article class="hentry">
+    <header class="entry-header">
+      <h3 class="entry-title"><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a></h3>
+      <div class="entry-date">February 17, 2023</div>
+    </header>
+    <div class="entry-content"><p>We are happy to announce the availability of <a href="/releases/spark-release-3-3-2.html" title="Spark Release 3.3.2">Spark 3.3.2</a>! Visit the <a href="/releases/spark-release-3-3-2.html" title="Spark Release 3.3.2">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+</div>
+  </article>
 
 <article class="hentry">
     <header class="entry-header">
@@ -1255,6 +1264,9 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -1263,9 +1275,6 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/new-repository-service.html
+++ b/site/news/new-repository-service.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/next-official-release-spark-3.1.1.html
+++ b/site/news/next-official-release-spark-3.1.1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -151,6 +151,9 @@ are no guarantees on using it such as binary compatibility.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -159,9 +162,6 @@ are no guarantees on using it such as binary compatibility.</p>
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -145,6 +145,9 @@ online to attend in person. We hope you enjoy the event!</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -153,9 +156,6 @@ online to attend in person. We hope you enjoy the event!</p>
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/plan-for-dropping-python-2-support.html
+++ b/site/news/plan-for-dropping-python-2-support.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -155,6 +155,9 @@ Python 2. However, after Python 2 EOL, we might not take patches that are specif
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -163,9 +166,6 @@ Python 2. However, after Python 2 EOL, we might not take patches that are specif
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/sigmod-system-award.html
+++ b/site/news/sigmod-system-award.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -150,6 +150,9 @@ the whole community earned together.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -158,9 +161,6 @@ the whole community earned together.</p>
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -146,6 +146,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -154,9 +157,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -145,6 +145,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -153,9 +156,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -144,6 +144,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -152,9 +155,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -142,6 +142,9 @@ This release expands Spark&#8217;s standard libraries, introducing a new SQL pac
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -150,9 +153,6 @@ This release expands Spark&#8217;s standard libraries, introducing a new SQL pac
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -145,6 +145,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -153,9 +156,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-3-released.html
+++ b/site/news/spark-2-1-3-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-2-released.html
+++ b/site/news/spark-2-2-2-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-1-released.html
+++ b/site/news/spark-2-3-1-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-2-released.html
+++ b/site/news/spark-2-3-2-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-3-released.html
+++ b/site/news/spark-2-3-3-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-4-released.html
+++ b/site/news/spark-2-3-4-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-0-released.html
+++ b/site/news/spark-2-4-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-1-released.html
+++ b/site/news/spark-2-4-1-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-3-released.html
+++ b/site/news/spark-2-4-3-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-4-released.html
+++ b/site/news/spark-2-4-4-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-5-released.html
+++ b/site/news/spark-2-4-5-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-6.html
+++ b/site/news/spark-2-4-6.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-7-released.html
+++ b/site/news/spark-2-4-7-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-8-released.html
+++ b/site/news/spark-2-4-8-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-0-released.html
+++ b/site/news/spark-3-0-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-1-released.html
+++ b/site/news/spark-3-0-1-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-2-released.html
+++ b/site/news/spark-3-0-2-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-3-released.html
+++ b/site/news/spark-3-0-3-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-1-released.html
+++ b/site/news/spark-3-1-1-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-2-released.html
+++ b/site/news/spark-3-1-2-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-0-released.html
+++ b/site/news/spark-3-2-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-1-released.html
+++ b/site/news/spark-3-2-1-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-2-released.html
+++ b/site/news/spark-3-2-2-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-3-released.html
+++ b/site/news/spark-3-2-3-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-0-released.html
+++ b/site/news/spark-3-3-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-1-released.html
+++ b/site/news/spark-3-3-1-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-2-released.html
+++ b/site/news/spark-3-3-2-released.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark 2.4.2 released | Apache Spark
+     Spark 3.3.2 released | Apache Spark
     
   </title>
 
@@ -122,10 +122,10 @@
 <div class="container">
   <div class="row mt-4">
     <div class="col-12 col-md-9">
-      <h2>Spark 2.4.2 released</h2>
+      <h2>Spark 3.3.2 released</h2>
 
 
-<p>We are happy to announce the availability of <a href="/releases/spark-release-2-4-2.html" title="Spark Release 2.4.2">Spark 2.4.2</a>! Visit the <a href="/releases/spark-release-2-4-2.html" title="Spark Release 2.4.2">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+<p>We are happy to announce the availability of <a href="/releases/spark-release-3-3-2.html" title="Spark Release 3.3.2">Spark 3.3.2</a>! Visit the <a href="/releases/spark-release-3-3-2.html" title="Spark Release 3.3.2">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
 
 
 <p>

--- a/site/news/spark-3.0.0-preview.html
+++ b/site/news/spark-3.0.0-preview.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview2.html
+++ b/site/news/spark-3.0.0-preview2.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-apr-2019-agenda-posted.html
+++ b/site/news/spark-ai-summit-apr-2019-agenda-posted.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-june-2020-agenda-posted.html
+++ b/site/news/spark-ai-summit-june-2020-agenda-posted.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -149,6 +149,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -157,9 +160,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -150,6 +150,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -158,9 +161,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-release-2-2-3.html
+++ b/site/news/spark-release-2-2-3.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -145,6 +145,9 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -153,9 +156,6 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -147,6 +147,9 @@ about the latest happenings in Spark.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -155,9 +158,6 @@ about the latest happenings in Spark.</p>
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2015.html
+++ b/site/news/spark-summit-east-agenda-posted-2015.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2016.html
+++ b/site/news/spark-summit-east-agenda-posted-2016.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-oct-2018-agenda-posted.html
+++ b/site/news/spark-summit-oct-2018-agenda-posted.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -144,6 +144,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -152,9 +155,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -146,6 +146,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -154,9 +157,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -148,6 +148,9 @@ on Spark.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -156,9 +159,6 @@ on Spark.</p>
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -149,6 +149,9 @@ online to attend in person. Otherwise, the Summit will offer a free live video s
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -157,9 +160,6 @@ online to attend in person. Otherwise, the Summit will offer a free live video s
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -489,6 +489,9 @@ to process islands identified from a search robor</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -497,9 +500,6 @@ to process islands identified from a search robor</li>
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -521,6 +521,9 @@ and then send an e-mail to the mailing list. To create an announcement, create a
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -529,9 +532,6 @@ and then send an e-mail to the mailing list. To create an announcement, create a
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -190,6 +190,9 @@ squares.saveAsSequenceFile(<span class="string">"hdfs://..."</span>)
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -198,9 +201,6 @@ squares.saveAsSequenceFile(<span class="string">"hdfs://..."</span>)
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -162,6 +162,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -170,9 +173,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -216,6 +216,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -224,9 +227,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -238,6 +238,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -246,9 +249,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -180,6 +180,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -188,9 +191,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -269,6 +269,9 @@ We’d especially like to thank Patrick Wendell for acting as the release manage
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -277,9 +280,6 @@ We’d especially like to thank Patrick Wendell for acting as the release manage
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -233,6 +233,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -241,9 +244,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -327,6 +327,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -335,9 +338,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -245,6 +245,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -253,9 +256,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -218,6 +218,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -226,9 +229,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -311,6 +311,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -319,9 +322,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -269,6 +269,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -277,9 +280,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -226,6 +226,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -234,9 +237,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -362,6 +362,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -370,9 +373,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -248,6 +248,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -256,9 +259,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -376,6 +376,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -384,9 +387,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -248,6 +248,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -256,9 +259,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -208,6 +208,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -216,9 +219,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -353,6 +353,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -361,9 +364,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -240,6 +240,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -248,9 +251,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -467,6 +467,9 @@ Python coverage. MLlib also adds several new algorithms.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -475,9 +478,6 @@ Python coverage. MLlib also adds several new algorithms.</p>
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -272,6 +272,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -280,9 +283,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -405,6 +405,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -413,9 +416,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -144,6 +144,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -152,9 +155,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -281,6 +281,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -289,9 +292,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -377,6 +377,9 @@ yzhou2001, zhonghaihua, zhuol, zlpmichelle, Örjan Lundberg, Łukasz Gieroń</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -385,9 +388,6 @@ yzhou2001, zhonghaihua, zhuol, zlpmichelle, Örjan Lundberg, Łukasz Gieroń</p>
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -289,6 +289,9 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Roberts, Adrian Petrescu, Ahmed Mahran
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -297,9 +300,6 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Roberts, Adrian Petrescu, Ahmed Mahran
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-3.html
+++ b/site/releases/spark-release-2-1-3.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -355,6 +355,9 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Budde, Adam Roberts, Adrian Ionescu, A
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -363,9 +366,6 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Budde, Adam Roberts, Adrian Ionescu, A
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -153,6 +153,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -161,9 +164,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-2.html
+++ b/site/releases/spark-release-2-2-2.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-3.html
+++ b/site/releases/spark-release-2-2-3.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -365,6 +365,9 @@ ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Albe
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -373,9 +376,6 @@ ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Albe
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-1.html
+++ b/site/releases/spark-release-2-3-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -153,6 +153,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -161,9 +164,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-2.html
+++ b/site/releases/spark-release-2-3-2.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -153,6 +153,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -161,9 +164,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-3.html
+++ b/site/releases/spark-release-2-3-3.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-4.html
+++ b/site/releases/spark-release-2-3-4.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-0.html
+++ b/site/releases/spark-release-2-4-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -371,6 +371,9 @@ Achuth17, Adam Bradbury, Adamyuanyuan, Adelbert Chang, Ala Luszczak, Aleksandr K
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -379,9 +382,6 @@ Achuth17, Adam Bradbury, Adamyuanyuan, Adelbert Chang, Ala Luszczak, Aleksandr K
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-1.html
+++ b/site/releases/spark-release-2-4-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -181,6 +181,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -189,9 +192,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-2.html
+++ b/site/releases/spark-release-2-4-2.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -153,6 +153,9 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -161,9 +164,6 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-3.html
+++ b/site/releases/spark-release-2-4-3.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -151,6 +151,9 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -159,9 +162,6 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-4.html
+++ b/site/releases/spark-release-2-4-4.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -157,6 +157,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -165,9 +168,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-5.html
+++ b/site/releases/spark-release-2-4-5.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-6.html
+++ b/site/releases/spark-release-2-4-6.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -179,6 +179,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -187,9 +190,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-7.html
+++ b/site/releases/spark-release-2-4-7.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -221,6 +221,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -229,9 +232,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-8.html
+++ b/site/releases/spark-release-2-4-8.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -222,6 +222,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -230,9 +233,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-0.html
+++ b/site/releases/spark-release-3-0-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -531,6 +531,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -539,9 +542,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-1.html
+++ b/site/releases/spark-release-3-0-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -180,6 +180,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -188,9 +191,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-2.html
+++ b/site/releases/spark-release-3-0-2.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -190,6 +190,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -198,9 +201,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-3.html
+++ b/site/releases/spark-release-3-0-3.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -207,6 +207,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -215,9 +218,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-1.html
+++ b/site/releases/spark-release-3-1-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -568,6 +568,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -576,9 +579,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-2.html
+++ b/site/releases/spark-release-3-1-2.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -255,6 +255,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -263,9 +266,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-3.html
+++ b/site/releases/spark-release-3-1-3.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-0.html
+++ b/site/releases/spark-release-3-2-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -541,6 +541,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -549,9 +552,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-1.html
+++ b/site/releases/spark-release-3-2-1.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-2.html
+++ b/site/releases/spark-release-3-2-2.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -249,6 +249,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -257,9 +260,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-3.html
+++ b/site/releases/spark-release-3-2-3.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -222,6 +222,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -230,9 +233,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-0.html
+++ b/site/releases/spark-release-3-3-0.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -721,6 +721,9 @@ Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</sp
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -729,9 +732,6 @@ Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</sp
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-2.html
+++ b/site/releases/spark-release-3-3-2.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark Release 3.3.1 | Apache Spark
+     Spark Release 3.3.2 | Apache Spark
     
   </title>
 
@@ -122,14 +122,89 @@
 <div class="container">
   <div class="row mt-4">
     <div class="col-12 col-md-9">
-      <h2>Spark Release 3.3.1</h2>
+      <h2>Spark Release 3.3.2</h2>
 
 
-<p>Spark 3.3.1 is a maintenance release containing stability fixes. This release is based on the branch-3.3 maintenance branch of Spark. We strongly recommend all 3.3 users to upgrade to this stable release.</p>
+<p>Spark 3.3.2 is a maintenance release containing stability fixes. This release is based on the branch-3.3 maintenance branch of Spark. We strongly recommend all 3.3 users to upgrade to this stable release.</p>
 
 <h3 id="notable-changes">Notable changes</h3>
 
 <ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38697">[SPARK-38697]</a>: Extend SparkSessionExtensions to inject rules into AQE Optimizer</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40872">[SPARK-40872]</a>: Fallback to original shuffle block when a push-merged shuffle chunk is zero-size</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41388">[SPARK-41388]</a>: getReusablePVCs should ignore recently created PVCs in the previous batch</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42071">[SPARK-42071]</a>: Register scala.math.Ordering$Reverse to KyroSerializer</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-32380">[SPARK-32380]</a>: sparksql cannot access hive table while data in hbase</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39404">[SPARK-39404]</a>: Unable to query _metadata in streaming if getBatch returns multiple logical nodes in the DataFrame</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40493">[SPARK-40493]</a>: Revert &#8220;[SPARK-33861][SQL] Simplify conditional in predicate&#8221;</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40588">[SPARK-40588]</a>: Sorting issue with partitioned-writing and AQE turned on</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40817">[SPARK-40817]</a>: Remote spark.jars URIs ignored for Spark on Kubernetes in cluster mode</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40819">[SPARK-40819]</a>: Parquet INT64 (TIMESTAMP(NANOS,true)) now throwing Illegal Parquet type instead of automatically converting to LongType</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40829">[SPARK-40829]</a>: STORED AS serde in CREATE TABLE LIKE view does not work</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40851">[SPARK-40851]</a>: TimestampFormatter behavior changed when using the latest Java 8/11/17</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40869">[SPARK-40869]</a>: KubernetesConf.getResourceNamePrefix creates invalid name prefixes</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40874">[SPARK-40874]</a>: Fix broadcasts in Python UDFs when encryption is enabled</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40902">[SPARK-40902]</a>: Quick submission of drivers in tests to mesos scheduler results in dropping drivers</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40918">[SPARK-40918]</a>: Mismatch between ParquetFileFormat and FileSourceScanExec in # columns for WSCG.isTooManyFields when using _metadata</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40924">[SPARK-40924]</a>: Unhex function works incorrectly when input has uneven number of symbols</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40932">[SPARK-40932]</a>: Barrier: messages for allGather will be overridden by the following barrier APIs</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40963">[SPARK-40963]</a>: ExtractGenerator sets incorrect nullability in new Project</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40987">[SPARK-40987]</a>: Avoid creating a directory when deleting a block, causing DAGScheduler to not work</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41035">[SPARK-41035]</a>: Incorrect results or NPE when a literal is reused across distinct aggregations</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41118">[SPARK-41118]</a>: to_number/try_to_number throws NullPointerException when format is null</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41144">[SPARK-41144]</a>: UnresolvedHint should not cause query failure</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41151">[SPARK-41151]</a>: Keep built-in file _metadata column nullable value consistent</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41154">[SPARK-41154]</a>: Incorrect relation caching for queries with time travel spec</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41162">[SPARK-41162]</a>: Anti-join must not be pushed below aggregation with ambiguous predicates</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41187">[SPARK-41187]</a>: [Core] LiveExecutor MemoryLeak in AppStatusListener when ExecutorLost happen</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41188">[SPARK-41188]</a>: Set executorEnv OMP_NUM_THREADS to be spark.task.cpus by default for spark executor JVM processes</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41254">[SPARK-41254]</a>: YarnAllocator.rpIdToYarnResource map is not properly updated</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41327">[SPARK-41327]</a>: Fix SparkStatusTracker.getExecutorInfos by switch On/OffHeapStorageMemory info</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41339">[SPARK-41339]</a>: RocksDB state store WriteBatch doesn&#8217;t clean up native memory</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41350">[SPARK-41350]</a>: allow simple name access of using join hidden columns after subquery alias</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41365">[SPARK-41365]</a>: Stages UI page fails to load for proxy in some yarn versions</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41375">[SPARK-41375]</a>: Avoid empty latest KafkaSourceOffset:</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41376">[SPARK-41376]</a>: Executor netty direct memory check should respect spark.shuffle.io.preferDirectBufs</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41379">[SPARK-41379]</a>: Inconsistency of spark session in DataFrame in user function for foreachBatch sink in PySpark</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41385">[SPARK-41385]</a>: Replace deprecated <code class="language-plaintext highlighter-rouge">.newInstance()</code> in K8s module</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41395">[SPARK-41395]</a>: InterpretedMutableProjection can corrupt unsafe buffer when used with decimal data</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41448">[SPARK-41448]</a>: Make consistent MR job IDs in FileBatchWriter and FileFormatWriter</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41458">[SPARK-41458]</a>: Correctly transform the SPI services for Yarn Shuffle Service</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41468">[SPARK-41468]</a>: Fix PlanExpression handling in EquivalentExpressions</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41522">[SPARK-41522]</a>: GA dependencies test faild</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41535">[SPARK-41535]</a>: InterpretedUnsafeProjection and InterpretedMutableProjection can corrupt unsafe buffer when used with calendar interval data</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41554">[SPARK-41554]</a>: Decimal.changePrecision produces ArrayIndexOutOfBoundsException</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41668">[SPARK-41668]</a>: DECODE function returns wrong results when passed NULL</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41732">[SPARK-41732]</a>: Session window: analysis rule &#8220;SessionWindowing&#8221; does not apply tree-pattern based pruning</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41989">[SPARK-41989]</a>: PYARROW_IGNORE_TIMEZONE warning can break application logging setup</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42084">[SPARK-42084]</a>: Avoid leaking the qualified-access-only restriction</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42090">[SPARK-42090]</a>: Introduce sasl retry count in RetryingBlockTransferor</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42134">[SPARK-42134]</a>: Fix getPartitionFiltersAndDataFilters() to handle filters without referenced attributes</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42157">[SPARK-42157]</a>: <code class="language-plaintext highlighter-rouge">spark.scheduler.mode=FAIR</code> should provide FAIR scheduler</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42176">[SPARK-42176]</a>: Cast boolean to timestamp fails with ClassCastException</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42188">[SPARK-42188]</a>: Force SBT protobuf version to match Maven on branch 3.2 and 3.3</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42201">[SPARK-42201]</a>: <code class="language-plaintext highlighter-rouge">build/sbt</code> should allow SBT_OPTS to override JVM memory setting</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42222">[SPARK-42222]</a>: Spark 3.3 Backport: SPARK-41344 Reading V2 datasource masks underlying error</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42259">[SPARK-42259]</a>: ResolveGroupingAnalytics should take care of Python UDAF</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42344">[SPARK-42344]</a>: The default size of the CONFIG_MAP_MAXSIZE should not be greater than 1048576</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42346">[SPARK-42346]</a>: distinct(count colname) with UNION ALL causes query analyzer bug</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38277">[SPARK-38277]</a>: Clear write batch after RocksDB state store&#8217;s commit</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40913">[SPARK-40913]</a>: Pin <code class="language-plaintext highlighter-rouge">pytest==7.1.3</code></li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41089">[SPARK-41089]</a>: Relocate Netty native arm64 libs</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41360">[SPARK-41360]</a>: Avoid BlockManager re-registration if the executor has been lost</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41476">[SPARK-41476]</a>: Prevent <code class="language-plaintext highlighter-rouge">README.md</code> from triggering CIs</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41541">[SPARK-41541]</a>: Fix wrong child call in SQLShuffleWriteMetricsReporter.decRecordsWritten()</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41962">[SPARK-41962]</a>: Update the import order of scala package in class SpecificParquetRecordReaderBase</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42230">[SPARK-42230]</a>: Improve <code class="language-plaintext highlighter-rouge">lint</code> job by skipping PySpark and SparkR docs if unchanged</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41863">[SPARK-41863]</a>: Skip <code class="language-plaintext highlighter-rouge">flake8</code> tests if the command is not available</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41864">[SPARK-41864]</a>: Fix mypy linter errors</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42110">[SPARK-42110]</a>: Reduce the number of repetition in ParquetDeltaEncodingSuite.<code class="language-plaintext highlighter-rouge">random data test</code></li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41415">[SPARK-41415]</a>: SASL Request Retries</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41538">[SPARK-41538]</a>: Metadata column should be appended at the end of project list</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40983">[SPARK-40983]</a>: Remove Hadoop requirements for zstd mention in Parquet compression codec</li>
+  <li>
+    <p><a href="https://issues.apache.org/jira/browse/SPARK-41185">[SPARK-41185]</a>: Remove ARM limitation for YuniKorn from docs</p>
+  </li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-35542">[SPARK-35542]</a>: Fix: Bucketizer created for multiple columns with parameters splitsArray, inputCols and outputCols can not be loaded after saving it</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-36057">[SPARK-36057]</a>: SPIP: Support Customized Kubernetes Schedulers</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-38034">[SPARK-38034]</a>: Optimize TransposeWindow rule</li>
@@ -205,17 +280,19 @@
 
 <h3 id="dependency-changes">Dependency Changes</h3>
 
-<p>While being a maintence release we did still upgrade some dependencies in this release they are:</p>
+<p>While being a maintenance release we did still upgrade some dependencies in this release they are:</p>
 
 <ul>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39947">[SPARK-39947]</a>: Upgrade Jersey to 2.36</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40134">[SPARK-40134]</a>: Update ORC to 1.7.6</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40326">[SPARK-40326]</a>: Upgrade fasterxml.jackson.version to 2.13.4</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-39725">[SPARK-39725]</a>: Upgrade jetty to 9.4.48.v20220622</li>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-40782">[SPARK-40782]</a>: Upgrade jackson-databind to 2.13.4.1</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40801">[SPARK-40801]</a>: Upgrade Apache Commons Text to 1.10</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40886">[SPARK-40886]</a>: Bump Jackson Databind 2.13.4.2</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41030">[SPARK-41030]</a>: Upgrade Apache Ivy to 2.5.1</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41031">[SPARK-41031]</a>: Upgrade <code class="language-plaintext highlighter-rouge">org.tukaani:xz</code> to 1.9</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41202">[SPARK-41202]</a>: Update ORC to 1.7.7</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41686">[SPARK-41686]</a>: Upgrade Apache Ivy to 2.5.1</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42179">[SPARK-42179]</a>: Upgrade ORC to 1.7.8</li>
 </ul>
 
-<p>You can consult JIRA for the <a href="https://s.apache.org/spark-3.3.1">detailed changes</a>.</p>
+<p>You can consult JIRA for the <a href="https://s.apache.org/spark-3.3.2">detailed changes</a>.</p>
 
 <p>We would like to acknowledge all community members for contributing patches to this release.</p>
 

--- a/site/research.html
+++ b/site/research.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -187,6 +187,9 @@ Spark offers an abstraction called <a href="http://people.csail.mit.edu/matei/pa
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -195,9 +198,6 @@ Spark offers an abstraction called <a href="http://people.csail.mit.edu/matei/pa
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -149,6 +149,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -157,9 +160,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -149,6 +149,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -157,9 +160,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/security.html
+++ b/site/security.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -612,6 +612,9 @@ PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -620,9 +623,6 @@ PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -144,6 +144,14 @@
 </url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
+  <loc>https://spark.apache.org/releases/spark-release-3-3-2.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/news/spark-3-3-2-released.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/releases/spark-release-3-2-3.html</loc>
   <changefreq>weekly</changefreq>
 </url>
@@ -973,10 +981,6 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/streaming/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
   <loc>https://spark.apache.org/news/</loc>
   <changefreq>weekly</changefreq>
 </url>
@@ -986,6 +990,10 @@
 </url>
 <url>
   <loc>https://spark.apache.org/sql/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/streaming/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -63,7 +63,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -285,6 +285,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -293,9 +296,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -63,7 +63,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -227,6 +227,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -235,9 +238,6 @@
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -231,6 +231,9 @@ transforming, and analyzing genomic data using Apache Spark</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -239,9 +242,6 @@ transforming, and analyzing genomic data using Apache Spark</li>
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -189,6 +189,9 @@ If you have any questions about the Apache trademark policy, please email
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -197,9 +200,6 @@ If you have any questions about the Apache trademark policy, please email
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -61,7 +61,7 @@
           Documentation
         </a>
         <ul class="dropdown-menu" aria-labelledby="documentation">
-          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.1)</a></li>
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release (Spark 3.3.2)</a></li>
           <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
           <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
         </ul>
@@ -291,6 +291,9 @@ For example, 2.4.0 was released in November 2nd 2018 and had been maintained for
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
+            <span class="small">(Feb 17, 2023)</span></li>
+          
           <li><a href="/news/spark-3-2-3-released.html">Spark 3.2.3 released</a>
             <span class="small">(Nov 28, 2022)</span></li>
           
@@ -299,9 +302,6 @@ For example, 2.4.0 was released in November 2nd 2018 and had been maintained for
           
           <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
             <span class="small">(Jul 17, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-3-0-released.html">Spark 3.3.0 released</a>
-            <span class="small">(Jun 16, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>


### PR DESCRIPTION
* Apache Download: https://downloads.apache.org/spark/spark-3.3.2/
* Apache Archieve: https://archive.apache.org/dist/spark/spark-3.3.2/
* Maven Central:
    * https://repo1.maven.org/maven2/org/apache/spark/spark-core_2.12/3.3.2/ 
    * https://repo1.maven.org/maven2/org/apache/spark/spark-core_2.13/3.3.2/
* PySpark: https://pypi.org/project/pyspark/3.3.2/