### PR TITLE
Fix UI issue for `published` docs about Switch languages consistently across docs for all code snippets

### DIFF
--- a/site/docs/3.1.1/js/main.js
+++ b/site/docs/3.1.1/js/main.js
@@ -63,7 +63,7 @@ function codeTabs() {
     // while retaining the scroll position
     e.preventDefault();
     var scrollOffset = $(this).offset().top - $(document).scrollTop();
-    $("." + $(this).attr('class')).tab('show');
+    $("." + $(this).attr('class').split(" ").join(".")).tab('show');
     $(document).scrollTop($(this).offset().top - scrollOffset);
   });
 }

--- a/site/docs/3.1.2/js/main.js
+++ b/site/docs/3.1.2/js/main.js
@@ -63,7 +63,7 @@ function codeTabs() {
     // while retaining the scroll position
     e.preventDefault();
     var scrollOffset = $(this).offset().top - $(document).scrollTop();
-    $("." + $(this).attr('class')).tab('show');
+    $("." + $(this).attr('class').split(" ").join(".")).tab('show');
     $(document).scrollTop($(this).offset().top - scrollOffset);
   });
 }

--- a/site/docs/3.1.3/js/main.js
+++ b/site/docs/3.1.3/js/main.js
@@ -63,7 +63,7 @@ function codeTabs() {
     // while retaining the scroll position
     e.preventDefault();
     var scrollOffset = $(this).offset().top - $(document).scrollTop();
-    $("." + $(this).attr('class')).tab('show');
+    $("." + $(this).attr('class').split(" ").join(".")).tab('show');
     $(document).scrollTop($(this).offset().top - scrollOffset);
   });
 }

--- a/site/docs/3.2.0/js/main.js
+++ b/site/docs/3.2.0/js/main.js
@@ -63,7 +63,7 @@ function codeTabs() {
     // while retaining the scroll position
     e.preventDefault();
     var scrollOffset = $(this).offset().top - $(document).scrollTop();
-    $("." + $(this).attr('class')).tab('show');
+    $("." + $(this).attr('class').split(" ").join(".")).tab('show');
     $(document).scrollTop($(this).offset().top - scrollOffset);
   });
 }

--- a/site/docs/3.2.1/js/main.js
+++ b/site/docs/3.2.1/js/main.js
@@ -63,7 +63,7 @@ function codeTabs() {
     // while retaining the scroll position
     e.preventDefault();
     var scrollOffset = $(this).offset().top - $(document).scrollTop();
-    $("." + $(this).attr('class')).tab('show');
+    $("." + $(this).attr('class').split(" ").join(".")).tab('show');
     $(document).scrollTop($(this).offset().top - scrollOffset);
   });
 }

--- a/site/docs/3.2.2/js/main.js
+++ b/site/docs/3.2.2/js/main.js
@@ -63,7 +63,7 @@ function codeTabs() {
     // while retaining the scroll position
     e.preventDefault();
     var scrollOffset = $(this).offset().top - $(document).scrollTop();
-    $("." + $(this).attr('class')).tab('show');
+    $("." + $(this).attr('class').split(" ").join(".")).tab('show');
     $(document).scrollTop($(this).offset().top - scrollOffset);
   });
 }

--- a/site/docs/3.2.3/js/main.js
+++ b/site/docs/3.2.3/js/main.js
@@ -63,7 +63,7 @@ function codeTabs() {
     // while retaining the scroll position
     e.preventDefault();
     var scrollOffset = $(this).offset().top - $(document).scrollTop();
-    $("." + $(this).attr('class')).tab('show');
+    $("." + $(this).attr('class').split(" ").join(".")).tab('show');
     $(document).scrollTop($(this).offset().top - scrollOffset);
   });
 }

--- a/site/docs/3.2.4/js/main.js
+++ b/site/docs/3.2.4/js/main.js
@@ -63,7 +63,7 @@ function codeTabs() {
     // while retaining the scroll position
     e.preventDefault();
     var scrollOffset = $(this).offset().top - $(document).scrollTop();
-    $("." + $(this).attr('class')).tab('show');
+    $("." + $(this).attr('class').split(" ").join(".")).tab('show');
     $(document).scrollTop($(this).offset().top - scrollOffset);
   });
 }

