### PR TITLE
Remove hadoop2 pre-built for 3.4.0

### DIFF
--- a/js/downloads.js
+++ b/js/downloads.js
@@ -24,8 +24,10 @@ var hadoop3pscala213 = {pretty: "Pre-built for Apache Hadoop 3.3 and later (Scal
 var packagesV12 = [hadoop3p3, hadoop3p3scala213, hadoop2p7, hadoopFree, sources];
 // 3.3.0+
 var packagesV13 = [hadoop3p, hadoop3pscala213, hadoop2p, hadoopFree, sources];
+// 3.4.0+
+var packagesV14 = [hadoop3p, hadoop3pscala213, hadoopFree, sources];
 
-addRelease("3.4.0", new Date("04/13/2023"), packagesV13, true);
+addRelease("3.4.0", new Date("04/13/2023"), packagesV14, true);
 addRelease("3.3.2", new Date("02/17/2023"), packagesV13, true);
 addRelease("3.2.4", new Date("04/13/2023"), packagesV12, true);
 

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -24,8 +24,10 @@ var hadoop3pscala213 = {pretty: "Pre-built for Apache Hadoop 3.3 and later (Scal
 var packagesV12 = [hadoop3p3, hadoop3p3scala213, hadoop2p7, hadoopFree, sources];
 // 3.3.0+
 var packagesV13 = [hadoop3p, hadoop3pscala213, hadoop2p, hadoopFree, sources];
+// 3.4.0+
+var packagesV14 = [hadoop3p, hadoop3pscala213, hadoopFree, sources];
 
-addRelease("3.4.0", new Date("04/13/2023"), packagesV13, true);
+addRelease("3.4.0", new Date("04/13/2023"), packagesV14, true);
 addRelease("3.3.2", new Date("02/17/2023"), packagesV13, true);
 addRelease("3.2.4", new Date("04/13/2023"), packagesV12, true);
 


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->

Referring to https://archive.apache.org/dist/spark/spark-3.4.0/, the binary release for hadoop2 is not pre-built and published