### PR TITLE
Add news, release note, download link for Apache Spark 3.4.2

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -13,6 +13,7 @@ navigation:
 
 <ul>
   <li><a href="{{site.baseurl}}/docs/3.5.0/">Spark 3.5.0</a></li>
+  <li><a href="{{site.baseurl}}/docs/3.4.2/">Spark 3.4.2</a></li>
   <li><a href="{{site.baseurl}}/docs/3.4.1/">Spark 3.4.1</a></li>
   <li><a href="{{site.baseurl}}/docs/3.4.0/">Spark 3.4.0</a></li>
   <li><a href="{{site.baseurl}}/docs/3.3.3/">Spark 3.3.3</a></li> 

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -28,7 +28,7 @@ var packagesV13 = [hadoop3p, hadoop3pscala213, hadoop2p, hadoopFree, sources];
 var packagesV14 = [hadoop3p, hadoop3pscala213, hadoopFree, sources];
 
 addRelease("3.5.0", new Date("09/13/2023"), packagesV14, true);
-addRelease("3.4.1", new Date("06/23/2023"), packagesV14, true);
+addRelease("3.4.2", new Date("11/30/2023"), packagesV14, true);
 addRelease("3.3.3", new Date("08/21/2023"), packagesV13, true);
 addRelease("3.2.4", new Date("04/13/2023"), packagesV12, true);
 

--- a/news/_posts/2023-11-30-spark-3-4-2-released.md
+++ b/news/_posts/2023-11-30-spark-3-4-2-released.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: Spark 3.4.2 released
+categories:
+- News
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+We are happy to announce the availability of <a href="{{site.baseurl}}/releases/spark-release-3-4-2.html" title="Spark Release 3.4.2">Spark 3.4.2</a>! Visit the <a href="{{site.baseurl}}/releases/spark-release-3-4-2.html" title="Spark Release 3.4.2">release notes</a> to read about the new features, or <a href="{{site.baseurl}}/downloads.html">download</a> the release today.

