### PR TITLE
Update Apache Spark 3.5 Release Window

### DIFF
--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -250,7 +250,7 @@ available APIs.</p>
 Hence, Spark 2.3.0 would generally be released about 6 months after 2.2.0. Maintenance releases happen as needed
 in between feature releases. Major releases do not happen according to a fixed schedule.</p>
 
-<h3>Spark 3.4 release window</h3>
+<h3>Spark 3.5 release window</h3>
 
 <table>
   <thead>
@@ -261,15 +261,15 @@ in between feature releases. Major releases do not happen according to a fixed s
   </thead>
   <tbody>
     <tr>
-      <td>January 16th 2023</td>
+      <td>July 16th 2023</td>
       <td>Code freeze. Release branch cut.</td>
     </tr>
     <tr>
-      <td>Late January 2023</td>
+      <td>Late July 2023</td>
       <td>QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.</td>
     </tr>
     <tr>
-      <td>February 2023</td>
+      <td>August 2023</td>
       <td>Release candidates (RC), voting, etc. until final release passes</td>
     </tr>
   </tbody>

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -103,13 +103,13 @@ The branch is cut every January and July, so feature ("minor") releases occur ab
 Hence, Spark 2.3.0 would generally be released about 6 months after 2.2.0. Maintenance releases happen as needed
 in between feature releases. Major releases do not happen according to a fixed schedule.
 
-<h3>Spark 3.4 release window</h3>
+<h3>Spark 3.5 release window</h3>
 
 | Date  | Event |
 | ----- | ----- |
-| January 16th 2023 | Code freeze. Release branch cut.|
-| Late January 2023 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
-| February 2023 | Release candidates (RC), voting, etc. until final release passes|
+| July 16th 2023 | Code freeze. Release branch cut.|
+| Late July 2023 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
+| August 2023 | Release candidates (RC), voting, etc. until final release passes|
 
 <h2>Maintenance releases and EOL</h2>
 


### PR DESCRIPTION
Update Apache Spark 3.5 Release Window, with proposed dates:

```
| July 16th 2023 | Code freeze. Release branch cut.|
| Late July 2023 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
| August 2023    | Release candidates (RC), voting, etc. until final release passes|
```