### PR TITLE
🚀 Including ApacheSparkMéxicoCity Meetup on community page 🚀

### DIFF
--- a/site/community.html
+++ b/site/community.html
@@ -293,6 +293,9 @@ vulnerabilities, and for information on known security issues.</p>
   <li>
     <a href="https://www.meetup.com/Apache-Spark-Maryland/">Maryland Spark Meetup</a>
   </li>
+   <li>
+    <a href="https://www.meetup.com/es/apache-spark-mexicocity/">México City Spark Meetup</a>
+  </li>
   <li>
     <a href="https://www.meetup.com/Mumbai-Spark-Meetup/">Mumbai Spark Meetup</a>
   </li>


### PR DESCRIPTION
While browsing the site, I find out that the site is missing Apache Spark México City. https://www.meetup.com/es/apache-spark-mexicocity/

I And would like to include the community on the following web page https://spark.apache.org/community.html

I change the .md and the .html community files. I hope this helps.

Author: Juan Diaz <juanchodis@hotmail.com>

<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->
