### PR TITLE
[SPARK-44820][DOCS] Switch languages consistently across docs for all code snippets

### DIFF
--- a/site/docs/3.1.1/js/main.js
+++ b/site/docs/3.1.1/js/main.js
@@ -50,7 +50,8 @@ function codeTabs() {
         var buttonLabel = ""
       }
       tabBar.append(
-        '<li class="nav-item"><a class="nav-link tab_' + lang + '" href="#' + id + '" data-toggle="tab">' + buttonLabel + '</a></li>'
+        '<li class="nav-item"><a class="nav-link tab_' + lang + '" href="#' + id +
+          '" data-tab-lang="tab_' + lang + '" data-toggle="tab">' + buttonLabel + '</a></li>'
       );
     });
 
@@ -63,7 +64,7 @@ function codeTabs() {
     // while retaining the scroll position
     e.preventDefault();
     var scrollOffset = $(this).offset().top - $(document).scrollTop();
-    $("." + $(this).attr('class')).tab('show');
+    $("." + $(this).attr('data-tab-lang')).tab('show');
     $(document).scrollTop($(this).offset().top - scrollOffset);
   });
 }


### PR DESCRIPTION
When a user chooses a different language for a code snippet, all code snippets on that page should switch to the chosen language. This was the behavior for, for example, Spark 2.0 doc: https://spark.apache.org/docs/2.0.0/structured-streaming-programming-guide.html

But it was broken for later docs, for example the Spark 3.4.1 doc: https://spark.apache.org/docs/latest/quick-start.html

We should fix this behavior change and possibly add test cases to prevent future regressions.

Jira: https://issues.apache.org/jira/browse/SPARK-44820