### PR TITLE
Remove koalas from third-party-projects

### DIFF
--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -159,7 +159,6 @@ against Spark, and data scientists to use Javascript in Jupyter notebooks.</li>
   <li><a href="https://developer.ibm.com/storage/products/ibm-spectrum-conductor-spark/">IBM Spectrum Conductor</a> - Cluster management software that integrates with Spark and modern computing frameworks.</li>
   <li><a href="https://delta.io">Delta Lake</a> - Storage layer that provides ACID transactions and scalable metadata handling for Apache Spark workloads.</li>
   <li><a href="https://mlflow.org">MLflow</a> - Open source platform to manage the machine learning lifecycle, including deploying models from diverse machine learning libraries on Apache Spark.</li>
-  <li><a href="https://github.com/databricks/koalas">Koalas</a> - Data frame API on Apache Spark that more closely follows Python&#8217;s pandas.</li>
   <li><a href="https://datafu.apache.org/docs/spark/getting-started.html">Apache DataFu</a> - A collection of utils and user-defined-functions for working with large scale data in Apache Spark, as well as making Scala-Python interoperability easier.</li>
 </ul>
 

--- a/third-party-projects.md
+++ b/third-party-projects.md
@@ -43,7 +43,6 @@ against Spark, and data scientists to use Javascript in Jupyter notebooks.
 - <a href="https://developer.ibm.com/storage/products/ibm-spectrum-conductor-spark/">IBM Spectrum Conductor</a> - Cluster management software that integrates with Spark and modern computing frameworks.
 - <a href="https://delta.io">Delta Lake</a> - Storage layer that provides ACID transactions and scalable metadata handling for Apache Spark workloads.
 - <a href="https://mlflow.org">MLflow</a> - Open source platform to manage the machine learning lifecycle, including deploying models from diverse machine learning libraries on Apache Spark.
-- <a href="https://github.com/databricks/koalas">Koalas</a> - Data frame API on Apache Spark that more closely follows Python's pandas.
 - <a href="https://datafu.apache.org/docs/spark/getting-started.html">Apache DataFu</a> - A collection of utils and user-defined-functions for working with large scale data in Apache Spark, as well as making Scala-Python interoperability easier.
 
 <h2>Applications using Spark</h2>


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->

Now that koalas is deprecated and we call it pandas API on spark I think we can remove it. 