### PR TITLE
Fix a typo from release notes in Spark 3.4

### DIFF
--- a/releases/_posts/2023-04-13-spark-release-3-4-0.md
+++ b/releases/_posts/2023-04-13-spark-release-3-4-0.md
@@ -17,8 +17,6 @@ This release introduces Python client for Spark Connect, augments Structured Str
 
 To download Apache Spark 3.4.0, visit the [downloads](https://spark.apache.org/downloads.html) page. You can consult JIRA for the [detailed changes](https://s.apache.org/spark-3.4.0). We have curated a list of high level changes here, grouped by major modules.
 
-* This will become a table of contents (this text will be scraped).
-  {:toc}
 
 ### Highlight
 

--- a/site/releases/spark-release-3-4-0.html
+++ b/site/releases/spark-release-3-4-0.html
@@ -131,10 +131,6 @@
 
 <p>To download Apache Spark 3.4.0, visit the <a href="https://spark.apache.org/downloads.html">downloads</a> page. You can consult JIRA for the <a href="https://s.apache.org/spark-3.4.0">detailed changes</a>. We have curated a list of high level changes here, grouped by major modules.</p>
 
-<ul>
-  <li>This will become a table of contents (this text will be scraped).</li>
-</ul>
-
 <h3 id="highlight">Highlight</h3>
 
 <ul>


### PR DESCRIPTION
This PR fixes "This will become a table of contents (this text will be scraped)." in the release notes that is a mistake.