--- a/site/docs/3.3.0/js/main.js
+++ b/site/docs/3.3.0/js/main.js
@@ -63,7 +63,7 @@ function codeTabs() {
     // while retaining the scroll position
     e.preventDefault();
     var scrollOffset = $(this).offset().top - $(document).scrollTop();
-    $("." + $(this).attr('class')).tab('show');
+    $("." + $(this).attr('class').split(" ").join(".")).tab('show');
     $(document).scrollTop($(this).offset().top - scrollOffset);
   });
 }

--- a/site/docs/3.3.1/js/main.js
+++ b/site/docs/3.3.1/js/main.js
@@ -63,7 +63,7 @@ function codeTabs() {
     // while retaining the scroll position
     e.preventDefault();
     var scrollOffset = $(this).offset().top - $(document).scrollTop();
-    $("." + $(this).attr('class')).tab('show');
+    $("." + $(this).attr('class').split(" ").join(".")).tab('show');
     $(document).scrollTop($(this).offset().top - scrollOffset);
   });
 }

--- a/site/docs/3.3.2/js/main.js
+++ b/site/docs/3.3.2/js/main.js
@@ -63,7 +63,7 @@ function codeTabs() {
     // while retaining the scroll position
     e.preventDefault();
     var scrollOffset = $(this).offset().top - $(document).scrollTop();
-    $("." + $(this).attr('class')).tab('show');
+    $("." + $(this).attr('class').split(" ").join(".")).tab('show');
     $(document).scrollTop($(this).offset().top - scrollOffset);
   });
 }

--- a/site/docs/3.3.3/js/main.js
+++ b/site/docs/3.3.3/js/main.js
@@ -63,7 +63,7 @@ function codeTabs() {
     // while retaining the scroll position
     e.preventDefault();
     var scrollOffset = $(this).offset().top - $(document).scrollTop();
-    $("." + $(this).attr('class')).tab('show');
+    $("." + $(this).attr('class').split(" ").join(".")).tab('show');
     $(document).scrollTop($(this).offset().top - scrollOffset);
   });
 }

--- a/site/docs/3.4.0/js/main.js
+++ b/site/docs/3.4.0/js/main.js
@@ -63,7 +63,7 @@ function codeTabs() {
     // while retaining the scroll position
     e.preventDefault();
     var scrollOffset = $(this).offset().top - $(document).scrollTop();
-    $("." + $(this).attr('class')).tab('show');
+    $("." + $(this).attr('class').split(" ").join(".")).tab('show');
     $(document).scrollTop($(this).offset().top - scrollOffset);
   });
 }

--- a/site/docs/3.4.1/js/main.js
+++ b/site/docs/3.4.1/js/main.js
@@ -63,7 +63,7 @@ function codeTabs() {
     // while retaining the scroll position
     e.preventDefault();
     var scrollOffset = $(this).offset().top - $(document).scrollTop();
-    $("." + $(this).attr('class')).tab('show');
+    $("." + $(this).attr('class').split(" ").join(".")).tab('show');
     $(document).scrollTop($(this).offset().top - scrollOffset);
   });
 }


### PR DESCRIPTION
The pr aims to fix UI issue for `published docs` about Switch languages consistently across docs for all code snippets

https://github.com/apache/spark-website/pull/474#issuecomment-1731741985
<img width="912" alt="image" src="https://github.com/apache/spark-website/assets/15246973/50b86a6f-4bde-4444-93bf-cb85b66e962c">

As discussed, we aim to fix the aforementioned issues by directly repairing files that have already been released in history.

include versions:
3.1.1, 3.1.2, 3.1.3, 3.2.0, 3.2.1, 3.2.2, 3.2.3, 3.2.4, 3.3.0, 3.3.1, 3.3.2, 3.3.3, 3.4.0, 3.4.1

Manually test:
```
bundle exec jekyll serve --watch
```