### PR TITLE
Add 3.2.4 announcement news, release note and download link

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -15,6 +15,7 @@ navigation:
   <li><a href="{{site.baseurl}}/docs/3.3.2/">Spark 3.3.2</a></li>
   <li><a href="{{site.baseurl}}/docs/3.3.1/">Spark 3.3.1</a></li>
   <li><a href="{{site.baseurl}}/docs/3.3.0/">Spark 3.3.0</a></li>
+  <li><a href="{{site.baseurl}}/docs/3.2.4/">Spark 3.2.4</a></li>
   <li><a href="{{site.baseurl}}/docs/3.2.3/">Spark 3.2.3</a></li>
   <li><a href="{{site.baseurl}}/docs/3.2.2/">Spark 3.2.2</a></li>
   <li><a href="{{site.baseurl}}/docs/3.2.1/">Spark 3.2.1</a></li>

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -26,7 +26,7 @@ var packagesV12 = [hadoop3p3, hadoop3p3scala213, hadoop2p7, hadoopFree, sources]
 var packagesV13 = [hadoop3p, hadoop3pscala213, hadoop2p, hadoopFree, sources];
 
 addRelease("3.3.2", new Date("02/17/2023"), packagesV13, true);
-addRelease("3.2.3", new Date("11/28/2022"), packagesV12, true);
+addRelease("3.2.4", new Date("04/13/2023"), packagesV12, true);
 
 function append(el, contents) {
   el.innerHTML += contents;

--- a/news/_posts/2023-04-13-spark-3-2-4-released.md
+++ b/news/_posts/2023-04-13-spark-3-2-4-released.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: Spark 3.2.4 released
+categories:
+- News
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+We are happy to announce the availability of <a href="{{site.baseurl}}/releases/spark-release-3-2-4.html" title="Spark Release 3.2.4">Spark 3.2.4</a>! Visit the <a href="{{site.baseurl}}/releases/spark-release-3-2-4.html" title="Spark Release 3.2.4">release notes</a> to read about the new features, or <a href="{{site.baseurl}}/downloads.html">download</a> the release today.

--- a/releases/_posts/2023-04-13-spark-release-3-2-4.md
+++ b/releases/_posts/2023-04-13-spark-release-3-2-4.md
@@ -1,0 +1,56 @@
+---
+layout: post
+title: Spark Release 3.2.4
+categories: []
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+
+Spark 3.2.4 is a maintenance release containing stability fixes. This release is based on the branch-3.2 maintenance branch of Spark. We strongly recommend all 3.2 users to upgrade to this stable release.
+
+### Notable changes
+
+  - [[SPARK-38173]](https://issues.apache.org/jira/browse/SPARK-38173): Quoted column cannot be recognized correctly when quotedRegexColumnNames is true
+
+  - [[SPARK-39399]](https://issues.apache.org/jira/browse/SPARK-39399): proxy-user not working for Spark on k8s in cluster deploy mode
+  - [[SPARK-40817]](https://issues.apache.org/jira/browse/SPARK-40817): Remote spark.jars URIs ignored for Spark on Kubernetes in cluster mode
+  - [[SPARK-40819]](https://issues.apache.org/jira/browse/SPARK-40819): Parquet INT64 (TIMESTAMP(NANOS,true)) now throwing Illegal Parquet type instead of automatically converting to LongType
+  - [[SPARK-41162]](https://issues.apache.org/jira/browse/SPARK-41162): Anti-join must not be pushed below aggregation with ambiguous predicates
+  - [[SPARK-41254]](https://issues.apache.org/jira/browse/SPARK-41254): YarnAllocator.rpIdToYarnResource map is not properly updated
+  - [[SPARK-41360]](https://issues.apache.org/jira/browse/SPARK-41360): Avoid BlockManager re-registration if the executor has been lost
+  - [[SPARK-41376]](https://issues.apache.org/jira/browse/SPARK-41376): Executor netty direct memory check should respect spark.shuffle.io.preferDirectBufs
+  - [[SPARK-41388]](https://issues.apache.org/jira/browse/SPARK-41388): getReusablePVCs should ignore recently created PVCs in the previous batch
+  - [[SPARK-41415]](https://issues.apache.org/jira/browse/SPARK-41415): SASL Request Retries
+  - [[SPARK-41554]](https://issues.apache.org/jira/browse/SPARK-41554): Decimal.changePrecision produces ArrayIndexOutOfBoundsException
+  - [[SPARK-41732]](https://issues.apache.org/jira/browse/SPARK-41732): Session window: analysis rule "SessionWindowing" does not apply tree-pattern based pruning
+  - [[SPARK-41952]](https://issues.apache.org/jira/browse/SPARK-41952): Upgrade Parquet to fix off-heap memory leaks in Zstd codec
+  - [[SPARK-41989]](https://issues.apache.org/jira/browse/SPARK-41989): PYARROW_IGNORE_TIMEZONE warning can break application logging setup
+  - [[SPARK-42071]](https://issues.apache.org/jira/browse/SPARK-42071): Register scala.math.Ordering$Reverse to KyroSerializer
+  - [[SPARK-42090]](https://issues.apache.org/jira/browse/SPARK-42090): Introduce sasl retry count in RetryingBlockTransferor
+  - [[SPARK-42157]](https://issues.apache.org/jira/browse/SPARK-42157): `spark.scheduler.mode=FAIR` should provide FAIR scheduler
+  - [[SPARK-42168]](https://issues.apache.org/jira/browse/SPARK-42168): CoGroup with window function returns incorrect result when partition keys differ in order
+  - [[SPARK-42259]](https://issues.apache.org/jira/browse/SPARK-42259): ResolveGroupingAnalytics should take care of Python UDAF
+  - [[SPARK-42462]](https://issues.apache.org/jira/browse/SPARK-42462): Prevent `docker-image-tool.sh` from publishing OCI manifests
+  - [[SPARK-42478]](https://issues.apache.org/jira/browse/SPARK-42478): Make a serializable jobTrackerId instead of a non-serializable JobID in FileWriterFactory
+  - [[SPARK-42596]](https://issues.apache.org/jira/browse/SPARK-42596): OMP_NUM_THREADS not set to number of executor cores by default
+  - [[SPARK-42697]](https://issues.apache.org/jira/browse/SPARK-42697): /api/v1/applications return 0 for duration
+  - [[SPARK-42747]](https://issues.apache.org/jira/browse/SPARK-42747): Fix incorrect internal status of LoR and AFT
+  - [[SPARK-42785]](https://issues.apache.org/jira/browse/SPARK-42785): When spark submit without --deploy-mode, will face NPE in Kubernetes Case
+  - [[SPARK-42906]](https://issues.apache.org/jira/browse/SPARK-42906): Replace a starting digit with `x` in resource name prefix
+  - [[SPARK-42967]](https://issues.apache.org/jira/browse/SPARK-42967): Fix SparkListenerTaskStart.stageAttemptId when a task is started after the stage is cancelled
+  - [[SPARK-43004]](https://issues.apache.org/jira/browse/SPARK-43004): vendor==vendor typo in ResourceRequest.equals()
+
+### Dependency Changes
+
+While being a maintence release we did still upgrade some dependencies in this release they are:
+
+  - [[SPARK-41030]](https://issues.apache.org/jira/browse/SPARK-41030): Upgrade Apache Ivy to 2.5.1
+
+You can consult JIRA for the [detailed changes](https://s.apache.org/spark-3.2.4).
+
+We would like to acknowledge all community members for contributing patches to this release.

--- a/releases/_posts/2023-04-13-spark-release-3-2-4.md
+++ b/releases/_posts/2023-04-13-spark-release-3-2-4.md
@@ -16,7 +16,6 @@ Spark 3.2.4 is a maintenance release containing stability fixes. This release is
 ### Notable changes
 
   - [[SPARK-38173]](https://issues.apache.org/jira/browse/SPARK-38173): Quoted column cannot be recognized correctly when quotedRegexColumnNames is true
-
   - [[SPARK-39399]](https://issues.apache.org/jira/browse/SPARK-39399): proxy-user not working for Spark on k8s in cluster deploy mode
   - [[SPARK-40817]](https://issues.apache.org/jira/browse/SPARK-40817): Remote spark.jars URIs ignored for Spark on Kubernetes in cluster mode
   - [[SPARK-40819]](https://issues.apache.org/jira/browse/SPARK-40819): Parquet INT64 (TIMESTAMP(NANOS,true)) now throwing Illegal Parquet type instead of automatically converting to LongType

--- a/releases/_posts/2023-04-13-spark-release-3-2-4.md
+++ b/releases/_posts/2023-04-13-spark-release-3-2-4.md
@@ -46,7 +46,7 @@ Spark 3.2.4 is a maintenance release containing stability fixes. This release is
 
 ### Dependency Changes
 
-While being a maintence release we did still upgrade some dependencies in this release they are:
+While being a maintenance release we did still upgrade some dependencies in this release they are:
 
   - [[SPARK-41030]](https://issues.apache.org/jira/browse/SPARK-41030): Upgrade Apache Ivy to 2.5.1
 

--- a/site/committers.html
+++ b/site/committers.html
@@ -648,6 +648,9 @@ of the immediate bug being fixed.</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -656,9 +659,6 @@ of the immediate bug being fixed.</li>
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/community.html
+++ b/site/community.html
@@ -345,6 +345,9 @@ Add yours by emailing `dev@spark.apache.org`.
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -353,9 +356,6 @@ Add yours by emailing `dev@spark.apache.org`.
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -658,6 +658,9 @@ to ask on the <code class="language-plaintext highlighter-rouge">dev@spark.apach
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -666,9 +669,6 @@ to ask on the <code class="language-plaintext highlighter-rouge">dev@spark.apach
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -663,6 +663,9 @@ The platform-specific paths to the profiler agents are listed in the
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -671,9 +674,6 @@ The platform-specific paths to the profiler agents are listed in the
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -130,6 +130,7 @@
   <li><a href="/docs/3.3.2/">Spark 3.3.2</a></li>
   <li><a href="/docs/3.3.1/">Spark 3.3.1</a></li>
   <li><a href="/docs/3.3.0/">Spark 3.3.0</a></li>
+  <li><a href="/docs/3.2.4/">Spark 3.2.4</a></li>
   <li><a href="/docs/3.2.3/">Spark 3.2.3</a></li>
   <li><a href="/docs/3.2.2/">Spark 3.2.2</a></li>
   <li><a href="/docs/3.2.1/">Spark 3.2.1</a></li>
@@ -336,6 +337,9 @@ The <a href="/research.html">research page</a> lists some of the original motiva
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -344,9 +348,6 @@ The <a href="/research.html">research page</a> lists some of the original motiva
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -186,6 +186,9 @@ before deciding to use it.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -194,9 +197,6 @@ before deciding to use it.</p>
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/error-message-guidelines.html
+++ b/site/error-message-guidelines.html
@@ -525,6 +525,9 @@ be redundant; you may skip an explicit explanation in this case.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -533,9 +536,6 @@ be redundant; you may skip an explicit explanation in this case.</p>
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/examples.html
+++ b/site/examples.html
@@ -527,6 +527,9 @@ We learn to predict the labels from feature vectors using the Logistic Regressio
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -535,9 +538,6 @@ We learn to predict the labels from feature vectors using the Logistic Regressio
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/faq.html
+++ b/site/faq.html
@@ -195,6 +195,9 @@ Please also refer to our
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -203,9 +206,6 @@ Please also refer to our
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -240,6 +240,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -248,9 +251,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/history.html
+++ b/site/history.html
@@ -149,6 +149,9 @@ You can get involved in Apache Spark development by reading
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -157,9 +160,6 @@ You can get involved in Apache Spark development by reading
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -221,6 +221,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -229,9 +232,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -26,7 +26,7 @@ var packagesV12 = [hadoop3p3, hadoop3p3scala213, hadoop2p7, hadoopFree, sources]
 var packagesV13 = [hadoop3p, hadoop3pscala213, hadoop2p, hadoopFree, sources];
 
 addRelease("3.3.2", new Date("02/17/2023"), packagesV13, true);
-addRelease("3.2.3", new Date("11/28/2022"), packagesV12, true);
+addRelease("3.2.4", new Date("04/13/2023"), packagesV12, true);
 
 function append(el, contents) {
   el.innerHTML += contents;

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -133,6 +133,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -141,9 +144,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -286,6 +286,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -294,9 +297,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/3-1-3-released.html
+++ b/site/news/3-1-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -126,6 +126,15 @@
 
 <article class="hentry">
     <header class="entry-header">
+      <h3 class="entry-title"><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a></h3>
+      <div class="entry-date">April 13, 2023</div>
+    </header>
+    <div class="entry-content"><p>We are happy to announce the availability of <a href="/releases/spark-release-3-2-4.html" title="Spark Release 3.2.4">Spark 3.2.4</a>! Visit the <a href="/releases/spark-release-3-2-4.html" title="Spark Release 3.2.4">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+</div>
+  </article>
+
+<article class="hentry">
+    <header class="entry-header">
       <h3 class="entry-title"><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a></h3>
       <div class="entry-date">February 17, 2023</div>
     </header>
@@ -1264,6 +1273,9 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -1272,9 +1284,6 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/new-repository-service.html
+++ b/site/news/new-repository-service.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/next-official-release-spark-3.1.1.html
+++ b/site/news/next-official-release-spark-3.1.1.html
@@ -151,6 +151,9 @@ are no guarantees on using it such as binary compatibility.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -159,9 +162,6 @@ are no guarantees on using it such as binary compatibility.</p>
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -145,6 +145,9 @@ online to attend in person. We hope you enjoy the event!</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -153,9 +156,6 @@ online to attend in person. We hope you enjoy the event!</p>
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/plan-for-dropping-python-2-support.html
+++ b/site/news/plan-for-dropping-python-2-support.html
@@ -155,6 +155,9 @@ Python 2. However, after Python 2 EOL, we might not take patches that are specif
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -163,9 +166,6 @@ Python 2. However, after Python 2 EOL, we might not take patches that are specif
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/sigmod-system-award.html
+++ b/site/news/sigmod-system-award.html
@@ -150,6 +150,9 @@ the whole community earned together.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -158,9 +161,6 @@ the whole community earned together.</p>
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -146,6 +146,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -154,9 +157,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -145,6 +145,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -153,9 +156,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -144,6 +144,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -152,9 +155,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -142,6 +142,9 @@ This release expands Spark&#8217;s standard libraries, introducing a new SQL pac
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -150,9 +153,6 @@ This release expands Spark&#8217;s standard libraries, introducing a new SQL pac
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -145,6 +145,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -153,9 +156,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-3-released.html
+++ b/site/news/spark-2-1-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-2-released.html
+++ b/site/news/spark-2-2-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-1-released.html
+++ b/site/news/spark-2-3-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-2-released.html
+++ b/site/news/spark-2-3-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-3-released.html
+++ b/site/news/spark-2-3-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-4-released.html
+++ b/site/news/spark-2-3-4-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-0-released.html
+++ b/site/news/spark-2-4-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-1-released.html
+++ b/site/news/spark-2-4-1-released.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-2-released.html
+++ b/site/news/spark-2-4-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-3-released.html
+++ b/site/news/spark-2-4-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-4-released.html
+++ b/site/news/spark-2-4-4-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-5-released.html
+++ b/site/news/spark-2-4-5-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-6.html
+++ b/site/news/spark-2-4-6.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-7-released.html
+++ b/site/news/spark-2-4-7-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-8-released.html
+++ b/site/news/spark-2-4-8-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-0-released.html
+++ b/site/news/spark-3-0-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-1-released.html
+++ b/site/news/spark-3-0-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-2-released.html
+++ b/site/news/spark-3-0-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-3-released.html
+++ b/site/news/spark-3-0-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-1-released.html
+++ b/site/news/spark-3-1-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-2-released.html
+++ b/site/news/spark-3-1-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-0-released.html
+++ b/site/news/spark-3-2-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-1-released.html
+++ b/site/news/spark-3-2-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-2-released.html
+++ b/site/news/spark-3-2-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-3-released.html
+++ b/site/news/spark-3-2-3-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-4-released.html
+++ b/site/news/spark-3-2-4-released.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Submission is open for Spark Summit East 2016 | Apache Spark
+     Spark 3.2.4 released | Apache Spark
     
   </title>
 
@@ -122,10 +122,10 @@
 <div class="container">
   <div class="row mt-4">
     <div class="col-12 col-md-9">
-      <h2>Submission is open for Spark Summit East 2016</h2>
+      <h2>Spark 3.2.4 released</h2>
 
 
-<p>Abstract submissions are now open for the 2nd <a href="https://spark-summit.org/east-2016/">Spark Summit East</a>! The event will take place on February 16th-18th in New York City. Submissions are welcome across a variety of Spark-related topics, including applications, development, data science, enterprise, and research.</p>
+<p>We are happy to announce the availability of <a href="/releases/spark-release-3-2-4.html" title="Spark Release 3.2.4">Spark 3.2.4</a>! Visit the <a href="/releases/spark-release-3-2-4.html" title="Spark Release 3.2.4">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
 
 
 <p>

--- a/site/news/spark-3-3-0-released.html
+++ b/site/news/spark-3-3-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-1-released.html
+++ b/site/news/spark-3-3-1-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-2-released.html
+++ b/site/news/spark-3-3-2-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview.html
+++ b/site/news/spark-3.0.0-preview.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview2.html
+++ b/site/news/spark-3.0.0-preview2.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-apr-2019-agenda-posted.html
+++ b/site/news/spark-ai-summit-apr-2019-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-june-2020-agenda-posted.html
+++ b/site/news/spark-ai-summit-june-2020-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -149,6 +149,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -157,9 +160,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -150,6 +150,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -158,9 +161,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-release-2-2-3.html
+++ b/site/news/spark-release-2-2-3.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -145,6 +145,9 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -153,9 +156,6 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -147,6 +147,9 @@ about the latest happenings in Spark.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -155,9 +158,6 @@ about the latest happenings in Spark.</p>
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2015.html
+++ b/site/news/spark-summit-east-agenda-posted-2015.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2016.html
+++ b/site/news/spark-summit-east-agenda-posted-2016.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-oct-2018-agenda-posted.html
+++ b/site/news/spark-summit-oct-2018-agenda-posted.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -144,6 +144,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -152,9 +155,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -146,6 +146,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -154,9 +157,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -148,6 +148,9 @@ on Spark.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -156,9 +159,6 @@ on Spark.</p>
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -140,6 +140,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -148,9 +151,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -149,6 +149,9 @@ online to attend in person. Otherwise, the Summit will offer a free live video s
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -157,9 +160,6 @@ online to attend in person. Otherwise, the Summit will offer a free live video s
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -139,6 +139,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -147,9 +150,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -489,6 +489,9 @@ to process islands identified from a search robor</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -497,9 +500,6 @@ to process islands identified from a search robor</li>
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -512,6 +512,9 @@ and then send an e-mail to the mailing list. To create an announcement, create a
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -520,9 +523,6 @@ and then send an e-mail to the mailing list. To create an announcement, create a
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -190,6 +190,9 @@ squares.saveAsSequenceFile(<span class="string">"hdfs://..."</span>)
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -198,9 +201,6 @@ squares.saveAsSequenceFile(<span class="string">"hdfs://..."</span>)
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -162,6 +162,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -170,9 +173,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -141,6 +141,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -149,9 +152,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -216,6 +216,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -224,9 +227,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -238,6 +238,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -246,9 +249,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -180,6 +180,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -188,9 +191,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -269,6 +269,9 @@ We’d especially like to thank Patrick Wendell for acting as the release manage
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -277,9 +280,6 @@ We’d especially like to thank Patrick Wendell for acting as the release manage
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -233,6 +233,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -241,9 +244,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -327,6 +327,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -335,9 +338,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -245,6 +245,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -253,9 +256,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -218,6 +218,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -226,9 +229,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -311,6 +311,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -319,9 +322,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -269,6 +269,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -277,9 +280,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -226,6 +226,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -234,9 +237,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -362,6 +362,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -370,9 +373,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -248,6 +248,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -256,9 +259,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -376,6 +376,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -384,9 +387,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -248,6 +248,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -256,9 +259,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -208,6 +208,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -216,9 +219,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -353,6 +353,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -361,9 +364,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -240,6 +240,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -248,9 +251,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -467,6 +467,9 @@ Python coverage. MLlib also adds several new algorithms.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -475,9 +478,6 @@ Python coverage. MLlib also adds several new algorithms.</p>
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -272,6 +272,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -280,9 +283,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -405,6 +405,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -413,9 +416,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -144,6 +144,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -152,9 +155,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -281,6 +281,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -289,9 +292,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -377,6 +377,9 @@ yzhou2001, zhonghaihua, zhuol, zlpmichelle, Örjan Lundberg, Łukasz Gieroń</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -385,9 +388,6 @@ yzhou2001, zhonghaihua, zhuol, zlpmichelle, Örjan Lundberg, Łukasz Gieroń</p>
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -289,6 +289,9 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Roberts, Adrian Petrescu, Ahmed Mahran
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -297,9 +300,6 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Roberts, Adrian Petrescu, Ahmed Mahran
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-3.html
+++ b/site/releases/spark-release-2-1-3.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -355,6 +355,9 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Budde, Adam Roberts, Adrian Ionescu, A
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -363,9 +366,6 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Budde, Adam Roberts, Adrian Ionescu, A
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -153,6 +153,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -161,9 +164,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-2.html
+++ b/site/releases/spark-release-2-2-2.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-3.html
+++ b/site/releases/spark-release-2-2-3.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -365,6 +365,9 @@ ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Albe
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -373,9 +376,6 @@ ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Albe
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-1.html
+++ b/site/releases/spark-release-2-3-1.html
@@ -153,6 +153,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -161,9 +164,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-2.html
+++ b/site/releases/spark-release-2-3-2.html
@@ -153,6 +153,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -161,9 +164,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-3.html
+++ b/site/releases/spark-release-2-3-3.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-4.html
+++ b/site/releases/spark-release-2-3-4.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-0.html
+++ b/site/releases/spark-release-2-4-0.html
@@ -371,6 +371,9 @@ Achuth17, Adam Bradbury, Adamyuanyuan, Adelbert Chang, Ala Luszczak, Aleksandr K
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -379,9 +382,6 @@ Achuth17, Adam Bradbury, Adamyuanyuan, Adelbert Chang, Ala Luszczak, Aleksandr K
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-1.html
+++ b/site/releases/spark-release-2-4-1.html
@@ -181,6 +181,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -189,9 +192,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-2.html
+++ b/site/releases/spark-release-2-4-2.html
@@ -153,6 +153,9 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -161,9 +164,6 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-3.html
+++ b/site/releases/spark-release-2-4-3.html
@@ -151,6 +151,9 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -159,9 +162,6 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-4.html
+++ b/site/releases/spark-release-2-4-4.html
@@ -157,6 +157,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -165,9 +168,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-5.html
+++ b/site/releases/spark-release-2-4-5.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-6.html
+++ b/site/releases/spark-release-2-4-6.html
@@ -179,6 +179,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -187,9 +190,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-7.html
+++ b/site/releases/spark-release-2-4-7.html
@@ -221,6 +221,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -229,9 +232,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-8.html
+++ b/site/releases/spark-release-2-4-8.html
@@ -222,6 +222,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -230,9 +233,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-0.html
+++ b/site/releases/spark-release-3-0-0.html
@@ -531,6 +531,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -539,9 +542,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-1.html
+++ b/site/releases/spark-release-3-0-1.html
@@ -180,6 +180,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -188,9 +191,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-2.html
+++ b/site/releases/spark-release-3-0-2.html
@@ -190,6 +190,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -198,9 +201,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-3.html
+++ b/site/releases/spark-release-3-0-3.html
@@ -207,6 +207,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -215,9 +218,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-1.html
+++ b/site/releases/spark-release-3-1-1.html
@@ -568,6 +568,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -576,9 +579,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-2.html
+++ b/site/releases/spark-release-3-1-2.html
@@ -255,6 +255,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -263,9 +266,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-3.html
+++ b/site/releases/spark-release-3-1-3.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-0.html
+++ b/site/releases/spark-release-3-2-0.html
@@ -541,6 +541,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -549,9 +552,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-1.html
+++ b/site/releases/spark-release-3-2-1.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-2.html
+++ b/site/releases/spark-release-3-2-2.html
@@ -249,6 +249,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -257,9 +260,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-3.html
+++ b/site/releases/spark-release-3-2-3.html
@@ -222,6 +222,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -230,9 +233,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-4.html
+++ b/site/releases/spark-release-3-2-4.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Submission is open for Spark Summit East 2016 | Apache Spark
+     Spark Release 3.2.4 | Apache Spark
     
   </title>
 
@@ -122,10 +122,57 @@
 <div class="container">
   <div class="row mt-4">
     <div class="col-12 col-md-9">
-      <h2>Submission is open for Spark Summit East 2016</h2>
+      <h2>Spark Release 3.2.4</h2>
 
 
-<p>Abstract submissions are now open for the 2nd <a href="https://spark-summit.org/east-2016/">Spark Summit East</a>! The event will take place on February 16th-18th in New York City. Submissions are welcome across a variety of Spark-related topics, including applications, development, data science, enterprise, and research.</p>
+<p>Spark 3.2.4 is a maintenance release containing stability fixes. This release is based on the branch-3.2 maintenance branch of Spark. We strongly recommend all 3.2 users to upgrade to this stable release.</p>
+
+<h3 id="notable-changes">Notable changes</h3>
+
+<ul>
+  <li>
+    <p><a href="https://issues.apache.org/jira/browse/SPARK-38173">[SPARK-38173]</a>: Quoted column cannot be recognized correctly when quotedRegexColumnNames is true</p>
+  </li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39399">[SPARK-39399]</a>: proxy-user not working for Spark on k8s in cluster deploy mode</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40817">[SPARK-40817]</a>: Remote spark.jars URIs ignored for Spark on Kubernetes in cluster mode</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40819">[SPARK-40819]</a>: Parquet INT64 (TIMESTAMP(NANOS,true)) now throwing Illegal Parquet type instead of automatically converting to LongType</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41162">[SPARK-41162]</a>: Anti-join must not be pushed below aggregation with ambiguous predicates</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41254">[SPARK-41254]</a>: YarnAllocator.rpIdToYarnResource map is not properly updated</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41360">[SPARK-41360]</a>: Avoid BlockManager re-registration if the executor has been lost</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41376">[SPARK-41376]</a>: Executor netty direct memory check should respect spark.shuffle.io.preferDirectBufs</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41388">[SPARK-41388]</a>: getReusablePVCs should ignore recently created PVCs in the previous batch</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41415">[SPARK-41415]</a>: SASL Request Retries</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41554">[SPARK-41554]</a>: Decimal.changePrecision produces ArrayIndexOutOfBoundsException</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41732">[SPARK-41732]</a>: Session window: analysis rule &#8220;SessionWindowing&#8221; does not apply tree-pattern based pruning</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41952">[SPARK-41952]</a>: Upgrade Parquet to fix off-heap memory leaks in Zstd codec</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41989">[SPARK-41989]</a>: PYARROW_IGNORE_TIMEZONE warning can break application logging setup</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42071">[SPARK-42071]</a>: Register scala.math.Ordering$Reverse to KyroSerializer</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42090">[SPARK-42090]</a>: Introduce sasl retry count in RetryingBlockTransferor</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42157">[SPARK-42157]</a>: <code class="language-plaintext highlighter-rouge">spark.scheduler.mode=FAIR</code> should provide FAIR scheduler</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42168">[SPARK-42168]</a>: CoGroup with window function returns incorrect result when partition keys differ in order</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42259">[SPARK-42259]</a>: ResolveGroupingAnalytics should take care of Python UDAF</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42462">[SPARK-42462]</a>: Prevent <code class="language-plaintext highlighter-rouge">docker-image-tool.sh</code> from publishing OCI manifests</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42478">[SPARK-42478]</a>: Make a serializable jobTrackerId instead of a non-serializable JobID in FileWriterFactory</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42596">[SPARK-42596]</a>: OMP_NUM_THREADS not set to number of executor cores by default</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42697">[SPARK-42697]</a>: /api/v1/applications return 0 for duration</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42747">[SPARK-42747]</a>: Fix incorrect internal status of LoR and AFT</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42785">[SPARK-42785]</a>: When spark submit without &#8211;deploy-mode, will face NPE in Kubernetes Case</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42906">[SPARK-42906]</a>: Replace a starting digit with <code class="language-plaintext highlighter-rouge">x</code> in resource name prefix</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42967">[SPARK-42967]</a>: Fix SparkListenerTaskStart.stageAttemptId when a task is started after the stage is cancelled</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-43004">[SPARK-43004]</a>: vendor==vendor typo in ResourceRequest.equals()</li>
+</ul>
+
+<h3 id="dependency-changes">Dependency Changes</h3>
+
+<p>While being a maintence release we did still upgrade some dependencies in this release they are:</p>
+
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-41030">[SPARK-41030]</a>: Upgrade Apache Ivy to 2.5.1</li>
+</ul>
+
+<p>You can consult JIRA for the <a href="https://s.apache.org/spark-3.2.4">detailed changes</a>.</p>
+
+<p>We would like to acknowledge all community members for contributing patches to this release.</p>
 
 
 <p>

--- a/site/releases/spark-release-3-2-4.html
+++ b/site/releases/spark-release-3-2-4.html
@@ -130,9 +130,7 @@
 <h3 id="notable-changes">Notable changes</h3>
 
 <ul>
-  <li>
-    <p><a href="https://issues.apache.org/jira/browse/SPARK-38173">[SPARK-38173]</a>: Quoted column cannot be recognized correctly when quotedRegexColumnNames is true</p>
-  </li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-38173">[SPARK-38173]</a>: Quoted column cannot be recognized correctly when quotedRegexColumnNames is true</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-39399">[SPARK-39399]</a>: proxy-user not working for Spark on k8s in cluster deploy mode</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-40817">[SPARK-40817]</a>: Remote spark.jars URIs ignored for Spark on Kubernetes in cluster mode</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-40819">[SPARK-40819]</a>: Parquet INT64 (TIMESTAMP(NANOS,true)) now throwing Illegal Parquet type instead of automatically converting to LongType</li>

--- a/site/releases/spark-release-3-3-0.html
+++ b/site/releases/spark-release-3-3-0.html
@@ -721,6 +721,9 @@ Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</sp
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -729,9 +732,6 @@ Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</sp
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-1.html
+++ b/site/releases/spark-release-3-3-1.html
@@ -231,6 +231,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -239,9 +242,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-2.html
+++ b/site/releases/spark-release-3-3-2.html
@@ -308,6 +308,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -316,9 +319,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/research.html
+++ b/site/research.html
@@ -187,6 +187,9 @@ Spark offers an abstraction called <a href="http://people.csail.mit.edu/matei/pa
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -195,9 +198,6 @@ Spark offers an abstraction called <a href="http://people.csail.mit.edu/matei/pa
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -149,6 +149,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -157,9 +160,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -149,6 +149,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -157,9 +160,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -145,6 +145,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -153,9 +156,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -143,6 +143,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -151,9 +154,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/security.html
+++ b/site/security.html
@@ -611,6 +611,9 @@ PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -619,9 +622,6 @@ PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -144,6 +144,14 @@
 </url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
+  <loc>https://spark.apache.org/releases/spark-release-3-2-4.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/news/spark-3-2-4-released.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/releases/spark-release-3-3-2.html</loc>
   <changefreq>weekly</changefreq>
 </url>
@@ -981,6 +989,10 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
+  <loc>https://spark.apache.org/streaming/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/news/</loc>
   <changefreq>weekly</changefreq>
 </url>
@@ -990,10 +1002,6 @@
 </url>
 <url>
   <loc>https://spark.apache.org/sql/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>https://spark.apache.org/streaming/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -285,6 +285,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -293,9 +296,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -227,6 +227,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -235,9 +238,6 @@
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -231,6 +231,9 @@ transforming, and analyzing genomic data using Apache Spark</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -239,9 +242,6 @@ transforming, and analyzing genomic data using Apache Spark</li>
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -189,6 +189,9 @@ If you have any questions about the Apache trademark policy, please email
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -197,9 +200,6 @@ If you have any questions about the Apache trademark policy, please email
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -291,6 +291,9 @@ For example, 2.4.0 was released in November 2nd 2018 and had been maintained for
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-2-4-released.html">Spark 3.2.4 released</a>
+            <span class="small">(Apr 13, 2023)</span></li>
+          
           <li><a href="/news/spark-3-3-2-released.html">Spark 3.3.2 released</a>
             <span class="small">(Feb 17, 2023)</span></li>
           
@@ -299,9 +302,6 @@ For example, 2.4.0 was released in November 2nd 2018 and had been maintained for
           
           <li><a href="/news/spark-3-3-1-released.html">Spark 3.3.1 released</a>
             <span class="small">(Oct 25, 2022)</span></li>
-          
-          <li><a href="/news/spark-3-2-2-released.html">Spark 3.2.2 released</a>
-            <span class="small">(Jul 17, 2022)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>


### PR DESCRIPTION
- Apache Download: https://downloads.apache.org/spark/spark-3.2.4/
- Maven Central: https://repo1.maven.org/maven2/org/apache/spark/spark-core_2.12/3.2.4/
- PyPI: https://pypi.org/project/pyspark/3.2.4/
- DockerHub: https://hub.docker.com/r/apache/spark/tags?page=1&name=v3.2.4