--- a/releases/_posts/2023-11-30-spark-release-3-4-2.md
+++ b/releases/_posts/2023-11-30-spark-release-3-4-2.md
@@ -1,0 +1,105 @@
+---
+layout: post
+title: Spark Release 3.4.2
+categories: []
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+
+Spark 3.4.2 is a maintenance release containing security and correctness fixes. This release is based on the branch-3.4 maintenance branch of Spark. We strongly recommend all 3.4 users to upgrade to this stable release.
+
+### Notable changes
+
+  - [[SPARK-42784]](https://issues.apache.org/jira/browse/SPARK-42784): should still create subDir when the number of subDir in merge dir is less than conf
+  - [[SPARK-43203]](https://issues.apache.org/jira/browse/SPARK-43203): Fix DROP table behavior in session catalog
+  - [[SPARK-43393]](https://issues.apache.org/jira/browse/SPARK-43393): Address sequence expression overflow bug
+  - [[SPARK-44040]](https://issues.apache.org/jira/browse/SPARK-44040): Fix compute stats when AggregateExec node above QueryStageExec
+  - [[SPARK-44079]](https://issues.apache.org/jira/browse/SPARK-44079): Fix `ArrayIndexOutOfBoundsException` when parse array as struct using PERMISSIVE mode with corrupt record
+  - [[SPARK-44134]](https://issues.apache.org/jira/browse/SPARK-44134): Fix setting resources (GPU/FPGA) to 0 when they are set in spark-defaults.conf
+  - [[SPARK-44136]](https://issues.apache.org/jira/browse/SPARK-44136): Fixed an issue that StateManager may get materialized in executor instead of driver in FlatMapGroupsWithStateExec
+  - [[SPARK-44142]](https://issues.apache.org/jira/browse/SPARK-44142): Replace type with tpe in utility to convert python types to spark types
+  - [[SPARK-44180]](https://issues.apache.org/jira/browse/SPARK-44180): DistributionAndOrderingUtils should apply ResolveTimeZone
+  - [[SPARK-44206]](https://issues.apache.org/jira/browse/SPARK-44206): DataSet.selectExpr scope Session.active
+  - [[SPARK-44215]](https://issues.apache.org/jira/browse/SPARK-44215): If num chunks are 0, then server should throw a RuntimeException
+  - [[SPARK-44241]](https://issues.apache.org/jira/browse/SPARK-44241): Mistakenly set io.connectionTimeout/connectionCreationTimeout to zero or negative will cause incessant executor cons/destructions
+  - [[SPARK-44251]](https://issues.apache.org/jira/browse/SPARK-44251): Set nullable correctly on coalesced join key in full outer USING join
+  - [[SPARK-44313]](https://issues.apache.org/jira/browse/SPARK-44313): Fix generated column expression validation when there is a char/varchar column in the schema
+  - [[SPARK-44391]](https://issues.apache.org/jira/browse/SPARK-44391): Check the number of argument types in `InvokeLike`
+  - [[SPARK-44464]](https://issues.apache.org/jira/browse/SPARK-44464): Fix applyInPandasWithStatePythonRunner to output rows that have Null as first column value
+  - [[SPARK-44479]](https://issues.apache.org/jira/browse/SPARK-44479): Fix protobuf conversion from an empty struct type
+  - [[SPARK-44547]](https://issues.apache.org/jira/browse/SPARK-44547): Ignore fallback storage for cached RDD migration
+  - [[SPARK-44581]](https://issues.apache.org/jira/browse/SPARK-44581): Fix the bug that ShutdownHookManager gets wrong UGI from SecurityManager of ApplicationMaster
+  - [[SPARK-44588]](https://issues.apache.org/jira/browse/SPARK-44588): Fix double encryption issue for migrated shuffle blocks
+  - [[SPARK-44630]](https://issues.apache.org/jira/browse/SPARK-44630): Revert "[SPARK-43043] Improve the performance of MapOutputTracker.updateMapOutput"
+  - [[SPARK-44634]](https://issues.apache.org/jira/browse/SPARK-44634): Encoders.bean does no longer support nested beans with type arguments
+  - [[SPARK-44641]](https://issues.apache.org/jira/browse/SPARK-44641): Incorrect result in certain scenarios when SPJ is not triggered
+  - [[SPARK-44653]](https://issues.apache.org/jira/browse/SPARK-44653): Non-trivial DataFrame unions should not break caching
+  - [[SPARK-44657]](https://issues.apache.org/jira/browse/SPARK-44657): Fix incorrect limit handling in ArrowBatchWithSchemaIterator and config parsing of CONNECT_GRPC_ARROW_MAX_BATCH_SIZE
+  - [[SPARK-44805]](https://issues.apache.org/jira/browse/SPARK-44805): getBytes/getShorts/getInts/etc. should work in a column vector that has a dictionary
+  - [[SPARK-44840]](https://issues.apache.org/jira/browse/SPARK-44840): Make `array_insert()` 1-based for negative indexes
+  - [[SPARK-44846]](https://issues.apache.org/jira/browse/SPARK-44846): Convert the lower redundant Aggregate to Project in RemoveRedundantAggregates
+  - [[SPARK-44854]](https://issues.apache.org/jira/browse/SPARK-44854): Python timedelta to DayTimeIntervalType edge case bug
+  - [[SPARK-44857]](https://issues.apache.org/jira/browse/SPARK-44857): Fix `getBaseURI` error in Spark Worker LogPage UI buttons
+  - [[SPARK-44859]](https://issues.apache.org/jira/browse/SPARK-44859): Fix incorrect property name in structured streaming doc
+  - [[SPARK-44871]](https://issues.apache.org/jira/browse/SPARK-44871): Fix percentile_disc behaviour
+  - [[SPARK-44910]](https://issues.apache.org/jira/browse/SPARK-44910): Encoders.bean does not support superclasses with generic type arguments
+  - [[SPARK-44920]](https://issues.apache.org/jira/browse/SPARK-44920): Use await() instead of awaitUninterruptibly() in TransportClientFactory.createClient()
+  - [[SPARK-44925]](https://issues.apache.org/jira/browse/SPARK-44925): K8s default service token file should not be materialized into token
+  - [[SPARK-44935]](https://issues.apache.org/jira/browse/SPARK-44935): Fix `RELEASE` file to have the correct information in Docker images if exists
+  - [[SPARK-44937]](https://issues.apache.org/jira/browse/SPARK-44937): Mark connection as timedOut in TransportClient.close
+  - [[SPARK-44940]](https://issues.apache.org/jira/browse/SPARK-44940): Improve performance of JSON parsing when "spark.sql.json.enablePartialResults" is enabled
+  - [[SPARK-44973]](https://issues.apache.org/jira/browse/SPARK-44973): Fix `ArrayIndexOutOfBoundsException` in `conv()`
+  - [[SPARK-44990]](https://issues.apache.org/jira/browse/SPARK-44990): Reduce the frequency of get `spark.sql.legacy.nullValueWrittenAsQuotedEmptyStringCsv`
+  - [[SPARK-45054]](https://issues.apache.org/jira/browse/SPARK-45054): HiveExternalCatalog.listPartitions should restore partition statistics
+  - [[SPARK-45057]](https://issues.apache.org/jira/browse/SPARK-45057): Avoid acquire read lock when keepReadLock is false
+  - [[SPARK-45071]](https://issues.apache.org/jira/browse/SPARK-45071): Optimize the processing speed of `BinaryArithmetic#dataType` when processing multi-column data
+  - [[SPARK-45075]](https://issues.apache.org/jira/browse/SPARK-45075): Fix alter table with invalid default value will not report error
+  - [[SPARK-45078]](https://issues.apache.org/jira/browse/SPARK-45078): Fix `array_insert` ImplicitCastInputTypes not work
+  - [[SPARK-45079]](https://issues.apache.org/jira/browse/SPARK-45079): Fix an internal error from `percentile_approx()`on `NULL` accuracy
+  - [[SPARK-45081]](https://issues.apache.org/jira/browse/SPARK-45081): Encoders.bean does no longer work with read-only properties
+  - [[SPARK-45100]](https://issues.apache.org/jira/browse/SPARK-45100): Fix an internal error from `reflect()`on `NULL` class and method
+  - [[SPARK-45109]](https://issues.apache.org/jira/browse/SPARK-45109): Fix log function in Connect
+  - [[SPARK-45187]](https://issues.apache.org/jira/browse/SPARK-45187): Fix `WorkerPage` to use the same pattern for `logPage` urls
+  - [[SPARK-45227]](https://issues.apache.org/jira/browse/SPARK-45227): Fix a subtle thread-safety issue with CoarseGrainedExecutorBackend
+  - [[SPARK-45282]](https://issues.apache.org/jira/browse/SPARK-45282): Correctness issue in AQE with InMemoryTableScanExec
+  - [[SPARK-45389]](https://issues.apache.org/jira/browse/SPARK-45389): Correct MetaException matching rule on getting partition metadata
+  - [[SPARK-45430]](https://issues.apache.org/jira/browse/SPARK-45430): Fix for FramelessOffsetWindowFunction when IGNORE NULLS and offset > rowCount
+  - [[SPARK-45433]](https://issues.apache.org/jira/browse/SPARK-45433): Fix CSV/JSON schema inference when timestamps do not match specified timestampFormat
+  - [[SPARK-45473]](https://issues.apache.org/jira/browse/SPARK-45473): Fix incorrect error message for RoundBase
+  - [[SPARK-45508]](https://issues.apache.org/jira/browse/SPARK-45508): Add "--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED" so Platform can access Cleaner on Java 9+
+  - [[SPARK-45592]](https://issues.apache.org/jira/browse/SPARK-45592): Correctness issue in AQE with InMemoryTableScanExec
+  - [[SPARK-45604]](https://issues.apache.org/jira/browse/SPARK-45604): Add LogicalType checking on INT64 -> DateTime conversion on Parquet Vectorized Reader
+  - [[SPARK-45652]](https://issues.apache.org/jira/browse/SPARK-45652): SPJ: Handle empty input partitions after dynamic filtering
+  - [[SPARK-45670]](https://issues.apache.org/jira/browse/SPARK-45670): SparkSubmit does not support `--total-executor-cores` when deploying on K8s
+  - [[SPARK-45678]](https://issues.apache.org/jira/browse/SPARK-45678): Cover BufferReleasingInputStream.available/reset under tryOrFetchFailedException
+  - [[SPARK-45749]](https://issues.apache.org/jira/browse/SPARK-45749): Fix `Spark History Server` to sort `Duration` column properly
+  - [[SPARK-45786]](https://issues.apache.org/jira/browse/SPARK-45786): Fix inaccurate Decimal multiplication and division results
+  - [[SPARK-45814]](https://issues.apache.org/jira/browse/SPARK-45814): Make ArrowConverters.createEmptyArrowBatch call close() to avoid memory leak
+  - [[SPARK-45882]](https://issues.apache.org/jira/browse/SPARK-45882): BroadcastHashJoinExec propagate partitioning should respect CoalescedHashPartitioning
+  - [[SPARK-45896]](https://issues.apache.org/jira/browse/SPARK-45896): Construct `ValidateExternalType` with the correct expected type
+  - [[SPARK-45920]](https://issues.apache.org/jira/browse/SPARK-45920): group by ordinal should be idempotent
+  - [[SPARK-46006]](https://issues.apache.org/jira/browse/SPARK-46006): YarnAllocator miss clean targetNumExecutorsPerResourceProfileId after YarnSchedulerBackend call stop
+  - [[SPARK-46012]](https://issues.apache.org/jira/browse/SPARK-46012): EventLogFileReader should not read rolling logs if app status file is missing
+  - [[SPARK-46062]](https://issues.apache.org/jira/browse/SPARK-46062): Sync the isStreaming flag between CTE definition and reference
+  - [[SPARK-46064]](https://issues.apache.org/jira/browse/SPARK-46064): Move out EliminateEventTimeWatermark to the analyzer and change to only take effect on resolved child
+
+### Dependency Changes
+
+While being a maintenance release we did still upgrade some dependencies in this release they are:
+
+  - [[SPARK-44415]](https://issues.apache.org/jira/browse/SPARK-44415): Upgrade snappy-java to 1.1.10.2
+  - [[SPARK-44513]](https://issues.apache.org/jira/browse/SPARK-44513): Upgrade snappy-java to 1.1.10.3
+  - [[SPARK-45103]](https://issues.apache.org/jira/browse/SPARK-45103): Update ORC to 1.8.5
+  - [[SPARK-45884]](https://issues.apache.org/jira/browse/SPARK-45884): Update ORC to 1.8.6
+
+You can consult JIRA for the [detailed changes](https://s.apache.org/spark-3.4.2).
+
+We would like to acknowledge all community members for contributing patches to this release.
+
+
+

--- a/site/committers.html
+++ b/site/committers.html
@@ -678,6 +678,9 @@ of the immediate bug being fixed.</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -686,9 +689,6 @@ of the immediate bug being fixed.</li>
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/community.html
+++ b/site/community.html
@@ -365,6 +365,9 @@ Add yours by emailing `dev@spark.apache.org`.
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -373,9 +376,6 @@ Add yours by emailing `dev@spark.apache.org`.
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -675,6 +675,9 @@ to ask on the <code class="language-plaintext highlighter-rouge">dev@spark.apach
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -683,9 +686,6 @@ to ask on the <code class="language-plaintext highlighter-rouge">dev@spark.apach
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -704,6 +704,9 @@ compatible with usage in an Open Source project and inclusion of the generated c
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -712,9 +715,6 @@ compatible with usage in an Open Source project and inclusion of the generated c
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -145,6 +145,7 @@
 
 <ul>
   <li><a href="/docs/3.5.0/">Spark 3.5.0</a></li>
+  <li><a href="/docs/3.4.2/">Spark 3.4.2</a></li>
   <li><a href="/docs/3.4.1/">Spark 3.4.1</a></li>
   <li><a href="/docs/3.4.0/">Spark 3.4.0</a></li>
   <li><a href="/docs/3.3.3/">Spark 3.3.3</a></li> 
@@ -358,6 +359,9 @@ The <a href="/research.html">research page</a> lists some of the original motiva
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -366,9 +370,6 @@ The <a href="/research.html">research page</a> lists some of the original motiva
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -203,6 +203,9 @@ before deciding to use it.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -211,9 +214,6 @@ before deciding to use it.</p>
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/error-message-guidelines.html
+++ b/site/error-message-guidelines.html
@@ -542,6 +542,9 @@ be redundant; you may skip an explicit explanation in this case.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -550,9 +553,6 @@ be redundant; you may skip an explicit explanation in this case.</p>
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/examples.html
+++ b/site/examples.html
@@ -544,6 +544,9 @@ We learn to predict the labels from feature vectors using the Logistic Regressio
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -552,9 +555,6 @@ We learn to predict the labels from feature vectors using the Logistic Regressio
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/faq.html
+++ b/site/faq.html
@@ -212,6 +212,9 @@ Please also refer to our
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -220,9 +223,6 @@ Please also refer to our
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -257,6 +257,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -265,9 +268,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/history.html
+++ b/site/history.html
@@ -166,6 +166,9 @@ You can get involved in Apache Spark development by reading
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -174,9 +177,6 @@ You can get involved in Apache Spark development by reading
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -238,6 +238,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -246,9 +249,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -28,7 +28,7 @@ var packagesV13 = [hadoop3p, hadoop3pscala213, hadoop2p, hadoopFree, sources];
 var packagesV14 = [hadoop3p, hadoop3pscala213, hadoopFree, sources];
 
 addRelease("3.5.0", new Date("09/13/2023"), packagesV14, true);
-addRelease("3.4.1", new Date("06/23/2023"), packagesV14, true);
+addRelease("3.4.2", new Date("11/30/2023"), packagesV14, true);
 addRelease("3.3.3", new Date("08/21/2023"), packagesV13, true);
 addRelease("3.2.4", new Date("04/13/2023"), packagesV12, true);
 

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -150,6 +150,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -158,9 +161,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -303,6 +303,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -311,9 +314,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/3-1-3-released.html
+++ b/site/news/3-1-3-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -143,6 +143,15 @@
 
 <article class="hentry">
     <header class="entry-header">
+      <h3 class="entry-title"><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a></h3>
+      <div class="entry-date">November 30, 2023</div>
+    </header>
+    <div class="entry-content"><p>We are happy to announce the availability of <a href="/releases/spark-release-3-4-2.html" title="Spark Release 3.4.2">Spark 3.4.2</a>! Visit the <a href="/releases/spark-release-3-4-2.html" title="Spark Release 3.4.2">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+</div>
+  </article>
+
+<article class="hentry">
+    <header class="entry-header">
       <h3 class="entry-title"><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a></h3>
       <div class="entry-date">September 13, 2023</div>
     </header>
@@ -1326,6 +1335,9 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -1334,9 +1346,6 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/new-repository-service.html
+++ b/site/news/new-repository-service.html
@@ -162,6 +162,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -170,9 +173,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/next-official-release-spark-3.1.1.html
+++ b/site/news/next-official-release-spark-3.1.1.html
@@ -168,6 +168,9 @@ are no guarantees on using it such as binary compatibility.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -176,9 +179,6 @@ are no guarantees on using it such as binary compatibility.</p>
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -162,6 +162,9 @@ online to attend in person. We hope you enjoy the event!</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -170,9 +173,6 @@ online to attend in person. We hope you enjoy the event!</p>
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/plan-for-dropping-python-2-support.html
+++ b/site/news/plan-for-dropping-python-2-support.html
@@ -172,6 +172,9 @@ Python 2. However, after Python 2 EOL, we might not take patches that are specif
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -180,9 +183,6 @@ Python 2. However, after Python 2 EOL, we might not take patches that are specif
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/sigmod-system-award.html
+++ b/site/news/sigmod-system-award.html
@@ -167,6 +167,9 @@ the whole community earned together.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -175,9 +178,6 @@ the whole community earned together.</p>
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -163,6 +163,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -171,9 +174,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -162,6 +162,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -170,9 +173,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -161,6 +161,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -169,9 +172,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -159,6 +159,9 @@ This release expands Spark&#8217;s standard libraries, introducing a new SQL pac
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -167,9 +170,6 @@ This release expands Spark&#8217;s standard libraries, introducing a new SQL pac
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -162,6 +162,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -170,9 +173,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -157,6 +157,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -165,9 +168,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -157,6 +157,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -165,9 +168,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-3-released.html
+++ b/site/news/spark-2-1-3-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -157,6 +157,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -165,9 +168,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-2-released.html
+++ b/site/news/spark-2-2-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-1-released.html
+++ b/site/news/spark-2-3-1-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-2-released.html
+++ b/site/news/spark-2-3-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-3-released.html
+++ b/site/news/spark-2-3-3-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-4-released.html
+++ b/site/news/spark-2-3-4-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-0-released.html
+++ b/site/news/spark-2-4-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-1-released.html
+++ b/site/news/spark-2-4-1-released.html
@@ -157,6 +157,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -165,9 +168,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-2-released.html
+++ b/site/news/spark-2-4-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-3-released.html
+++ b/site/news/spark-2-4-3-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-4-released.html
+++ b/site/news/spark-2-4-4-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-5-released.html
+++ b/site/news/spark-2-4-5-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-6.html
+++ b/site/news/spark-2-4-6.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-7-released.html
+++ b/site/news/spark-2-4-7-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-8-released.html
+++ b/site/news/spark-2-4-8-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-0-released.html
+++ b/site/news/spark-3-0-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-1-released.html
+++ b/site/news/spark-3-0-1-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-2-released.html
+++ b/site/news/spark-3-0-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-3-released.html
+++ b/site/news/spark-3-0-3-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-1-released.html
+++ b/site/news/spark-3-1-1-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-2-released.html
+++ b/site/news/spark-3-1-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-0-released.html
+++ b/site/news/spark-3-2-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-1-released.html
+++ b/site/news/spark-3-2-1-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-2-released.html
+++ b/site/news/spark-3-2-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-3-released.html
+++ b/site/news/spark-3-2-3-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-4-released.html
+++ b/site/news/spark-3-2-4-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-0-released.html
+++ b/site/news/spark-3-3-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-1-released.html
+++ b/site/news/spark-3-3-1-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-2-released.html
+++ b/site/news/spark-3-3-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-3-released.html
+++ b/site/news/spark-3-3-3-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-4-0-released.html
+++ b/site/news/spark-3-4-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-4-1-released.html
+++ b/site/news/spark-3-4-1-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-4-2-released.html
+++ b/site/news/spark-3-4-2-released.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark Screencast Archive | Apache Spark
+     Spark 3.4.2 released | Apache Spark
     
   </title>
 
@@ -139,48 +139,16 @@
 <div class="container">
   <div class="row mt-4">
     <div class="col-12 col-md-9">
-      <h2 id="spark-screencast-archive">Spark Screencast Archive</h2>
+      <h2>Spark 3.4.2 released</h2>
 
-<article class="hentry">
-    <header class="entry-header">
-      <h1 class="entry-title"><a href="/screencasts/4-a-standalone-job-in-spark.html">A Standalone Job in Scala - Spark Screencast #4</a></h1>
-      <div class="entry-meta">August 26, 2013</div>
-    </header>
-    <div class="entry-content"><p>In this Spark screencast, we create a standalone Apache Spark job in Scala. In the job, we create a spark context and read a file into an RDD of strings; then apply transformations and actions to the RDD and print out the results.</p>
-</div>
-  </article>
 
-<article class="hentry">
-    <header class="entry-header">
-      <h1 class="entry-title"><a href="/screencasts/3-transformations-and-caching.html">Transformations and Caching - Spark Screencast #3</a></h1>
-      <div class="entry-meta">April 16, 2013</div>
-    </header>
-    <div class="entry-content"><p>In this third Spark screencast, we demonstrate more advanced use of RDD actions and transformations, as well as caching RDDs in memory.</p>
-</div>
-  </article>
+<p>We are happy to announce the availability of <a href="/releases/spark-release-3-4-2.html" title="Spark Release 3.4.2">Spark 3.4.2</a>! Visit the <a href="/releases/spark-release-3-4-2.html" title="Spark Release 3.4.2">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
 
-<article class="hentry">
-    <header class="entry-header">
-      <h1 class="entry-title"><a href="/screencasts/2-spark-documentation-overview.html">Spark Documentation Overview – Screencast #2</a></h1>
-      <div class="entry-meta">April 11, 2013</div>
-    </header>
-    <div class="entry-content"><p>This is our 2nd Spark screencast. In it, we take a tour of the documentation available for Spark users online.</p>
-</div>
-  </article>
 
-<article class="hentry">
-    <header class="entry-header">
-      <h1 class="entry-title"><a href="/screencasts/1-first-steps-with-spark.html">First Steps with Spark - Screencast #1</a></h1>
-      <div class="entry-meta">April 10, 2013</div>
-    </header>
-    <div class="entry-content"><p>This screencast marks the beginning of a series of hands-on screencasts we will be publishing to help new users get up and running in minutes. In this screencast, we:</p>
-<ol>
-  <li>Download and build Spark on a local machine (running OS X, but should be a similar process for Linux or Unix).</li>
-  <li>Introduce the API using the Spark interactive shell to explore a file.</li>
-</ol>
-</div>
-  </article>
-
+<p>
+<br/>
+<a href="/news/">Spark News Archive</a>
+</p>
 
     </div>
     <div class="col-12 col-md-3">

--- a/site/news/spark-3-5-0-released.html
+++ b/site/news/spark-3-5-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview.html
+++ b/site/news/spark-3.0.0-preview.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview2.html
+++ b/site/news/spark-3.0.0-preview2.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-apr-2019-agenda-posted.html
+++ b/site/news/spark-ai-summit-apr-2019-agenda-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-june-2020-agenda-posted.html
+++ b/site/news/spark-ai-summit-june-2020-agenda-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -166,6 +166,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -174,9 +177,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -167,6 +167,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -175,9 +178,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-release-2-2-3.html
+++ b/site/news/spark-release-2-2-3.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -162,6 +162,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -170,9 +173,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -162,6 +162,9 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -170,9 +173,6 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -164,6 +164,9 @@ about the latest happenings in Spark.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -172,9 +175,6 @@ about the latest happenings in Spark.</p>
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2015.html
+++ b/site/news/spark-summit-east-agenda-posted-2015.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2016.html
+++ b/site/news/spark-summit-east-agenda-posted-2016.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -157,6 +157,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -165,9 +168,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-oct-2018-agenda-posted.html
+++ b/site/news/spark-summit-oct-2018-agenda-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -161,6 +161,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -169,9 +172,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -163,6 +163,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -171,9 +174,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -162,6 +162,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -170,9 +173,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -165,6 +165,9 @@ on Spark.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -173,9 +176,6 @@ on Spark.</p>
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -157,6 +157,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -165,9 +168,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -166,6 +166,9 @@ online to attend in person. Otherwise, the Summit will offer a free live video s
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -174,9 +177,6 @@ online to attend in person. Otherwise, the Summit will offer a free live video s
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -507,6 +507,9 @@ to process islands identified from a search robor</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -515,9 +518,6 @@ to process islands identified from a search robor</li>
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -558,6 +558,9 @@ and then send an e-mail to the mailing list with a subject that looks something 
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -566,9 +569,6 @@ and then send an e-mail to the mailing list with a subject that looks something 
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -207,6 +207,9 @@ squares.saveAsSequenceFile(<span class="string">"hdfs://..."</span>)
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -215,9 +218,6 @@ squares.saveAsSequenceFile(<span class="string">"hdfs://..."</span>)
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -179,6 +179,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -187,9 +190,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -189,6 +189,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -197,9 +200,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -233,6 +233,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -241,9 +244,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -186,6 +186,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -194,9 +197,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -255,6 +255,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -263,9 +266,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -197,6 +197,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -205,9 +208,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -191,6 +191,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -199,9 +202,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -286,6 +286,9 @@ We’d especially like to thank Patrick Wendell for acting as the release manage
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -294,9 +297,6 @@ We’d especially like to thank Patrick Wendell for acting as the release manage
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -250,6 +250,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -258,9 +261,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -344,6 +344,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -352,9 +355,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -262,6 +262,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -270,9 +273,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -235,6 +235,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -243,9 +246,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -328,6 +328,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -336,9 +339,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -286,6 +286,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -294,9 +297,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -243,6 +243,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -251,9 +254,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -379,6 +379,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -387,9 +390,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -265,6 +265,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -273,9 +276,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -393,6 +393,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -401,9 +404,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -265,6 +265,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -273,9 +276,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -225,6 +225,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -233,9 +236,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -370,6 +370,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -378,9 +381,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -257,6 +257,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -265,9 +268,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -484,6 +484,9 @@ Python coverage. MLlib also adds several new algorithms.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -492,9 +495,6 @@ Python coverage. MLlib also adds several new algorithms.</p>
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -289,6 +289,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -297,9 +300,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -422,6 +422,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -430,9 +433,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -161,6 +161,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -169,9 +172,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -298,6 +298,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -306,9 +309,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -394,6 +394,9 @@ yzhou2001, zhonghaihua, zhuol, zlpmichelle, Örjan Lundberg, Łukasz Gieroń</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -402,9 +405,6 @@ yzhou2001, zhonghaihua, zhuol, zlpmichelle, Örjan Lundberg, Łukasz Gieroń</p>
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -162,6 +162,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -170,9 +173,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -306,6 +306,9 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Roberts, Adrian Petrescu, Ahmed Mahran
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -314,9 +317,6 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Roberts, Adrian Petrescu, Ahmed Mahran
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-3.html
+++ b/site/releases/spark-release-2-1-3.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -372,6 +372,9 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Budde, Adam Roberts, Adrian Ionescu, A
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -380,9 +383,6 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Budde, Adam Roberts, Adrian Ionescu, A
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-2.html
+++ b/site/releases/spark-release-2-2-2.html
@@ -162,6 +162,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -170,9 +173,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-3.html
+++ b/site/releases/spark-release-2-2-3.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -382,6 +382,9 @@ ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Albe
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -390,9 +393,6 @@ ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Albe
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-1.html
+++ b/site/releases/spark-release-2-3-1.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-2.html
+++ b/site/releases/spark-release-2-3-2.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-3.html
+++ b/site/releases/spark-release-2-3-3.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-4.html
+++ b/site/releases/spark-release-2-3-4.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-0.html
+++ b/site/releases/spark-release-2-4-0.html
@@ -388,6 +388,9 @@ Achuth17, Adam Bradbury, Adamyuanyuan, Adelbert Chang, Ala Luszczak, Aleksandr K
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -396,9 +399,6 @@ Achuth17, Adam Bradbury, Adamyuanyuan, Adelbert Chang, Ala Luszczak, Aleksandr K
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-1.html
+++ b/site/releases/spark-release-2-4-1.html
@@ -198,6 +198,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -206,9 +209,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-2.html
+++ b/site/releases/spark-release-2-4-2.html
@@ -170,6 +170,9 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -178,9 +181,6 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-3.html
+++ b/site/releases/spark-release-2-4-3.html
@@ -168,6 +168,9 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -176,9 +179,6 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-4.html
+++ b/site/releases/spark-release-2-4-4.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-5.html
+++ b/site/releases/spark-release-2-4-5.html
@@ -188,6 +188,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -196,9 +199,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-6.html
+++ b/site/releases/spark-release-2-4-6.html
@@ -196,6 +196,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -204,9 +207,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-7.html
+++ b/site/releases/spark-release-2-4-7.html
@@ -238,6 +238,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -246,9 +249,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-8.html
+++ b/site/releases/spark-release-2-4-8.html
@@ -239,6 +239,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -247,9 +250,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-0.html
+++ b/site/releases/spark-release-3-0-0.html
@@ -548,6 +548,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -556,9 +559,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-1.html
+++ b/site/releases/spark-release-3-0-1.html
@@ -197,6 +197,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -205,9 +208,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-2.html
+++ b/site/releases/spark-release-3-0-2.html
@@ -207,6 +207,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -215,9 +218,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-3.html
+++ b/site/releases/spark-release-3-0-3.html
@@ -224,6 +224,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -232,9 +235,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-1.html
+++ b/site/releases/spark-release-3-1-1.html
@@ -585,6 +585,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -593,9 +596,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-2.html
+++ b/site/releases/spark-release-3-1-2.html
@@ -272,6 +272,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -280,9 +283,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-3.html
+++ b/site/releases/spark-release-3-1-3.html
@@ -186,6 +186,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -194,9 +197,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-0.html
+++ b/site/releases/spark-release-3-2-0.html
@@ -558,6 +558,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -566,9 +569,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-1.html
+++ b/site/releases/spark-release-3-2-1.html
@@ -191,6 +191,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -199,9 +202,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-2.html
+++ b/site/releases/spark-release-3-2-2.html
@@ -266,6 +266,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -274,9 +277,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-3.html
+++ b/site/releases/spark-release-3-2-3.html
@@ -239,6 +239,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -247,9 +250,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-4.html
+++ b/site/releases/spark-release-3-2-4.html
@@ -201,6 +201,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -209,9 +212,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-0.html
+++ b/site/releases/spark-release-3-3-0.html
@@ -738,6 +738,9 @@ Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</sp
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -746,9 +749,6 @@ Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</sp
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-1.html
+++ b/site/releases/spark-release-3-3-1.html
@@ -248,6 +248,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -256,9 +259,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-2.html
+++ b/site/releases/spark-release-3-3-2.html
@@ -325,6 +325,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -333,9 +336,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-3.html
+++ b/site/releases/spark-release-3-3-3.html
@@ -180,6 +180,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -188,9 +191,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-4-0.html
+++ b/site/releases/spark-release-3-4-0.html
@@ -566,6 +566,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -574,9 +577,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-4-1.html
+++ b/site/releases/spark-release-3-4-1.html
@@ -253,6 +253,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -261,9 +264,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-4-2.html
+++ b/site/releases/spark-release-3-4-2.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>
+     Spark Release 3.4.2 | Apache Spark
+    
+  </title>
+
+  
+
+  
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
+  <link href="/css/custom.css" rel="stylesheet">
+  <!-- Code highlighter CSS -->
+  <link href="/css/pygments-default.css" rel="stylesheet">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+  <!-- Matomo -->
+  <script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["disableCookies"]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="https://analytics.apache.org/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '40']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
+</head>
+<body class="global">
+<nav class="navbar navbar-expand-lg navbar-dark p-0 px-4" style="background: #1D6890;">
+  <a class="navbar-brand" href="/">
+    <img src="/images/spark-logo-rev.svg" alt="" width="141" height="72">
+  </a>
+  <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent"
+          aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse col-md-12 col-lg-auto pt-4" id="navbarContent">
+
+    <ul class="navbar-nav me-auto">
+      <li class="nav-item">
+        <a class="nav-link active" aria-current="page" href="/downloads.html">Download</a>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="libraries" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Libraries
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="libraries">
+          <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
+          <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
+          <li>
+            <hr class="dropdown-divider">
+          </li>
+          <li><a class="dropdown-item" href="/third-party-projects.html">Third-Party Projects</a></li>
+        </ul>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="documentation" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Documentation
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="documentation">
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release</a></li>
+          <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
+          <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
+        </ul>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link active" aria-current="page" href="/examples.html">Examples</a>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="community" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Community
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="community">
+          <li><a class="dropdown-item" href="/community.html">Mailing Lists &amp; Resources</a></li>
+          <li><a class="dropdown-item" href="/contributing.html">Contributing to Spark</a></li>
+          <li><a class="dropdown-item" href="/improvement-proposals.html">Improvement Proposals (SPIP)</a>
+          </li>
+          <li><a class="dropdown-item" href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a>
+          </li>
+          <li><a class="dropdown-item" href="/powered-by.html">Powered By</a></li>
+          <li><a class="dropdown-item" href="/committers.html">Project Committers</a></li>
+          <li><a class="dropdown-item" href="/history.html">Project History</a></li>
+        </ul>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="developers" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Developers
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="developers">
+          <li><a class="dropdown-item" href="/developer-tools.html">Useful Developer Tools</a></li>
+          <li><a class="dropdown-item" href="/versioning-policy.html">Versioning Policy</a></li>
+          <li><a class="dropdown-item" href="/release-process.html">Release Process</a></li>
+          <li><a class="dropdown-item" href="/security.html">Security</a></li>
+        </ul>
+      </li>
+    </ul>
+    <ul class="navbar-nav ml-auto">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="apacheFoundation" role="button"
+           data-bs-toggle="dropdown" aria-expanded="false">
+          Apache Software Foundation
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="apacheFoundation">
+          <li><a class="dropdown-item" href="https://www.apache.org/">Apache Homepage</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/licenses/">License</a></li>
+          <li><a class="dropdown-item"
+                 href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/security/">Security</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/events/current-event">Event</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</nav>
+
+<div class="container">
+  <div class="row mt-4">
+    <div class="col-12 col-md-9">
+      <h2>Spark Release 3.4.2</h2>
+
+
+<p>Spark 3.4.2 is a maintenance release containing security and correctness fixes. This release is based on the branch-3.4 maintenance branch of Spark. We strongly recommend all 3.4 users to upgrade to this stable release.</p>
+
+<h3 id="notable-changes">Notable changes</h3>
+
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-42784">[SPARK-42784]</a>: should still create subDir when the number of subDir in merge dir is less than conf</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-43203">[SPARK-43203]</a>: Fix DROP table behavior in session catalog</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-43393">[SPARK-43393]</a>: Address sequence expression overflow bug</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44040">[SPARK-44040]</a>: Fix compute stats when AggregateExec node above QueryStageExec</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44079">[SPARK-44079]</a>: Fix <code class="language-plaintext highlighter-rouge">ArrayIndexOutOfBoundsException</code> when parse array as struct using PERMISSIVE mode with corrupt record</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44134">[SPARK-44134]</a>: Fix setting resources (GPU/FPGA) to 0 when they are set in spark-defaults.conf</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44136">[SPARK-44136]</a>: Fixed an issue that StateManager may get materialized in executor instead of driver in FlatMapGroupsWithStateExec</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44142">[SPARK-44142]</a>: Replace type with tpe in utility to convert python types to spark types</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44180">[SPARK-44180]</a>: DistributionAndOrderingUtils should apply ResolveTimeZone</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44206">[SPARK-44206]</a>: DataSet.selectExpr scope Session.active</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44215">[SPARK-44215]</a>: If num chunks are 0, then server should throw a RuntimeException</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44241">[SPARK-44241]</a>: Mistakenly set io.connectionTimeout/connectionCreationTimeout to zero or negative will cause incessant executor cons/destructions</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44251">[SPARK-44251]</a>: Set nullable correctly on coalesced join key in full outer USING join</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44313">[SPARK-44313]</a>: Fix generated column expression validation when there is a char/varchar column in the schema</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44391">[SPARK-44391]</a>: Check the number of argument types in <code class="language-plaintext highlighter-rouge">InvokeLike</code></li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44464">[SPARK-44464]</a>: Fix applyInPandasWithStatePythonRunner to output rows that have Null as first column value</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44479">[SPARK-44479]</a>: Fix protobuf conversion from an empty struct type</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44547">[SPARK-44547]</a>: Ignore fallback storage for cached RDD migration</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44581">[SPARK-44581]</a>: Fix the bug that ShutdownHookManager gets wrong UGI from SecurityManager of ApplicationMaster</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44588">[SPARK-44588]</a>: Fix double encryption issue for migrated shuffle blocks</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44630">[SPARK-44630]</a>: Revert &#8220;[SPARK-43043] Improve the performance of MapOutputTracker.updateMapOutput&#8221;</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44634">[SPARK-44634]</a>: Encoders.bean does no longer support nested beans with type arguments</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44641">[SPARK-44641]</a>: Incorrect result in certain scenarios when SPJ is not triggered</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44653">[SPARK-44653]</a>: Non-trivial DataFrame unions should not break caching</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44657">[SPARK-44657]</a>: Fix incorrect limit handling in ArrowBatchWithSchemaIterator and config parsing of CONNECT_GRPC_ARROW_MAX_BATCH_SIZE</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44805">[SPARK-44805]</a>: getBytes/getShorts/getInts/etc. should work in a column vector that has a dictionary</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44840">[SPARK-44840]</a>: Make <code class="language-plaintext highlighter-rouge">array_insert()</code> 1-based for negative indexes</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44846">[SPARK-44846]</a>: Convert the lower redundant Aggregate to Project in RemoveRedundantAggregates</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44854">[SPARK-44854]</a>: Python timedelta to DayTimeIntervalType edge case bug</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44857">[SPARK-44857]</a>: Fix <code class="language-plaintext highlighter-rouge">getBaseURI</code> error in Spark Worker LogPage UI buttons</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44859">[SPARK-44859]</a>: Fix incorrect property name in structured streaming doc</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44871">[SPARK-44871]</a>: Fix percentile_disc behaviour</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44910">[SPARK-44910]</a>: Encoders.bean does not support superclasses with generic type arguments</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44920">[SPARK-44920]</a>: Use await() instead of awaitUninterruptibly() in TransportClientFactory.createClient()</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44925">[SPARK-44925]</a>: K8s default service token file should not be materialized into token</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44935">[SPARK-44935]</a>: Fix <code class="language-plaintext highlighter-rouge">RELEASE</code> file to have the correct information in Docker images if exists</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44937">[SPARK-44937]</a>: Mark connection as timedOut in TransportClient.close</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44940">[SPARK-44940]</a>: Improve performance of JSON parsing when &#8220;spark.sql.json.enablePartialResults&#8221; is enabled</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44973">[SPARK-44973]</a>: Fix <code class="language-plaintext highlighter-rouge">ArrayIndexOutOfBoundsException</code> in <code class="language-plaintext highlighter-rouge">conv()</code></li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44990">[SPARK-44990]</a>: Reduce the frequency of get <code class="language-plaintext highlighter-rouge">spark.sql.legacy.nullValueWrittenAsQuotedEmptyStringCsv</code></li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45054">[SPARK-45054]</a>: HiveExternalCatalog.listPartitions should restore partition statistics</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45057">[SPARK-45057]</a>: Avoid acquire read lock when keepReadLock is false</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45071">[SPARK-45071]</a>: Optimize the processing speed of <code class="language-plaintext highlighter-rouge">BinaryArithmetic#dataType</code> when processing multi-column data</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45075">[SPARK-45075]</a>: Fix alter table with invalid default value will not report error</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45078">[SPARK-45078]</a>: Fix <code class="language-plaintext highlighter-rouge">array_insert</code> ImplicitCastInputTypes not work</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45079">[SPARK-45079]</a>: Fix an internal error from <code class="language-plaintext highlighter-rouge">percentile_approx()</code>on <code class="language-plaintext highlighter-rouge">NULL</code> accuracy</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45081">[SPARK-45081]</a>: Encoders.bean does no longer work with read-only properties</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45100">[SPARK-45100]</a>: Fix an internal error from <code class="language-plaintext highlighter-rouge">reflect()</code>on <code class="language-plaintext highlighter-rouge">NULL</code> class and method</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45109">[SPARK-45109]</a>: Fix log function in Connect</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45187">[SPARK-45187]</a>: Fix <code class="language-plaintext highlighter-rouge">WorkerPage</code> to use the same pattern for <code class="language-plaintext highlighter-rouge">logPage</code> urls</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45227">[SPARK-45227]</a>: Fix a subtle thread-safety issue with CoarseGrainedExecutorBackend</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45282">[SPARK-45282]</a>: Correctness issue in AQE with InMemoryTableScanExec</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45389">[SPARK-45389]</a>: Correct MetaException matching rule on getting partition metadata</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45430">[SPARK-45430]</a>: Fix for FramelessOffsetWindowFunction when IGNORE NULLS and offset &gt; rowCount</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45433">[SPARK-45433]</a>: Fix CSV/JSON schema inference when timestamps do not match specified timestampFormat</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45473">[SPARK-45473]</a>: Fix incorrect error message for RoundBase</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45508">[SPARK-45508]</a>: Add &#8220;&#8211;add-opens=java.base/jdk.internal.ref=ALL-UNNAMED&#8221; so Platform can access Cleaner on Java 9+</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45592">[SPARK-45592]</a>: Correctness issue in AQE with InMemoryTableScanExec</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45604">[SPARK-45604]</a>: Add LogicalType checking on INT64 -&gt; DateTime conversion on Parquet Vectorized Reader</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45652">[SPARK-45652]</a>: SPJ: Handle empty input partitions after dynamic filtering</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45670">[SPARK-45670]</a>: SparkSubmit does not support <code class="language-plaintext highlighter-rouge">--total-executor-cores</code> when deploying on K8s</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45678">[SPARK-45678]</a>: Cover BufferReleasingInputStream.available/reset under tryOrFetchFailedException</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45749">[SPARK-45749]</a>: Fix <code class="language-plaintext highlighter-rouge">Spark History Server</code> to sort <code class="language-plaintext highlighter-rouge">Duration</code> column properly</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45786">[SPARK-45786]</a>: Fix inaccurate Decimal multiplication and division results</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45814">[SPARK-45814]</a>: Make ArrowConverters.createEmptyArrowBatch call close() to avoid memory leak</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45882">[SPARK-45882]</a>: BroadcastHashJoinExec propagate partitioning should respect CoalescedHashPartitioning</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45896">[SPARK-45896]</a>: Construct <code class="language-plaintext highlighter-rouge">ValidateExternalType</code> with the correct expected type</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45920">[SPARK-45920]</a>: group by ordinal should be idempotent</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46006">[SPARK-46006]</a>: YarnAllocator miss clean targetNumExecutorsPerResourceProfileId after YarnSchedulerBackend call stop</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46012">[SPARK-46012]</a>: EventLogFileReader should not read rolling logs if app status file is missing</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46062">[SPARK-46062]</a>: Sync the isStreaming flag between CTE definition and reference</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46064">[SPARK-46064]</a>: Move out EliminateEventTimeWatermark to the analyzer and change to only take effect on resolved child</li>
+</ul>
+
+<h3 id="dependency-changes">Dependency Changes</h3>
+
+<p>While being a maintenance release we did still upgrade some dependencies in this release they are:</p>
+
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44415">[SPARK-44415]</a>: Upgrade snappy-java to 1.1.10.2</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44513">[SPARK-44513]</a>: Upgrade snappy-java to 1.1.10.3</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45103">[SPARK-45103]</a>: Update ORC to 1.8.5</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45884">[SPARK-45884]</a>: Update ORC to 1.8.6</li>
+</ul>
+
+<p>You can consult JIRA for the <a href="https://s.apache.org/spark-3.4.2">detailed changes</a>.</p>
+
+<p>We would like to acknowledge all community members for contributing patches to this release.</p>
+
+
+
+<p>
+<br/>
+<a href="/news/">Spark News Archive</a>
+</p>
+
+    </div>
+    <div class="col-12 col-md-3">
+      <div class="news" style="margin-bottom: 20px;">
+        <h5>Latest News</h5>
+        <ul class="list-unstyled">
+          
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
+          <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
+            <span class="small">(Sep 13, 2023)</span></li>
+          
+          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
+            <span class="small">(Aug 21, 2023)</span></li>
+          
+          <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
+            <span class="small">(Jun 23, 2023)</span></li>
+          
+        </ul>
+        <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
+      </div>
+      <div style="text-align:center; margin-bottom: 20px;">
+        <a href="https://www.apache.org/events/current-event.html">
+          <img src="https://www.apache.org/events/current-event-234x60.png" style="max-width: 100%;"/>
+        </a>
+      </div>
+      <div class="hidden-xs hidden-sm">
+        <a href="/downloads.html" class="btn btn-cta btn-lg d-grid" style="margin-bottom: 30px;">
+          Download Spark
+        </a>
+        <p style="font-size: 16px; font-weight: 500; color: #555;">
+          Built-in Libraries:
+        </p>
+        <ul class="list-none">
+          <li><a href="/sql/">SQL and DataFrames</a></li>
+          <li><a href="/streaming/">Spark Streaming</a></li>
+          <li><a href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a href="/graphx/">GraphX (graph)</a></li>
+        </ul>
+        <a href="/third-party-projects.html">Third-Party Projects</a>
+      </div>
+    </div>
+  </div>
+
+  
+
+  <footer class="small">
+    <hr>
+    Apache Spark, Spark, Apache, the Apache feather logo, and the Apache Spark project logo are either registered
+    trademarks or trademarks of The Apache Software Foundation in the United States and other countries.
+    See guidance on use of Apache Spark <a href="/trademarks.html">trademarks</a>.
+    All other marks mentioned may be trademarks or registered trademarks of their respective owners.
+    Copyright &copy; 2018 The Apache Software Foundation, Licensed under the
+    <a href="https://www.apache.org/licenses/">Apache License, Version 2.0</a>.
+  </footer>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+        crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery.js"></script>
+<script src="/js/lang-tabs.js"></script>
+<script src="/js/downloads.js"></script>
+</body>
+</html>

--- a/site/releases/spark-release-3-5-0.html
+++ b/site/releases/spark-release-3-5-0.html
@@ -535,6 +535,9 @@ Adam Binford, Ahmed Hussein, Alex Jing, Alice Sayutina, Alkis Evlogimenos, Allan
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -543,9 +546,6 @@ Adam Binford, Ahmed Hussein, Alex Jing, Alice Sayutina, Alkis Evlogimenos, Allan
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/research.html
+++ b/site/research.html
@@ -204,6 +204,9 @@ Spark offers an abstraction called <a href="http://people.csail.mit.edu/matei/pa
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -212,9 +215,6 @@ Spark offers an abstraction called <a href="http://people.csail.mit.edu/matei/pa
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -166,6 +166,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -174,9 +177,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -166,6 +166,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -174,9 +177,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -162,6 +162,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -170,9 +173,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/security.html
+++ b/site/security.html
@@ -667,6 +667,9 @@ PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -675,9 +678,6 @@ PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -144,6 +144,14 @@
 </url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
+  <loc>https://spark.apache.org/releases/spark-release-3-4-2.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/news/spark-3-4-2-released.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/releases/spark-release-3-5-0.html</loc>
   <changefreq>weekly</changefreq>
 </url>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -302,6 +302,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -310,9 +313,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -244,6 +244,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -252,9 +255,6 @@
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -247,6 +247,9 @@ transforming, and analyzing genomic data using Apache Spark</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -255,9 +258,6 @@ transforming, and analyzing genomic data using Apache Spark</li>
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -206,6 +206,9 @@ If you have any questions about the Apache trademark policy, please email
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -214,9 +217,6 @@ If you have any questions about the Apache trademark policy, please email
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -308,6 +308,9 @@ For example, 2.4.0 was released in November 2nd 2018 and had been maintained for
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
           
@@ -316,9 +319,6 @@ For example, 2.4.0 was released in November 2nd 2018 and had been maintained for
           
           <li><a href="/news/spark-3-4-1-released.html">Spark 3.4.1 released</a>
             <span class="small">(Jun 23, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-4-0-released.html">Spark 3.4.0 released</a>
-            <span class="small">(Apr 13, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>


### PR DESCRIPTION
Vote Result: https://lists.apache.org/thread/nlk9n25cznksqqf0j9wxdxg62x8vtj87
Documentation: https://spark.apache.org/docs/3.4.2/
Binary: https://downloads.apache.org/spark/spark-3.4.2/
PySpark: https://pypi.org/project/pyspark/3.4.2/
Maven Central: https://repo1.maven.org/maven2/org/apache/spark/spark-core_2.13/3.4.2/


![Screenshot 2023-11-30 at 9 06 02 AM](https://github.com/apache/spark-website/assets/9700541/4a5aa2cd-8e74-4fab-aded-61a7b6b48e09)

![Screenshot 2023-11-30 at 9 06 53 AM](https://github.com/apache/spark-website/assets/9700541/78cd5d72-7378-4f38-8d7e-8df0d0587c4a)

![Screenshot 2023-11-30 at 9 07 37 AM](https://github.com/apache/spark-website/assets/9700541/281b7b04-f166-4f2b-b72b-a6f49989cb69)

