### PR TITLE
Upgrade bundle dependencies for doc build 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.1)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     colorator (1.1.0)
-    concurrent-ruby (1.1.8)
-    em-websocket (0.5.2)
+    concurrent-ruby (1.2.3)
+    em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
-      http_parser.rb (~> 0.6.0)
+      http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.14.2)
+    ffi (1.16.3)
     forwardable-extended (2.6.0)
-    http_parser.rb (0.6.0)
-    i18n (1.8.9)
+    http_parser.rb (0.8.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     jekyll (4.2.0)
       addressable (~> 2.4)
@@ -29,7 +29,7 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 2.0)
-    jekyll-sass-converter (2.1.0)
+    jekyll-sass-converter (2.2.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
@@ -38,25 +38,25 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
-    listen (3.4.1)
+    listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.0.0)
-    rb-fsevent (0.10.4)
+    public_suffix (5.0.4)
+    rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rouge (3.26.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    unicode-display_width (1.7.0)
-    webrick (1.7.0)
+    unicode-display_width (1.8.0)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby
@@ -67,4 +67,4 @@ DEPENDENCIES
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.3.7
+   2.4.19


### PR DESCRIPTION
On my Mac M2, I failed to gen the docs via `bundle exec jekyll build`


```
/Users/hzyaoqin/spark-website/.local_ruby_bundle/ruby/2.6.0/gems/ffi-1.14.2/lib/ffi/library.rb:275: [BUG] Bus Error at 0x00000001025b4000
ruby 2.6.10p210 (2022-04-12 revision 67958) [universal.arm64e-darwin23]

-- Crash Report log information --------------------------------------------
   See Crash Report log file under the one of following:
     * ~/Library/Logs/DiagnosticReports
     * /Library/Logs/DiagnosticReports
   for more details.
Don't forget to include the above Crash Report log file in bug reports.

-- Control frame information -----------------------------------------------
```

After `bundle update`, it's done

```
Configuration file: /Users/hzyaoqin/spark-website/_config.yml
            Source: /Users/hzyaoqin/spark-website
       Destination: /Users/hzyaoqin/spark-website/site
 Incremental build: disabled. Enable with --incremental
      Generating...
                    done in 3.648 seconds.
```