### PR TITLE
Fix the link of developer-tools docs

### DIFF
--- a/developer-tools.md
+++ b/developer-tools.md
@@ -120,7 +120,7 @@ If you'd prefer, you can run all of these commands on the command line (but this
 $ build/sbt "core/testOnly *DAGSchedulerSuite -- -z SPARK-12345"
 ```
 
-For more about how to run individual tests with sbt, see the [sbt documentation](https://www.scala-sbt.org/0.13/docs/Testing.html).
+For more about how to run individual tests with sbt, see the [sbt documentation](https://www.scala-sbt.org/1.x/docs/Testing.html).
 
 <h4>Testing with Maven</h4>
 
@@ -242,7 +242,7 @@ build/sbt "testOnly org.apache.spark.rdd.SortingSuite"
 
 <h3>Binary compatibility</h3>
 
-To ensure binary compatibility, Spark uses [MiMa](https://github.com/typesafehub/migration-manager).
+To ensure binary compatibility, Spark uses [MiMa](https://github.com/lightbend/mima).
 
 <h4>Ensuring binary compatibility</h4>
 
@@ -548,4 +548,4 @@ Please see the full YourKit documentation for the full list of profiler agent
 When running Spark tests through SBT, add `javaOptions in Test += "-agentpath:/path/to/yjp"`
 to `SparkBuild.scala` to launch the tests with the YourKit profiler agent enabled.  
 The platform-specific paths to the profiler agents are listed in the 
-<a href="http://www.yourkit.com/docs/80/help/agent.jsp">YourKit documentation</a>.
+<a href="https://www.yourkit.com/docs/java/help/agent.jsp">YourKit documentation</a>.

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -233,7 +233,7 @@ $ build/mvn package -DskipTests -pl core
 <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>$ build/sbt "core/testOnly *DAGSchedulerSuite -- -z SPARK-12345"
 </code></pre></div></div>
 
-<p>For more about how to run individual tests with sbt, see the <a href="https://www.scala-sbt.org/0.13/docs/Testing.html">sbt documentation</a>.</p>
+<p>For more about how to run individual tests with sbt, see the <a href="https://www.scala-sbt.org/1.x/docs/Testing.html">sbt documentation</a>.</p>
 
 <h4>Testing with Maven</h4>
 
@@ -352,7 +352,7 @@ sufficient to run a test from the command line:</p>
 
 <h3>Binary compatibility</h3>
 
-<p>To ensure binary compatibility, Spark uses <a href="https://github.com/typesafehub/migration-manager">MiMa</a>.</p>
+<p>To ensure binary compatibility, Spark uses <a href="https://github.com/lightbend/mima">MiMa</a>.</p>
 
 <h4>Ensuring binary compatibility</h4>
 
@@ -655,7 +655,7 @@ cluster with the same name, your security group settings will be re-used.</li>
 <p>When running Spark tests through SBT, add <code class="language-plaintext highlighter-rouge">javaOptions in Test += "-agentpath:/path/to/yjp"</code>
 to <code class="language-plaintext highlighter-rouge">SparkBuild.scala</code> to launch the tests with the YourKit profiler agent enabled.<br />
 The platform-specific paths to the profiler agents are listed in the 
-<a href="http://www.yourkit.com/docs/80/help/agent.jsp">YourKit documentation</a>.</p>
+<a href="https://www.yourkit.com/docs/java/help/agent.jsp">YourKit documentation</a>.</p>
 
     </div>
     <div class="col-12 col-md-3">


### PR DESCRIPTION
The pr aims to update some outdated links in `developer-tools` docs, include:
- https://www.scala-sbt.org/0.13/docs/Testing.html -> https://www.scala-sbt.org/1.x/docs/Testing.html
Because Spark's dependency on the SBT version has been upgraded to 1. x for a long time

- https://github.com/typesafehub/migration-manager -> https://github.com/lightbend/mima
Avoid jumping

- http://www.yourkit.com/docs/80/help/agent.jsp -> https://www.yourkit.com/docs/java/help/agent.jsp
Dead link
