### PR TITLE
Update gpg's keyserver

### DIFF
--- a/release-process.md
+++ b/release-process.md
@@ -102,7 +102,7 @@ Note that the last 8 digits (26A27D33) of the public key is the <a href="https:/
 After generating the public key, we should upload it to <a href="https://infra.apache.org/release-signing.html#keyserver">public key server</a>:
 
 ```
-$ gpg --keyserver keys.openpgp.org --send-key 26A27D33
+$ gpg --keyserver hkps://keys.openpgp.org --send-key 26A27D33
 ```
 
 Please refer to <a href="https://infra.apache.org/release-signing.html#keyserver-upload">keyserver-upload</a> for details.

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -228,7 +228,7 @@ sub   rsa4096 2021-08-19 [E]
 
 <p>After generating the public key, we should upload it to <a href="https://infra.apache.org/release-signing.html#keyserver">public key server</a>:</p>
 
-<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>$ gpg --keyserver keys.openpgp.org --send-key 26A27D33
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>$ gpg --keyserver hkps://keys.openpgp.org --send-key 26A27D33
 </code></pre></div></div>
 
 <p>Please refer to <a href="https://infra.apache.org/release-signing.html#keyserver-upload">keyserver-upload</a> for details.</p>


### PR DESCRIPTION
This PR updates gpg's keyserver from `keys.openpgp.org` to `hkps://keys.openpgp.org` to fix failure to upload to public keyserver.

Before:
```shell
yumwang@G9L07H60PK spark % gpg --keyserver keys.openpgp.org --send-key 1B16BB6E
gpg: sending key C94CC8441B16BB6E to hkp://keys.openpgp.org
gpg: keyserver send failed: End of file
gpg: keyserver send failed: End of file
yumwang@G9L07H60PK spark % 
```

After:
```shell
yumwang@G9L07H60PK spark % gpg --keyserver hkps://keys.openpgp.org --send-key 1B16BB6E
gpg: sending key C94CC8441B16BB6E to hkps://keys.openpgp.org
yumwang@G9L07H60PK spark % 
```