### PR TITLE
Fix the link of PR-41535 in Spark 3.4.1 release note

### DIFF
--- a/releases/_posts/2023-06-23-spark-release-3-4-1.md
+++ b/releases/_posts/2023-06-23-spark-release-3-4-1.md
@@ -15,7 +15,7 @@ Spark 3.4.1 is a maintenance release containing stability fixes. This release is
 
 ### Notable changes
 
-  - [[SPARK-32559]](https://issues.apache.org/jira/browse/SPARK-32559): Fix the trim logic did't handle ASCII control characters correctly
+  - [[SPARK-44383]](https://issues.apache.org/jira/browse/SPARK-44383): Fix the trim logic did't handle ASCII control characters correctly
   - [[SPARK-37829]](https://issues.apache.org/jira/browse/SPARK-37829): Dataframe.joinWith outer-join should return a null value for unmatched row
   - [[SPARK-42078]](https://issues.apache.org/jira/browse/SPARK-42078): Add `CapturedException` to utils
   - [[SPARK-42290]](https://issues.apache.org/jira/browse/SPARK-42290): Fix the OOM error can't be reported when AQE on

--- a/site/releases/spark-release-3-4-1.html
+++ b/site/releases/spark-release-3-4-1.html
@@ -130,7 +130,7 @@
 <h3 id="notable-changes">Notable changes</h3>
 
 <ul>
-  <li><a href="https://issues.apache.org/jira/browse/SPARK-32559">[SPARK-32559]</a>: Fix the trim logic did&#8217;t handle ASCII control characters correctly</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44383">[SPARK-44383]</a>: Fix the trim logic did&#8217;t handle ASCII control characters correctly</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-37829">[SPARK-37829]</a>: Dataframe.joinWith outer-join should return a null value for unmatched row</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-42078">[SPARK-42078]</a>: Add <code class="language-plaintext highlighter-rouge">CapturedException</code> to utils</li>
   <li><a href="https://issues.apache.org/jira/browse/SPARK-42290">[SPARK-42290]</a>: Fix the OOM error can&#8217;t be reported when AQE on</li>


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->

For my mistake, [PR-41535](https://github.com/apache/spark/pull/41535) was incorrectly linked to https://issues.apache.org/jira/browse/SPARK-32559, it should have been linked to https://issues.apache.org/jira/browse/SPARK-44383. This PR fixes it.