### PR TITLE
Remove Apache Spark 3.3.4 EOL version from Download page

### DIFF
--- a/js/downloads.js
+++ b/js/downloads.js
@@ -13,18 +13,14 @@ function addRelease(version, releaseDate, packages, mirrored) {
 
 var sources = {pretty: "Source Code", tag: "sources"};
 var hadoopFree = {pretty: "Pre-built with user-provided Apache Hadoop", tag: "without-hadoop"};
-var hadoop2p = {pretty: "Pre-built for Apache Hadoop 2.7", tag: "hadoop2"};
 var hadoop3p = {pretty: "Pre-built for Apache Hadoop 3.3 and later", tag: "hadoop3"};
 var hadoop3pscala213 = {pretty: "Pre-built for Apache Hadoop 3.3 and later (Scala 2.13)", tag: "hadoop3-scala2.13"};
 
-// 3.3.0+
-var packagesV13 = [hadoop3p, hadoop3pscala213, hadoop2p, hadoopFree, sources];
 // 3.4.0+
 var packagesV14 = [hadoop3p, hadoop3pscala213, hadoopFree, sources];
 
 addRelease("3.5.0", new Date("09/13/2023"), packagesV14, true);
 addRelease("3.4.2", new Date("11/30/2023"), packagesV14, true);
-addRelease("3.3.4", new Date("12/16/2023"), packagesV13, true);
 
 function append(el, contents) {
   el.innerHTML += contents;

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -13,18 +13,14 @@ function addRelease(version, releaseDate, packages, mirrored) {
 
 var sources = {pretty: "Source Code", tag: "sources"};
 var hadoopFree = {pretty: "Pre-built with user-provided Apache Hadoop", tag: "without-hadoop"};
-var hadoop2p = {pretty: "Pre-built for Apache Hadoop 2.7", tag: "hadoop2"};
 var hadoop3p = {pretty: "Pre-built for Apache Hadoop 3.3 and later", tag: "hadoop3"};
 var hadoop3pscala213 = {pretty: "Pre-built for Apache Hadoop 3.3 and later (Scala 2.13)", tag: "hadoop3-scala2.13"};
 
-// 3.3.0+
-var packagesV13 = [hadoop3p, hadoop3pscala213, hadoop2p, hadoopFree, sources];
 // 3.4.0+
 var packagesV14 = [hadoop3p, hadoop3pscala213, hadoopFree, sources];
 
 addRelease("3.5.0", new Date("09/13/2023"), packagesV14, true);
 addRelease("3.4.2", new Date("11/30/2023"), packagesV14, true);
-addRelease("3.3.4", new Date("12/16/2023"), packagesV13, true);
 
 function append(el, contents) {
   el.innerHTML += contents;


### PR DESCRIPTION
- Apache Spark 3.3.4 is the EOL version.
- We had better clean up this in order to focus on the upcoming Apache Spark 3.5.1.

![Screenshot 2024-02-14 at 22 21 58](https://github.com/apache/spark-website/assets/9700541/26c1d074-bf8f-4eaf-b6a0-a252f8c118b9)
