### PR TITLE
Fix the thirdparty integration with Spark documentation in 3.4.0

### DIFF
--- a/site/docs/3.4.0/api/python/_sources/getting_started/quickstart_connect.ipynb.txt
+++ b/site/docs/3.4.0/api/python/_sources/getting_started/quickstart_connect.ipynb.txt
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!./sbin/start-connect-server.sh --packages org.apache.spark:spark-connect_2.12:$SPARK_VERSION"
+    "!$HOME/sbin/start-connect-server.sh --packages org.apache.spark:spark-connect_2.12:$SPARK_VERSION"
    ]
   },
   {

--- a/site/docs/3.4.0/api/python/getting_started/quickstart_connect.html
+++ b/site/docs/3.4.0/api/python/getting_started/quickstart_connect.html
@@ -456,7 +456,7 @@ div.rendered_html tbody tr:hover {
 </pre></div>
 </div>
 <div class="input_area highlight-ipython3 notranslate"><div class="highlight"><pre>
-<span></span><span class="o">!</span>./sbin/start-connect-server.sh<span class="w"> </span>--packages<span class="w"> </span>org.apache.spark:spark-connect_2.12:<span class="nv">$SPARK_VERSION</span>
+<span></span><span class="o">!</span><span class="nv">$HOME</span>/sbin/start-connect-server.sh<span class="w"> </span>--packages<span class="w"> </span>org.apache.spark:spark-connect_2.12:<span class="nv">$SPARK_VERSION</span>
 </pre></div>
 </div>
 </div>

--- a/site/docs/3.4.0/api/python/getting_started/quickstart_connect.ipynb
+++ b/site/docs/3.4.0/api/python/getting_started/quickstart_connect.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!./sbin/start-connect-server.sh --packages org.apache.spark:spark-connect_2.12:$SPARK_VERSION"
+    "!$HOME/sbin/start-connect-server.sh --packages org.apache.spark:spark-connect_2.12:$SPARK_VERSION"
    ]
   },
   {


### PR DESCRIPTION
There was a behaviour change in Binder itself so now **none** of Binder integrations work with quickstarts.
This PR proposes to change the `HOME` expression from `.` to `HOME` (semantically same). 