### PR TITLE
[SPARK-45706][PYTHON][DOCS] Fix the links for Binder builds for Spark 3.5.0

### DIFF
--- a/site/docs/3.5.0/api/python/getting_started/index.html
+++ b/site/docs/3.5.0/api/python/getting_started/index.html
@@ -215,9 +215,9 @@ There are more guides shared with other languages such as
 at <a class="reference external" href="https://spark.apache.org/docs/latest/index.html#where-to-go-from-here">the Spark documentation</a>.</p>
 <p>There are live notebooks where you can try PySpark out without any other step:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/ce5ddad9903?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook: DataFrame</a></p></li>
-<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/ce5ddad9903?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_connect.ipynb">Live Notebook: Spark Connect</a></p></li>
-<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/ce5ddad9903?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb">Live Notebook: pandas API on Spark</a></p></li>
+<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/270861a3cd6?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook: DataFrame</a></p></li>
+<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/270861a3cd6?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_connect.ipynb">Live Notebook: Spark Connect</a></p></li>
+<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/270861a3cd6?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb">Live Notebook: pandas API on Spark</a></p></li>
 </ul>
 <p>The list below is the contents of this quickstart page:</p>
 <div class="toctree-wrapper compound">

--- a/site/docs/3.5.0/api/python/index.html
+++ b/site/docs/3.5.0/api/python/index.html
@@ -183,7 +183,7 @@
 <h1>PySpark Overview<a class="headerlink" href="#pyspark-overview" title="Permalink to this headline">¶</a></h1>
 <p><strong>Date</strong>: Sep 09, 2023 <strong>Version</strong>: 3.5.0</p>
 <p><strong>Useful links</strong>:
-<a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/ce5ddad9903?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook</a> | <a class="reference external" href="https://github.com/apache/spark">GitHub</a> | <a class="reference external" href="https://issues.apache.org/jira/projects/SPARK/issues">Issues</a> | <a class="reference external" href="https://github.com/apache/spark/tree/ce5ddad9903/examples/src/main/python">Examples</a> | <a class="reference external" href="https://spark.apache.org/community.html">Community</a></p>
+<a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/270861a3cd6?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook</a> | <a class="reference external" href="https://github.com/apache/spark">GitHub</a> | <a class="reference external" href="https://issues.apache.org/jira/projects/SPARK/issues">Issues</a> | <a class="reference external" href="https://github.com/apache/spark/tree/270861a3cd6/examples/src/main/python">Examples</a> | <a class="reference external" href="https://spark.apache.org/community.html">Community</a></p>
 <p>PySpark is the Python API for Apache Spark. It enables you to perform real-time,
 large-scale data processing in a distributed environment using Python. It also provides a PySpark
 shell for interactively analyzing your data.</p>
@@ -237,7 +237,7 @@ Whether you use Python or SQL, the same underlying execution
 engine is used so you will always leverage the full power of Spark.</p>
 <ul class="simple">
 <li><p><a class="reference internal" href="getting_started/quickstart_df.html"><span class="std std-ref">Quickstart: DataFrame</span></a></p></li>
-<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/ce5ddad9903?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook: DataFrame</a></p></li>
+<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/270861a3cd6?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook: DataFrame</a></p></li>
 <li><p><a class="reference internal" href="reference/pyspark.sql/index.html"><span class="std std-ref">Spark SQL API Reference</span></a></p></li>
 </ul>
 <p><strong>Pandas API on Spark</strong></p>
@@ -253,7 +253,7 @@ if you are new to Spark or deciding which API to use, we recommend using PySpark
 (see <a class="reference internal" href="#index-page-spark-sql-and-dataframes"><span class="std std-ref">Spark SQL and DataFrames</span></a>).</p>
 <ul class="simple">
 <li><p><a class="reference internal" href="getting_started/quickstart_ps.html"><span class="std std-ref">Quickstart: Pandas API on Spark</span></a></p></li>
-<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/ce5ddad9903?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb">Live Notebook: pandas API on Spark</a></p></li>
+<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/270861a3cd6?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb">Live Notebook: pandas API on Spark</a></p></li>
 <li><p><a class="reference internal" href="reference/pyspark.pandas/index.html"><span class="std std-ref">Pandas API on Spark Reference</span></a></p></li>
 </ul>
 <p id="index-page-structured-streaming"><strong>Structured Streaming</strong></p>


### PR DESCRIPTION
This PR cherry-picks https://github.com/apache/spark/pull/43553 into Spark 3.5.0 PySpark documentation to recover the live notebooks