### PR TITLE
Add News, Release Note, Download Link for Apache Spark 3.5.1

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -12,6 +12,7 @@ navigation:
 <p>Setup instructions, programming guides, and other documentation are available for each stable version of Spark below:</p>
 
 <ul>
+  <li><a href="{{site.baseurl}}/docs/3.5.1/">Spark 3.5.1</a></li>
   <li><a href="{{site.baseurl}}/docs/3.5.0/">Spark 3.5.0</a></li>
   <li><a href="{{site.baseurl}}/docs/3.4.2/">Spark 3.4.2</a></li>
   <li><a href="{{site.baseurl}}/docs/3.4.1/">Spark 3.4.1</a></li>

--- a/downloads.md
+++ b/downloads.md
@@ -35,7 +35,7 @@ Spark artifacts are [hosted in Maven Central](https://search.maven.org/search?q=
 
     groupId: org.apache.spark
     artifactId: spark-core_2.12
-    version: 3.5.0
+    version: 3.5.1
 
 ### Installing with PyPi
 <a href="https://pypi.org/project/pyspark/">PySpark</a> is now available in pypi. To install just run `pip install pyspark`.

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -19,7 +19,7 @@ var hadoop3pscala213 = {pretty: "Pre-built for Apache Hadoop 3.3 and later (Scal
 // 3.4.0+
 var packagesV14 = [hadoop3p, hadoop3pscala213, hadoopFree, sources];
 
-addRelease("3.5.0", new Date("09/13/2023"), packagesV14, true);
+addRelease("3.5.1", new Date("02/21/2024"), packagesV14, true);
 addRelease("3.4.2", new Date("11/30/2023"), packagesV14, true);
 
 function append(el, contents) {

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -19,7 +19,7 @@ var hadoop3pscala213 = {pretty: "Pre-built for Apache Hadoop 3.3 and later (Scal
 // 3.4.0+
 var packagesV14 = [hadoop3p, hadoop3pscala213, hadoopFree, sources];
 
-addRelease("3.5.1", new Date("02/21/2024"), packagesV14, true);
+addRelease("3.5.1", new Date("02/23/2024"), packagesV14, true);
 addRelease("3.4.2", new Date("11/30/2023"), packagesV14, true);
 
 function append(el, contents) {

--- a/news/_posts/2024-02-23-spark-3-5-1-released.md
+++ b/news/_posts/2024-02-23-spark-3-5-1-released.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: Spark 3.5.1 released
+categories:
+- News
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+We are happy to announce the availability of <a href="{{site.baseurl}}/releases/spark-release-3-5-1.html" title="Spark Release 3.5.1">Spark 3.5.1</a>! Visit the <a href="{{site.baseurl}}/releases/spark-release-3-5-1.html" title="Spark Release 3.5.1">release notes</a> to read about the new features, or <a href="{{site.baseurl}}/downloads.html">download</a> the release today.

--- a/releases/_posts/2024-02-23-spark-release-3-5-1.md
+++ b/releases/_posts/2024-02-23-spark-release-3-5-1.md
@@ -1,0 +1,149 @@
+---
+layout: post
+title: Spark Release 3.5.1
+categories: []
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+
+Spark 3.5.1 is the last maintenance release containing security and correctness fixes. This release is based on the branch-3.5 maintenance branch of Spark. We strongly recommend all 3.5 users to upgrade to this stable release.
+
+### Notable changes
+
+  - [[SPARK-45187]](https://issues.apache.org/jira/browse/SPARK-45187): Fix WorkerPage to use the same pattern for `logPage` urls
+  - [[SPARK-45553]](https://issues.apache.org/jira/browse/SPARK-45553): Deprecate assertPandasOnSparkEqual
+  - [[SPARK-45652]](https://issues.apache.org/jira/browse/SPARK-45652): SPJ: Handle empty input partitions after dynamic filtering
+  - [[SPARK-46012]](https://issues.apache.org/jira/browse/SPARK-46012): EventLogFileReader should not read rolling logs if appStatus is missing
+  - [[SPARK-46029]](https://issues.apache.org/jira/browse/SPARK-46029): Escape the single quote, _ and % for DS V2 pushdown
+  - [[SPARK-46369]](https://issues.apache.org/jira/browse/SPARK-46369): Remove `kill` link from RELAUNCHING drivers in MasterPage
+  - [[SPARK-46704]](https://issues.apache.org/jira/browse/SPARK-46704): Fix `MasterPage` to sort `Running Drivers` table by `Duration` column correctly
+  - [[SPARK-46817]](https://issues.apache.org/jira/browse/SPARK-46817): Fix `spark-daemon.sh` usage by adding `decommission` command
+  - [[SPARK-46888]](https://issues.apache.org/jira/browse/SPARK-46888): Fix `Master` to reject worker kill request if decommission is disabled
+  - [[SPARK-39910]](https://issues.apache.org/jira/browse/SPARK-39910): DataFrameReader API cannot read files from hadoop archives (.har)
+  - [[SPARK-40154]](https://issues.apache.org/jira/browse/SPARK-40154): PySpark: DataFrame.cache docstring gives wrong storage level
+  - [[SPARK-43393]](https://issues.apache.org/jira/browse/SPARK-43393): Sequence expression can overflow
+  - [[SPARK-44683]](https://issues.apache.org/jira/browse/SPARK-44683): Logging level isn't passed to RocksDB state store provider correctly
+  - [[SPARK-44805]](https://issues.apache.org/jira/browse/SPARK-44805): Data lost after union using spark.sql.parquet.enableNestedColumnVectorizedReader=true
+  - [[SPARK-44840]](https://issues.apache.org/jira/browse/SPARK-44840): array_insert() give wrong results for ngative index
+  - [[SPARK-44910]](https://issues.apache.org/jira/browse/SPARK-44910): Encoders.bean does not support superclasses with generic type arguments
+  - [[SPARK-44973]](https://issues.apache.org/jira/browse/SPARK-44973): Fix ArrayIndexOutOfBoundsException in conv()
+  - [[SPARK-45014]](https://issues.apache.org/jira/browse/SPARK-45014): Clean up fileserver when cleaning up files, jars and archives in SparkContext
+  - [[SPARK-45057]](https://issues.apache.org/jira/browse/SPARK-45057): Deadlock caused by rdd replication level of 2
+  - [[SPARK-45072]](https://issues.apache.org/jira/browse/SPARK-45072): Fix Outerscopes for same cell evaluation
+  - [[SPARK-45075]](https://issues.apache.org/jira/browse/SPARK-45075): Alter table with invalid default value will not report error
+  - [[SPARK-45078]](https://issues.apache.org/jira/browse/SPARK-45078): The ArrayInsert function should make explicit casting when element type not equals derived component type
+  - [[SPARK-45081]](https://issues.apache.org/jira/browse/SPARK-45081): Encoders.bean does no longer work with read-only properties
+  - [[SPARK-45106]](https://issues.apache.org/jira/browse/SPARK-45106): percentile_cont gets internal error when user input fails runtime replacement's input type check
+  - [[SPARK-45117]](https://issues.apache.org/jira/browse/SPARK-45117): Implement missing otherCopyArgs for the MultiCommutativeOp expression
+  - [[SPARK-45124]](https://issues.apache.org/jira/browse/SPARK-45124): Do not use local user ID for Local Relations
+  - [[SPARK-45132]](https://issues.apache.org/jira/browse/SPARK-45132): Fix IDENTIFIER clause for functions
+  - [[SPARK-45171]](https://issues.apache.org/jira/browse/SPARK-45171): GenerateExec fails to initialize non-deterministic expressions before use
+  - [[SPARK-45182]](https://issues.apache.org/jira/browse/SPARK-45182): Ignore task completion from old stage after retrying indeterminate stages
+  - [[SPARK-45205]](https://issues.apache.org/jira/browse/SPARK-45205): Since version 3.2.0, Spark SQL has taken longer to execute "show paritions",probably because of changes introduced by SPARK-35278
+  - [[SPARK-45227]](https://issues.apache.org/jira/browse/SPARK-45227): Fix a subtle thread-safety issue with CoarseGrainedExecutorBackend where an executor process randomly gets stuck
+  - [[SPARK-45291]](https://issues.apache.org/jira/browse/SPARK-45291): Use unknown query execution id instead of no such app when id is invalid
+  - [[SPARK-45311]](https://issues.apache.org/jira/browse/SPARK-45311): Encoder fails on many "NoSuchElementException: None.get" since 3.4.x, search for an encoder for a generic type, and since 3.5.x isn't "an expression encoder"
+  - [[SPARK-45346]](https://issues.apache.org/jira/browse/SPARK-45346): Parquet schema inference should respect case sensitive flag when merging schema
+  - [[SPARK-45371]](https://issues.apache.org/jira/browse/SPARK-45371): FIx shading problem in Spark Connect
+  - [[SPARK-45383]](https://issues.apache.org/jira/browse/SPARK-45383): Missing case for RelationTimeTravel in CheckAnalysis
+  - [[SPARK-45389]](https://issues.apache.org/jira/browse/SPARK-45389): Correct MetaException matching rule on getting partition metadata
+  - [[SPARK-45424]](https://issues.apache.org/jira/browse/SPARK-45424): Regression in CSV schema inference when timestamps do not match specified timestampFormat
+  - [[SPARK-45430]](https://issues.apache.org/jira/browse/SPARK-45430): FramelessOffsetWindowFunctionFrame fails when ignore nulls and offset > # of rows
+  - [[SPARK-45433]](https://issues.apache.org/jira/browse/SPARK-45433): CSV/JSON schema inference when timestamps do not match specified timestampFormat with only one row on each partition report error
+  - [[SPARK-45449]](https://issues.apache.org/jira/browse/SPARK-45449): Cache Invalidation Issue with JDBC Table
+  - [[SPARK-45484]](https://issues.apache.org/jira/browse/SPARK-45484): Fix the bug that uses incorrect parquet compression codec lz4raw
+  - [[SPARK-45498]](https://issues.apache.org/jira/browse/SPARK-45498): Followup: Ignore task completion from old stage after retrying indeterminate stages
+  - [[SPARK-45508]](https://issues.apache.org/jira/browse/SPARK-45508): Add "--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED" so Platform can access cleaner on Java 9+
+  - [[SPARK-45543]](https://issues.apache.org/jira/browse/SPARK-45543): InferWindowGroupLimit causes bug if the other window functions haven't the same window frame as the rank-like functions
+  - [[SPARK-45561]](https://issues.apache.org/jira/browse/SPARK-45561): Convert TINYINT catalyst properly in MySQL Dialect
+  - [[SPARK-45580]](https://issues.apache.org/jira/browse/SPARK-45580): Subquery changes the output schema of the outer query
+  - [[SPARK-45584]](https://issues.apache.org/jira/browse/SPARK-45584): Execution fails when there are subqueries in TakeOrderedAndProjectExec
+  - [[SPARK-45592]](https://issues.apache.org/jira/browse/SPARK-45592): AQE and InMemoryTableScanExec correctness bug
+  - [[SPARK-45604]](https://issues.apache.org/jira/browse/SPARK-45604): Converting timestamp_ntz to array<timestamp_ntz> can cause NPE or SEGFAULT on parquet vectorized reader
+  - [[SPARK-45616]](https://issues.apache.org/jira/browse/SPARK-45616): Usages of ParVector are unsafe because it does not propagate ThreadLocals or SparkSession
+  - [[SPARK-45631]](https://issues.apache.org/jira/browse/SPARK-45631): Broken backward compatibility in PySpark: StreamingQueryListener due to the addition of onQueryIdle
+  - [[SPARK-45670]](https://issues.apache.org/jira/browse/SPARK-45670): SparkSubmit does not support --total-executor-cores when deploying on K8s
+  - [[SPARK-45678]](https://issues.apache.org/jira/browse/SPARK-45678): Cover BufferReleasingInputStream.available under tryOrFetchFailedException
+  - [[SPARK-45786]](https://issues.apache.org/jira/browse/SPARK-45786): Inaccurate Decimal multiplication and division results
+  - [[SPARK-45814]](https://issues.apache.org/jira/browse/SPARK-45814): ArrowConverters.createEmptyArrowBatch may cause memory leak
+  - [[SPARK-45896]](https://issues.apache.org/jira/browse/SPARK-45896): Expression encoding fails for Seq/Map of `Option[Seq/Date/Timestamp/BigDecimal]`
+  - [[SPARK-45920]](https://issues.apache.org/jira/browse/SPARK-45920): group by ordinal should be idempotent
+  - [[SPARK-46006]](https://issues.apache.org/jira/browse/SPARK-46006): YarnAllocator miss clean targetNumExecutorsPerResourceProfileId after YarnSchedulerBackend call stop
+  - [[SPARK-46016]](https://issues.apache.org/jira/browse/SPARK-46016): Fix pandas API support list properly
+  - [[SPARK-46062]](https://issues.apache.org/jira/browse/SPARK-46062): CTE reference node does not inherit the flag `isStreaming` from CTE definition node
+  - [[SPARK-46064]](https://issues.apache.org/jira/browse/SPARK-46064): EliminateEventTimeWatermark does not consider the fact that isStreaming flag can change for current child during resolution
+  - [[SPARK-46092]](https://issues.apache.org/jira/browse/SPARK-46092): Overflow in Parquet row group filter creation causes incorrect results
+  - [[SPARK-46189]](https://issues.apache.org/jira/browse/SPARK-46189): Various Pandas functions fail in interpreted mode
+  - [[SPARK-46239]](https://issues.apache.org/jira/browse/SPARK-46239): Hide Jetty info
+  - [[SPARK-46274]](https://issues.apache.org/jira/browse/SPARK-46274): Range operator computeStats() proper long conversions
+  - [[SPARK-46275]](https://issues.apache.org/jira/browse/SPARK-46275): Protobuf: Permissive mode should return null rather than struct with null fields
+  - [[SPARK-46330]](https://issues.apache.org/jira/browse/SPARK-46330): Loading of Spark UI blocks for a long time when HybridStore enabled
+  - [[SPARK-46339]](https://issues.apache.org/jira/browse/SPARK-46339): Directory with number name should not be treated as metadata log
+  - [[SPARK-46388]](https://issues.apache.org/jira/browse/SPARK-46388): HiveAnalysis misses pattern guard `query.resolved`
+  - [[SPARK-46396]](https://issues.apache.org/jira/browse/SPARK-46396): LegacyFastTimestampFormatter.parseOptional should not throw exception
+  - [[SPARK-46443]](https://issues.apache.org/jira/browse/SPARK-46443): Decimal precision and scale should decided by JDBC dialect.
+  - [[SPARK-46453]](https://issues.apache.org/jira/browse/SPARK-46453): SessionHolder doesn't throw exceptions from internalError()
+  - [[SPARK-46466]](https://issues.apache.org/jira/browse/SPARK-46466): vectorized parquet reader should never do rebase for timestamp ntz
+  - [[SPARK-46480]](https://issues.apache.org/jira/browse/SPARK-46480): Fix NPE when table cache task attempt
+  - [[SPARK-46535]](https://issues.apache.org/jira/browse/SPARK-46535): NPE when describe extended a column without col stats
+  - [[SPARK-46562]](https://issues.apache.org/jira/browse/SPARK-46562): Remove retrieval of `keytabFile` from `UserGroupInformation` in `HiveAuthFactory`
+  - [[SPARK-46590]](https://issues.apache.org/jira/browse/SPARK-46590): Coalesce partiton assert error after skew join optimization
+  - [[SPARK-46598]](https://issues.apache.org/jira/browse/SPARK-46598): OrcColumnarBatchReader should respect the memory mode when creating column vectors for the missing column
+  - [[SPARK-46602]](https://issues.apache.org/jira/browse/SPARK-46602): CREATE VIEW IF NOT EXISTS should never throw `TABLE_OR_VIEW_ALREADY_EXISTS` exception
+  - [[SPARK-46609]](https://issues.apache.org/jira/browse/SPARK-46609): avoid exponential explosion in PartitioningPreservingUnaryExecNode
+  - [[SPARK-46640]](https://issues.apache.org/jira/browse/SPARK-46640): RemoveRedundantAliases does not account for SubqueryExpression when removing aliases
+  - [[SPARK-46663]](https://issues.apache.org/jira/browse/SPARK-46663): Disable memory profiler for pandas UDFs with iterators
+  - [[SPARK-46676]](https://issues.apache.org/jira/browse/SPARK-46676): dropDuplicatesWithinWatermark throws error on canonicalizing plan
+  - [[SPARK-46684]](https://issues.apache.org/jira/browse/SPARK-46684): CoGroup.applyInPandas/Arrow should pass arguments properly
+  - [[SPARK-46700]](https://issues.apache.org/jira/browse/SPARK-46700): count the last spilling for the shuffle disk spilling bytes metric
+  - [[SPARK-46747]](https://issues.apache.org/jira/browse/SPARK-46747): Too Many Shared Locks due to PostgresDialect.getTableExistsQuery - LIMIT 1
+  - [[SPARK-46763]](https://issues.apache.org/jira/browse/SPARK-46763): ReplaceDeduplicateWithAggregate fails when non-grouping keys have duplicate attributes
+  - [[SPARK-46769]](https://issues.apache.org/jira/browse/SPARK-46769): Refine timestamp related schema inference
+  - [[SPARK-46779]](https://issues.apache.org/jira/browse/SPARK-46779): Grouping by subquery with a cached relation can fail
+  - [[SPARK-46786]](https://issues.apache.org/jira/browse/SPARK-46786): Fix MountVolumesFeatureStep to use ReadWriteOncePod instead of ReadWriteOnce
+  - [[SPARK-46794]](https://issues.apache.org/jira/browse/SPARK-46794): Incorrect results due to inferred predicate from checkpoint with subquery
+  - [[SPARK-46796]](https://issues.apache.org/jira/browse/SPARK-46796): RocksDB versionID Mismatch in SST files
+  - [[SPARK-46855]](https://issues.apache.org/jira/browse/SPARK-46855): Add `sketch` to the dependencies of the `catalyst` module in `module.py`
+  - [[SPARK-46861]](https://issues.apache.org/jira/browse/SPARK-46861): Avoid Deadlock in DAGScheduler
+  - [[SPARK-46862]](https://issues.apache.org/jira/browse/SPARK-46862): Incorrect count() of a dataframe loaded from CSV datasource
+  - [[SPARK-46945]](https://issues.apache.org/jira/browse/SPARK-46945): Add `spark.kubernetes.legacy.useReadWriteOnceAccessMode` for old K8s clusters
+  - [[SPARK-47019]](https://issues.apache.org/jira/browse/SPARK-47019): AQE dynamic cache partitioning causes SortMergeJoin to result in data loss
+  - [[SPARK-45360]](https://issues.apache.org/jira/browse/SPARK-45360): Initialize spark session builder configuration from SPARK_REMOTE
+  - [[SPARK-45706]](https://issues.apache.org/jira/browse/SPARK-45706): Makes entire Binder build fails fast during setting up
+  - [[SPARK-46732]](https://issues.apache.org/jira/browse/SPARK-46732): Propagate JobArtifactSet to broadcast execution thread
+  - [[SPARK-44833]](https://issues.apache.org/jira/browse/SPARK-44833): Spark Connect reattach when initial ExecutePlan didn't reach server doing too eager Reattach
+  - [[SPARK-44835]](https://issues.apache.org/jira/browse/SPARK-44835): SparkConnect ReattachExecute could raise before ExecutePlan even attaches.
+  - [[SPARK-45050]](https://issues.apache.org/jira/browse/SPARK-45050): Improve error message for UNKNOWN io.grpc.StatusRuntimeException
+  - [[SPARK-45071]](https://issues.apache.org/jira/browse/SPARK-45071): Optimize the processing speed of `BinaryArithmetic#dataType` when processing multi-column data
+  - [[SPARK-45250]](https://issues.apache.org/jira/browse/SPARK-45250): Support stage level task resource profile for yarn cluster when dynamic allocation disabled
+  - [[SPARK-45386]](https://issues.apache.org/jira/browse/SPARK-45386): Correctness issue when persisting using StorageLevel.NONE
+  - [[SPARK-45419]](https://issues.apache.org/jira/browse/SPARK-45419): Avoid reusing rocksdb sst files in a dfferent rocksdb instance by removing file version map entry of larger versions
+  - [[SPARK-45495]](https://issues.apache.org/jira/browse/SPARK-45495): Support stage level task resource profile for k8s cluster when dynamic allocation disabled
+  - [[SPARK-45538]](https://issues.apache.org/jira/browse/SPARK-45538): pyspark connect overwrite_partitions bug
+  - [[SPARK-45770]](https://issues.apache.org/jira/browse/SPARK-45770): Fix column resolution in DataFrame.drop
+  - [[SPARK-45882]](https://issues.apache.org/jira/browse/SPARK-45882): BroadcastHashJoinExec propagate partitioning should respect CoalescedHashPartitioning
+  - [[SPARK-45974]](https://issues.apache.org/jira/browse/SPARK-45974): Add scan.filterAttributes non-empty judgment for RowLevelOperationRuntimeGroupFiltering
+  - [[SPARK-46170]](https://issues.apache.org/jira/browse/SPARK-46170): Support inject adaptive query post planner strategy rules in SparkSessionExtensions
+  - [[SPARK-46380]](https://issues.apache.org/jira/browse/SPARK-46380): Replacing current time prior to inline table eval
+  - [[SPARK-46600]](https://issues.apache.org/jira/browse/SPARK-46600): Move shared code between SqlConf and SqlApiConf to another object
+  - [[SPARK-46610]](https://issues.apache.org/jira/browse/SPARK-46610): Create table should throw exception when no value for a key in options
+  - [[SPARK-45189]](https://issues.apache.org/jira/browse/SPARK-45189): Creating UnresolvedRelation from TableIdentifier should include the catalog field
+  - [[SPARK-46182]](https://issues.apache.org/jira/browse/SPARK-46182): Shuffle data lost on decommissioned executor caused by race condition between lastTaskRunningTime and lastShuffleMigrationTime
+  - [[SPARK-46547]](https://issues.apache.org/jira/browse/SPARK-46547): Fix deadlock issue between maintenance thread and streaming agg physical operators
+  - [[SPARK-46628]](https://issues.apache.org/jira/browse/SPARK-46628): Use SPDX short identifier in `licenses` name
+
+### Dependency Changes
+
+While being a maintenance release we did still upgrade some dependencies in this release they are:
+
+  - [[SPARK-47023]](https://issues.apache.org/jira/browse/SPARK-47023): Upgrade `aircompressor` to 0.26
+  - [[SPARK-45883]](https://issues.apache.org/jira/browse/SPARK-47023): Upgrade ORC to 1.9.2
+
+You can consult JIRA for the [detailed changes](https://s.apache.org/spark-3.5.1).
+
+We would like to acknowledge all community members for contributing patches to this release.

--- a/site/committers.html
+++ b/site/committers.html
@@ -678,6 +678,9 @@ of the immediate bug being fixed.</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -686,9 +689,6 @@ of the immediate bug being fixed.</li>
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/community.html
+++ b/site/community.html
@@ -365,6 +365,9 @@ Add yours by emailing `dev@spark.apache.org`.
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -373,9 +376,6 @@ Add yours by emailing `dev@spark.apache.org`.
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -675,6 +675,9 @@ to ask on the <code class="language-plaintext highlighter-rouge">dev@spark.apach
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -683,9 +686,6 @@ to ask on the <code class="language-plaintext highlighter-rouge">dev@spark.apach
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -709,6 +709,9 @@ compatible with usage in an Open Source project and inclusion of the generated c
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -717,9 +720,6 @@ compatible with usage in an Open Source project and inclusion of the generated c
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -144,6 +144,7 @@
 <p>Setup instructions, programming guides, and other documentation are available for each stable version of Spark below:</p>
 
 <ul>
+  <li><a href="/docs/3.5.1/">Spark 3.5.1</a></li>
   <li><a href="/docs/3.5.0/">Spark 3.5.0</a></li>
   <li><a href="/docs/3.4.2/">Spark 3.4.2</a></li>
   <li><a href="/docs/3.4.1/">Spark 3.4.1</a></li>
@@ -360,6 +361,9 @@ The <a href="/research.html">research page</a> lists some of the original motiva
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -368,9 +372,6 @@ The <a href="/research.html">research page</a> lists some of the original motiva
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -174,7 +174,7 @@ window.onload = function () {
 
 <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>groupId: org.apache.spark
 artifactId: spark-core_2.12
-version: 3.5.0
+version: 3.5.1
 </code></pre></div></div>
 
 <h3 id="installing-with-pypi">Installing with PyPi</h3>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -203,6 +203,9 @@ before deciding to use it.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -211,9 +214,6 @@ before deciding to use it.</p>
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/error-message-guidelines.html
+++ b/site/error-message-guidelines.html
@@ -542,6 +542,9 @@ be redundant; you may skip an explicit explanation in this case.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -550,9 +553,6 @@ be redundant; you may skip an explicit explanation in this case.</p>
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/examples.html
+++ b/site/examples.html
@@ -490,6 +490,9 @@ counts = (
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -498,9 +501,6 @@ counts = (
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/faq.html
+++ b/site/faq.html
@@ -212,6 +212,9 @@ Please also refer to our
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -220,9 +223,6 @@ Please also refer to our
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -257,6 +257,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -265,9 +268,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/history.html
+++ b/site/history.html
@@ -166,6 +166,9 @@ You can get involved in Apache Spark development by reading
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -174,9 +177,6 @@ You can get involved in Apache Spark development by reading
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -238,6 +238,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -246,9 +249,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -19,7 +19,7 @@ var hadoop3pscala213 = {pretty: "Pre-built for Apache Hadoop 3.3 and later (Scal
 // 3.4.0+
 var packagesV14 = [hadoop3p, hadoop3pscala213, hadoopFree, sources];
 
-addRelease("3.5.0", new Date("09/13/2023"), packagesV14, true);
+addRelease("3.5.1", new Date("02/21/2024"), packagesV14, true);
 addRelease("3.4.2", new Date("11/30/2023"), packagesV14, true);
 
 function append(el, contents) {

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -19,7 +19,7 @@ var hadoop3pscala213 = {pretty: "Pre-built for Apache Hadoop 3.3 and later (Scal
 // 3.4.0+
 var packagesV14 = [hadoop3p, hadoop3pscala213, hadoopFree, sources];
 
-addRelease("3.5.1", new Date("02/21/2024"), packagesV14, true);
+addRelease("3.5.1", new Date("02/23/2024"), packagesV14, true);
 addRelease("3.4.2", new Date("11/30/2023"), packagesV14, true);
 
 function append(el, contents) {

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -150,6 +150,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -158,9 +161,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -303,6 +303,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -311,9 +314,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/3-1-3-released.html
+++ b/site/news/3-1-3-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -143,6 +143,15 @@
 
 <article class="hentry">
     <header class="entry-header">
+      <h3 class="entry-title"><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a></h3>
+      <div class="entry-date">February 23, 2024</div>
+    </header>
+    <div class="entry-content"><p>We are happy to announce the availability of <a href="/releases/spark-release-3-5-1.html" title="Spark Release 3.5.1">Spark 3.5.1</a>! Visit the <a href="/releases/spark-release-3-5-1.html" title="Spark Release 3.5.1">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+</div>
+  </article>
+
+<article class="hentry">
+    <header class="entry-header">
       <h3 class="entry-title"><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a></h3>
       <div class="entry-date">December 16, 2023</div>
     </header>
@@ -1344,6 +1353,9 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -1352,9 +1364,6 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/new-repository-service.html
+++ b/site/news/new-repository-service.html
@@ -162,6 +162,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -170,9 +173,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/next-official-release-spark-3.1.1.html
+++ b/site/news/next-official-release-spark-3.1.1.html
@@ -168,6 +168,9 @@ are no guarantees on using it such as binary compatibility.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -176,9 +179,6 @@ are no guarantees on using it such as binary compatibility.</p>
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -162,6 +162,9 @@ online to attend in person. We hope you enjoy the event!</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -170,9 +173,6 @@ online to attend in person. We hope you enjoy the event!</p>
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/plan-for-dropping-python-2-support.html
+++ b/site/news/plan-for-dropping-python-2-support.html
@@ -172,6 +172,9 @@ Python 2. However, after Python 2 EOL, we might not take patches that are specif
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -180,9 +183,6 @@ Python 2. However, after Python 2 EOL, we might not take patches that are specif
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/sigmod-system-award.html
+++ b/site/news/sigmod-system-award.html
@@ -167,6 +167,9 @@ the whole community earned together.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -175,9 +178,6 @@ the whole community earned together.</p>
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -163,6 +163,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -171,9 +174,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -162,6 +162,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -170,9 +173,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -161,6 +161,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -169,9 +172,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -159,6 +159,9 @@ This release expands Spark&#8217;s standard libraries, introducing a new SQL pac
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -167,9 +170,6 @@ This release expands Spark&#8217;s standard libraries, introducing a new SQL pac
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -162,6 +162,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -170,9 +173,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -157,6 +157,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -165,9 +168,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -157,6 +157,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -165,9 +168,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-3-released.html
+++ b/site/news/spark-2-1-3-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -157,6 +157,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -165,9 +168,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-2-released.html
+++ b/site/news/spark-2-2-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-1-released.html
+++ b/site/news/spark-2-3-1-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-2-released.html
+++ b/site/news/spark-2-3-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-3-released.html
+++ b/site/news/spark-2-3-3-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-4-released.html
+++ b/site/news/spark-2-3-4-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-0-released.html
+++ b/site/news/spark-2-4-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-1-released.html
+++ b/site/news/spark-2-4-1-released.html
@@ -157,6 +157,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -165,9 +168,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-2-released.html
+++ b/site/news/spark-2-4-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-3-released.html
+++ b/site/news/spark-2-4-3-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-4-released.html
+++ b/site/news/spark-2-4-4-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-5-released.html
+++ b/site/news/spark-2-4-5-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-6.html
+++ b/site/news/spark-2-4-6.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-7-released.html
+++ b/site/news/spark-2-4-7-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-8-released.html
+++ b/site/news/spark-2-4-8-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-0-released.html
+++ b/site/news/spark-3-0-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-1-released.html
+++ b/site/news/spark-3-0-1-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-2-released.html
+++ b/site/news/spark-3-0-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-3-released.html
+++ b/site/news/spark-3-0-3-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-1-released.html
+++ b/site/news/spark-3-1-1-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-2-released.html
+++ b/site/news/spark-3-1-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-0-released.html
+++ b/site/news/spark-3-2-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-1-released.html
+++ b/site/news/spark-3-2-1-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-2-released.html
+++ b/site/news/spark-3-2-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-3-released.html
+++ b/site/news/spark-3-2-3-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-4-released.html
+++ b/site/news/spark-3-2-4-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-0-released.html
+++ b/site/news/spark-3-3-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-1-released.html
+++ b/site/news/spark-3-3-1-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-2-released.html
+++ b/site/news/spark-3-3-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-3-released.html
+++ b/site/news/spark-3-3-3-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-4-released.html
+++ b/site/news/spark-3-3-4-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-4-0-released.html
+++ b/site/news/spark-3-4-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-4-1-released.html
+++ b/site/news/spark-3-4-1-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-4-2-released.html
+++ b/site/news/spark-3-4-2-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-5-0-released.html
+++ b/site/news/spark-3-5-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-5-1-released.html
+++ b/site/news/spark-3-5-1-released.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark Release 1.2.1 | Apache Spark
+     Spark 3.5.1 released | Apache Spark
     
   </title>
 
@@ -139,119 +139,10 @@
 <div class="container">
   <div class="row mt-4">
     <div class="col-12 col-md-9">
-      <h2>Spark Release 1.2.1</h2>
+      <h2>Spark 3.5.1 released</h2>
 
 
-<p>Spark 1.2.1 is a maintenance release containing stability fixes. This release is based on the <a href="https://github.com/apache/spark/tree/branch-1.2">branch-1.2</a> maintenance branch of Spark. We recommend all 1.2.0 users to upgrade to this stable release. Contributions to this release came from 69 developers.</p>
-
-<p>To download Spark 1.2.1 visit the <a href="/downloads.html">downloads</a> page.</p>
-
-<h3 id="fixes">Fixes</h3>
-<p>Spark 1.2.1 contains bug fixes in several components. Some of the more important fixes are highlighted below. You can visit the <a href="http://s.apache.org/Mpn">Spark issue tracker</a> for the full list of fixes.</p>
-
-<h4 id="security">Security</h4>
-<ul>
-  <li>Locks down file permissions for temporary file storage</li>
-</ul>
-
-<h4 id="spark-core">Spark Core</h4>
-<ul>
-  <li>Netty shuffle ignores spark.blockManager.port (<a href="https://issues.apache.org/jira/browse/SPARK-4837">SPARK-4837</a>)</li>
-  <li>MetricsServlet does not initialize properly (<a href="https://issues.apache.org/jira/browse/SPARK-4595">SPARK-4595</a>)</li>
-  <li>Repl and YARN dependencies are not published to Maven (<a href="https://issues.apache.org/jira/browse/SPARK-5289">SPARK-5289</a>)</li>
-  <li>SparkConf is not thread safe (<a href="https://issues.apache.org/jira/browse/SPARK-5355">SPARK-5355</a>)</li>
-  <li>Byte code errors when linking against Spark (<a href="https://issues.apache.org/jira/browse/SPARK-2075">SPARK-2075</a>)</li>
-</ul>
-
-<h4 id="sql">SQL</h4>
-<ul>
-  <li>CACHE TABLE AS SELECT fails with Hive UDFs (<a href="https://issues.apache.org/jira/browse/SPARK-5187">SPARK-5187</a>)</li>
-  <li>Attributes are case sensitive when using a select query from a projection (<a href="https://issues.apache.org/jira/browse/SPARK-4959">SPARK-4959</a>)</li>
-  <li>Spark SQL built for Hive 13 fails under concurrent metadata queries (<a href="https://issues.apache.org/jira/browse/SPARK-4908">SPARK-4908</a>)</li>
-  <li>Throw &#8220;Expression not in GROUP BY&#8221; when using same expression in group by clause and select clause (<a href="https://issues.apache.org/jira/browse/SPARK-4296">SPARK-4296</a>)</li>
-</ul>
-
-<h4 id="streaming">Streaming</h4>
-<ul>
-  <li>Proper file clean up for write ahead logs (<a href="https://issues.apache.org/jira/browse/SPARK-5147">SPARK-5147</a>)</li>
-  <li>Error with existing files during checkpoint recovery (<a href="https://issues.apache.org/jira/browse/SPARK-4835">SPARK-4835</a>)</li>
-  <li>Socket Receiver does not stop when streaming context is stopped (<a href="https://issues.apache.org/jira/browse/SPARK-2892">SPARK-2892</a>)</li>
-</ul>
-
-<h4 id="pyspark">PySpark</h4>
-<ul>
-  <li>Parallelizing lists or arrays is slow (<a href="https://issues.apache.org/jira/browse/SPARK-5224">SPARK-5224</a>)</li>
-  <li>Serializer bug when using zip (<a href="https://issues.apache.org/jira/browse/SPARK-4841">SPARK-4841</a>)</li>
-  <li>Support Vector types within a dictionary (<a href="https://issues.apache.org/jira/browse/SPARK-5223">SPARK-5223</a>)</li>
-</ul>
-
-<h3 id="contributors">Contributors</h3>
-<p>The following developers contributed to this release:</p>
-
-<ul>
-  <li>Aaron Davidson &#8211; Bug fixes in Core</li>
-  <li>Alex Liu &#8211; Improvements in Core and SQL; bug fixes in SQL</li>
-  <li>Andrew Ash &#8211; Documentation in Core</li>
-  <li>Andrew Or &#8211; Improvements in Core and YARN; bug fixes in Core and YARN</li>
-  <li>Bilna &#8211; Test in Streaming</li>
-  <li>Brennon York &#8211; Bug fixes in Core</li>
-  <li>Cheng Hao &#8211; Bug fixes in Core and SQL</li>
-  <li>Cheng Lian &#8211; Bug fixes in Core</li>
-  <li>Christophe Preaud &#8211; Improvements in Core</li>
-  <li>Dale Richardson &#8211; Improvement in Core</li>
-  <li>Davies Liu &#8211; Bug fixes in Core, MLlib, and PySpark</li>
-  <li>Derek Ma &#8211; Bug fixes in Shuffle</li>
-  <li>Earne &#8211; Improvements in Core and GraphX</li>
-  <li>GuoQiang Li &#8211; Bug fixes in Core and YARN</li>
-  <li>Hari Shreedharan &#8211; Bug fixes in Streaming</li>
-  <li>Ilayaperumal Gopinathan &#8211; Bug fixes in Streaming</li>
-  <li>Ilya Ganelin &#8211; Bug fixes in Core and Shuffle</li>
-  <li>Jacek Lewandowski &#8211; Bug fixes in Core</li>
-  <li>Jeremy Freeman &#8211; Bug fixes in MLlib and PySpark</li>
-  <li>Jongyoul Lee &#8211; Documentation in Streaming; bug fixes in Core and Mesos</li>
-  <li>Joseph K. Bradley &#8211; Bug fixes in Core, MLlib, and PySpark</li>
-  <li>Josh Rosen &#8211; Improvements in Core and SQL; new features in Core; bug fixes in Streaming and PySpark</li>
-  <li>Kanwaljit Singh &#8211; Bug fixes in Core</li>
-  <li>Kenji Kikushima &#8211; Bug fixes in GraphX</li>
-  <li>Kousuke Saruta &#8211; Bug fixes in Core and Web UI</li>
-  <li>Lianhui Wang &#8211; Bug fixes in Core</li>
-  <li>Madhu Siddalingaiah &#8211; Documentation in Core</li>
-  <li>Marcelo Vanzin &#8211; Bug fixes in Core</li>
-  <li>Michael Armbrust &#8211; Improvements in Core; bug fixes in SQL</li>
-  <li>Michael Davies &#8211; Improvements in SQL</li>
-  <li>Nan Zhu &#8211; Improvements and bug fixes in Streaming</li>
-  <li>Nathan Kronenfeld &#8211; Bug fixes in Core</li>
-  <li>Nicholas Chammas &#8211; Documentation in Core</li>
-  <li>Patrick Wendell &#8211; Improvements and documentation in Core</li>
-  <li>Peter Klipfel &#8211; Documentation in Core</li>
-  <li>Peter Vandenabeele &#8211; Documentation in Core</li>
-  <li>Ryan Williams &#8211; Improvements, bug fixes, and documentation in Core</li>
-  <li>SaintBacchus &#8211; Bug fixes in Core and YARN</li>
-  <li>Saisai Shao &#8211; Bug fixes in Core</li>
-  <li>Saisai Shao &#8211; Improvements in Streaming; bug fixes in Streaming and SQL; improvement in Streaming</li>
-  <li>Sandy Ryza &#8211; Improvements in Core</li>
-  <li>Sean Owen &#8211; Improvements in Core; wish in Core; documentation in Core; bug fixes in Java API, Core, and SQL</li>
-  <li>Shixiong Zhu &#8211; Improvements in Streaming and Shuffle; bug fixes in Core and Streaming; documentation in Core and YARN</li>
-  <li>Su Yan &#8211; Improvements in Core; bug fixes in Core and Web UI</li>
-  <li>Takeshi Yamamuro &#8211; Improvements and bug fixes in GraphX</li>
-  <li>Tathagata Das &#8211; Improvements and improvement in Streaming</li>
-  <li>Timothy Chen &#8211; Documentation in Core</li>
-  <li>Tingjun Xu &#8211; Bug fixes in YARN</li>
-  <li>Tsuyoshi Ozawa &#8211; Documentation in Core and YARN</li>
-  <li>UncleGen &#8211; Improvements in Web UI; bug fixes in Core</li>
-  <li>Venkata Ramana Gollamudi &#8211; Bug fixes in Core</li>
-  <li>Wang Tao &#8211; Bug fixes in Core</li>
-  <li>Xiangrui Meng &#8211; Documentation in MLlib</li>
-  <li>Xiaohua Yi &#8211; Bug fixes in SQL</li>
-  <li>Xiaojing Wang &#8211; Documentation in Core</li>
-  <li>Yash Datta &#8211; Bug fixes in SQL</li>
-  <li>Ye Xianjin &#8211; Bug fixes in Core</li>
-  <li>Yuhao Yang &#8211; Improvements and bug fixes in MLlib</li>
-  <li>Zhang, Liye &#8211; Improvements in Web UI</li>
-</ul>
-
-<p><em>Thanks to everyone who contributed!</em></p>
-
+<p>We are happy to announce the availability of <a href="/releases/spark-release-3-5-1.html" title="Spark Release 3.5.1">Spark 3.5.1</a>! Visit the <a href="/releases/spark-release-3-5-1.html" title="Spark Release 3.5.1">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
 
 
 <p>

--- a/site/news/spark-3.0.0-preview.html
+++ b/site/news/spark-3.0.0-preview.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview2.html
+++ b/site/news/spark-3.0.0-preview2.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-apr-2019-agenda-posted.html
+++ b/site/news/spark-ai-summit-apr-2019-agenda-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-june-2020-agenda-posted.html
+++ b/site/news/spark-ai-summit-june-2020-agenda-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -166,6 +166,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -174,9 +177,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -167,6 +167,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -175,9 +178,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-release-2-2-3.html
+++ b/site/news/spark-release-2-2-3.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -162,6 +162,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -170,9 +173,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -162,6 +162,9 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -170,9 +173,6 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -164,6 +164,9 @@ about the latest happenings in Spark.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -172,9 +175,6 @@ about the latest happenings in Spark.</p>
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2015.html
+++ b/site/news/spark-summit-east-agenda-posted-2015.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2016.html
+++ b/site/news/spark-summit-east-agenda-posted-2016.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -157,6 +157,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -165,9 +168,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-oct-2018-agenda-posted.html
+++ b/site/news/spark-summit-oct-2018-agenda-posted.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -161,6 +161,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -169,9 +172,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -163,6 +163,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -171,9 +174,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -162,6 +162,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -170,9 +173,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -165,6 +165,9 @@ on Spark.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -173,9 +176,6 @@ on Spark.</p>
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -157,6 +157,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -165,9 +168,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -166,6 +166,9 @@ online to attend in person. Otherwise, the Summit will offer a free live video s
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -174,9 +177,6 @@ online to attend in person. Otherwise, the Summit will offer a free live video s
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -156,6 +156,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -164,9 +167,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -507,6 +507,9 @@ to process islands identified from a search robor</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -515,9 +518,6 @@ to process islands identified from a search robor</li>
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -558,6 +558,9 @@ and then send an e-mail to the mailing list with a subject that looks something 
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -566,9 +569,6 @@ and then send an e-mail to the mailing list with a subject that looks something 
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -207,6 +207,9 @@ squares.saveAsSequenceFile(<span class="string">"hdfs://..."</span>)
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -215,9 +218,6 @@ squares.saveAsSequenceFile(<span class="string">"hdfs://..."</span>)
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -179,6 +179,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -187,9 +190,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -189,6 +189,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -197,9 +200,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -158,6 +158,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -166,9 +169,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -233,6 +233,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -241,9 +244,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -186,6 +186,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -194,9 +197,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -255,6 +255,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -263,9 +266,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -197,6 +197,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -205,9 +208,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -191,6 +191,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -199,9 +202,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -286,6 +286,9 @@ We’d especially like to thank Patrick Wendell for acting as the release manage
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -294,9 +297,6 @@ We’d especially like to thank Patrick Wendell for acting as the release manage
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -250,6 +250,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -258,9 +261,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -344,6 +344,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -352,9 +355,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -262,6 +262,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -270,9 +273,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -235,6 +235,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -243,9 +246,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -328,6 +328,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -336,9 +339,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -286,6 +286,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -294,9 +297,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -243,6 +243,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -251,9 +254,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -379,6 +379,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -387,9 +390,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -265,6 +265,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -273,9 +276,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -393,6 +393,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -401,9 +404,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -225,6 +225,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -233,9 +236,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -370,6 +370,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -378,9 +381,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -257,6 +257,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -265,9 +268,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -484,6 +484,9 @@ Python coverage. MLlib also adds several new algorithms.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -492,9 +495,6 @@ Python coverage. MLlib also adds several new algorithms.</p>
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -289,6 +289,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -297,9 +300,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -422,6 +422,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -430,9 +433,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -161,6 +161,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -169,9 +172,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -298,6 +298,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -306,9 +309,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -394,6 +394,9 @@ yzhou2001, zhonghaihua, zhuol, zlpmichelle, Örjan Lundberg, Łukasz Gieroń</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -402,9 +405,6 @@ yzhou2001, zhonghaihua, zhuol, zlpmichelle, Örjan Lundberg, Łukasz Gieroń</p>
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -162,6 +162,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -170,9 +173,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -306,6 +306,9 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Roberts, Adrian Petrescu, Ahmed Mahran
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -314,9 +317,6 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Roberts, Adrian Petrescu, Ahmed Mahran
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-3.html
+++ b/site/releases/spark-release-2-1-3.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -372,6 +372,9 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Budde, Adam Roberts, Adrian Ionescu, A
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -380,9 +383,6 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Budde, Adam Roberts, Adrian Ionescu, A
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-2.html
+++ b/site/releases/spark-release-2-2-2.html
@@ -162,6 +162,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -170,9 +173,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-3.html
+++ b/site/releases/spark-release-2-2-3.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -382,6 +382,9 @@ ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Albe
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -390,9 +393,6 @@ ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Albe
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-1.html
+++ b/site/releases/spark-release-2-3-1.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-2.html
+++ b/site/releases/spark-release-2-3-2.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-3.html
+++ b/site/releases/spark-release-2-3-3.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-4.html
+++ b/site/releases/spark-release-2-3-4.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-0.html
+++ b/site/releases/spark-release-2-4-0.html
@@ -388,6 +388,9 @@ Achuth17, Adam Bradbury, Adamyuanyuan, Adelbert Chang, Ala Luszczak, Aleksandr K
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -396,9 +399,6 @@ Achuth17, Adam Bradbury, Adamyuanyuan, Adelbert Chang, Ala Luszczak, Aleksandr K
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-1.html
+++ b/site/releases/spark-release-2-4-1.html
@@ -198,6 +198,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -206,9 +209,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-2.html
+++ b/site/releases/spark-release-2-4-2.html
@@ -170,6 +170,9 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -178,9 +181,6 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-3.html
+++ b/site/releases/spark-release-2-4-3.html
@@ -168,6 +168,9 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -176,9 +179,6 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-4.html
+++ b/site/releases/spark-release-2-4-4.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-5.html
+++ b/site/releases/spark-release-2-4-5.html
@@ -188,6 +188,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -196,9 +199,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-6.html
+++ b/site/releases/spark-release-2-4-6.html
@@ -196,6 +196,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -204,9 +207,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-7.html
+++ b/site/releases/spark-release-2-4-7.html
@@ -238,6 +238,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -246,9 +249,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-8.html
+++ b/site/releases/spark-release-2-4-8.html
@@ -239,6 +239,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -247,9 +250,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-0.html
+++ b/site/releases/spark-release-3-0-0.html
@@ -548,6 +548,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -556,9 +559,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-1.html
+++ b/site/releases/spark-release-3-0-1.html
@@ -197,6 +197,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -205,9 +208,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-2.html
+++ b/site/releases/spark-release-3-0-2.html
@@ -207,6 +207,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -215,9 +218,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-3.html
+++ b/site/releases/spark-release-3-0-3.html
@@ -224,6 +224,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -232,9 +235,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-1.html
+++ b/site/releases/spark-release-3-1-1.html
@@ -585,6 +585,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -593,9 +596,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-2.html
+++ b/site/releases/spark-release-3-1-2.html
@@ -272,6 +272,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -280,9 +283,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-3.html
+++ b/site/releases/spark-release-3-1-3.html
@@ -186,6 +186,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -194,9 +197,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-0.html
+++ b/site/releases/spark-release-3-2-0.html
@@ -558,6 +558,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -566,9 +569,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-1.html
+++ b/site/releases/spark-release-3-2-1.html
@@ -191,6 +191,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -199,9 +202,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-2.html
+++ b/site/releases/spark-release-3-2-2.html
@@ -266,6 +266,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -274,9 +277,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-3.html
+++ b/site/releases/spark-release-3-2-3.html
@@ -239,6 +239,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -247,9 +250,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-4.html
+++ b/site/releases/spark-release-3-2-4.html
@@ -201,6 +201,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -209,9 +212,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-0.html
+++ b/site/releases/spark-release-3-3-0.html
@@ -738,6 +738,9 @@ Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</sp
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -746,9 +749,6 @@ Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</sp
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-1.html
+++ b/site/releases/spark-release-3-3-1.html
@@ -248,6 +248,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -256,9 +259,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-2.html
+++ b/site/releases/spark-release-3-3-2.html
@@ -325,6 +325,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -333,9 +336,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-3.html
+++ b/site/releases/spark-release-3-3-3.html
@@ -180,6 +180,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -188,9 +191,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-4.html
+++ b/site/releases/spark-release-3-3-4.html
@@ -207,6 +207,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -215,9 +218,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-4-0.html
+++ b/site/releases/spark-release-3-4-0.html
@@ -566,6 +566,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -574,9 +577,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-4-1.html
+++ b/site/releases/spark-release-3-4-1.html
@@ -253,6 +253,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -261,9 +264,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-4-2.html
+++ b/site/releases/spark-release-3-4-2.html
@@ -249,6 +249,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -257,9 +260,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-5-0.html
+++ b/site/releases/spark-release-3-5-0.html
@@ -535,6 +535,9 @@ Adam Binford, Ahmed Hussein, Alex Jing, Alice Sayutina, Alkis Evlogimenos, Allan
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -543,9 +546,6 @@ Adam Binford, Ahmed Hussein, Alex Jing, Alice Sayutina, Alkis Evlogimenos, Allan
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-5-1.html
+++ b/site/releases/spark-release-3-5-1.html
@@ -1,0 +1,356 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>
+     Spark Release 3.5.1 | Apache Spark
+    
+  </title>
+
+  
+
+  
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
+  <link href="/css/custom.css" rel="stylesheet">
+  <!-- Code highlighter CSS -->
+  <link href="/css/pygments-default.css" rel="stylesheet">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+  <!-- Matomo -->
+  <script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["disableCookies"]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="https://analytics.apache.org/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '40']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
+</head>
+<body class="global">
+<nav class="navbar navbar-expand-lg navbar-dark p-0 px-4" style="background: #1D6890;">
+  <a class="navbar-brand" href="/">
+    <img src="/images/spark-logo-rev.svg" alt="" width="141" height="72">
+  </a>
+  <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent"
+          aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse col-md-12 col-lg-auto pt-4" id="navbarContent">
+
+    <ul class="navbar-nav me-auto">
+      <li class="nav-item">
+        <a class="nav-link active" aria-current="page" href="/downloads.html">Download</a>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="libraries" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Libraries
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="libraries">
+          <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
+          <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
+          <li>
+            <hr class="dropdown-divider">
+          </li>
+          <li><a class="dropdown-item" href="/third-party-projects.html">Third-Party Projects</a></li>
+        </ul>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="documentation" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Documentation
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="documentation">
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release</a></li>
+          <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
+          <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
+        </ul>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link active" aria-current="page" href="/examples.html">Examples</a>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="community" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Community
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="community">
+          <li><a class="dropdown-item" href="/community.html">Mailing Lists &amp; Resources</a></li>
+          <li><a class="dropdown-item" href="/contributing.html">Contributing to Spark</a></li>
+          <li><a class="dropdown-item" href="/improvement-proposals.html">Improvement Proposals (SPIP)</a>
+          </li>
+          <li><a class="dropdown-item" href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a>
+          </li>
+          <li><a class="dropdown-item" href="/powered-by.html">Powered By</a></li>
+          <li><a class="dropdown-item" href="/committers.html">Project Committers</a></li>
+          <li><a class="dropdown-item" href="/history.html">Project History</a></li>
+        </ul>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="developers" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Developers
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="developers">
+          <li><a class="dropdown-item" href="/developer-tools.html">Useful Developer Tools</a></li>
+          <li><a class="dropdown-item" href="/versioning-policy.html">Versioning Policy</a></li>
+          <li><a class="dropdown-item" href="/release-process.html">Release Process</a></li>
+          <li><a class="dropdown-item" href="/security.html">Security</a></li>
+        </ul>
+      </li>
+    </ul>
+    <ul class="navbar-nav ml-auto">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="apacheFoundation" role="button"
+           data-bs-toggle="dropdown" aria-expanded="false">
+          Apache Software Foundation
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="apacheFoundation">
+          <li><a class="dropdown-item" href="https://www.apache.org/">Apache Homepage</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/licenses/">License</a></li>
+          <li><a class="dropdown-item"
+                 href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/security/">Security</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/events/current-event">Event</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</nav>
+
+<div class="container">
+  <div class="row mt-4">
+    <div class="col-12 col-md-9">
+      <h2>Spark Release 3.5.1</h2>
+
+
+<p>Spark 3.5.1 is the last maintenance release containing security and correctness fixes. This release is based on the branch-3.5 maintenance branch of Spark. We strongly recommend all 3.5 users to upgrade to this stable release.</p>
+
+<h3 id="notable-changes">Notable changes</h3>
+
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45187">[SPARK-45187]</a>: Fix WorkerPage to use the same pattern for <code class="language-plaintext highlighter-rouge">logPage</code> urls</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45553">[SPARK-45553]</a>: Deprecate assertPandasOnSparkEqual</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45652">[SPARK-45652]</a>: SPJ: Handle empty input partitions after dynamic filtering</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46012">[SPARK-46012]</a>: EventLogFileReader should not read rolling logs if appStatus is missing</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46029">[SPARK-46029]</a>: Escape the single quote, _ and % for DS V2 pushdown</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46369">[SPARK-46369]</a>: Remove <code class="language-plaintext highlighter-rouge">kill</code> link from RELAUNCHING drivers in MasterPage</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46704">[SPARK-46704]</a>: Fix <code class="language-plaintext highlighter-rouge">MasterPage</code> to sort <code class="language-plaintext highlighter-rouge">Running Drivers</code> table by <code class="language-plaintext highlighter-rouge">Duration</code> column correctly</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46817">[SPARK-46817]</a>: Fix <code class="language-plaintext highlighter-rouge">spark-daemon.sh</code> usage by adding <code class="language-plaintext highlighter-rouge">decommission</code> command</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46888">[SPARK-46888]</a>: Fix <code class="language-plaintext highlighter-rouge">Master</code> to reject worker kill request if decommission is disabled</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-39910">[SPARK-39910]</a>: DataFrameReader API cannot read files from hadoop archives (.har)</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-40154">[SPARK-40154]</a>: PySpark: DataFrame.cache docstring gives wrong storage level</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-43393">[SPARK-43393]</a>: Sequence expression can overflow</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44683">[SPARK-44683]</a>: Logging level isn&#8217;t passed to RocksDB state store provider correctly</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44805">[SPARK-44805]</a>: Data lost after union using spark.sql.parquet.enableNestedColumnVectorizedReader=true</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44840">[SPARK-44840]</a>: array_insert() give wrong results for ngative index</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44910">[SPARK-44910]</a>: Encoders.bean does not support superclasses with generic type arguments</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44973">[SPARK-44973]</a>: Fix ArrayIndexOutOfBoundsException in conv()</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45014">[SPARK-45014]</a>: Clean up fileserver when cleaning up files, jars and archives in SparkContext</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45057">[SPARK-45057]</a>: Deadlock caused by rdd replication level of 2</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45072">[SPARK-45072]</a>: Fix Outerscopes for same cell evaluation</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45075">[SPARK-45075]</a>: Alter table with invalid default value will not report error</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45078">[SPARK-45078]</a>: The ArrayInsert function should make explicit casting when element type not equals derived component type</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45081">[SPARK-45081]</a>: Encoders.bean does no longer work with read-only properties</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45106">[SPARK-45106]</a>: percentile_cont gets internal error when user input fails runtime replacement&#8217;s input type check</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45117">[SPARK-45117]</a>: Implement missing otherCopyArgs for the MultiCommutativeOp expression</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45124">[SPARK-45124]</a>: Do not use local user ID for Local Relations</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45132">[SPARK-45132]</a>: Fix IDENTIFIER clause for functions</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45171">[SPARK-45171]</a>: GenerateExec fails to initialize non-deterministic expressions before use</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45182">[SPARK-45182]</a>: Ignore task completion from old stage after retrying indeterminate stages</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45205">[SPARK-45205]</a>: Since version 3.2.0, Spark SQL has taken longer to execute &#8220;show paritions&#8221;,probably because of changes introduced by SPARK-35278</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45227">[SPARK-45227]</a>: Fix a subtle thread-safety issue with CoarseGrainedExecutorBackend where an executor process randomly gets stuck</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45291">[SPARK-45291]</a>: Use unknown query execution id instead of no such app when id is invalid</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45311">[SPARK-45311]</a>: Encoder fails on many &#8220;NoSuchElementException: None.get&#8221; since 3.4.x, search for an encoder for a generic type, and since 3.5.x isn&#8217;t &#8220;an expression encoder&#8221;</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45346">[SPARK-45346]</a>: Parquet schema inference should respect case sensitive flag when merging schema</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45371">[SPARK-45371]</a>: FIx shading problem in Spark Connect</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45383">[SPARK-45383]</a>: Missing case for RelationTimeTravel in CheckAnalysis</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45389">[SPARK-45389]</a>: Correct MetaException matching rule on getting partition metadata</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45424">[SPARK-45424]</a>: Regression in CSV schema inference when timestamps do not match specified timestampFormat</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45430">[SPARK-45430]</a>: FramelessOffsetWindowFunctionFrame fails when ignore nulls and offset &gt; # of rows</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45433">[SPARK-45433]</a>: CSV/JSON schema inference when timestamps do not match specified timestampFormat with only one row on each partition report error</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45449">[SPARK-45449]</a>: Cache Invalidation Issue with JDBC Table</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45484">[SPARK-45484]</a>: Fix the bug that uses incorrect parquet compression codec lz4raw</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45498">[SPARK-45498]</a>: Followup: Ignore task completion from old stage after retrying indeterminate stages</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45508">[SPARK-45508]</a>: Add &#8220;&#8211;add-opens=java.base/jdk.internal.ref=ALL-UNNAMED&#8221; so Platform can access cleaner on Java 9+</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45543">[SPARK-45543]</a>: InferWindowGroupLimit causes bug if the other window functions haven&#8217;t the same window frame as the rank-like functions</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45561">[SPARK-45561]</a>: Convert TINYINT catalyst properly in MySQL Dialect</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45580">[SPARK-45580]</a>: Subquery changes the output schema of the outer query</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45584">[SPARK-45584]</a>: Execution fails when there are subqueries in TakeOrderedAndProjectExec</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45592">[SPARK-45592]</a>: AQE and InMemoryTableScanExec correctness bug</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45604">[SPARK-45604]</a>: Converting timestamp_ntz to array<timestamp_ntz> can cause NPE or SEGFAULT on parquet vectorized reader</timestamp_ntz></li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45616">[SPARK-45616]</a>: Usages of ParVector are unsafe because it does not propagate ThreadLocals or SparkSession</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45631">[SPARK-45631]</a>: Broken backward compatibility in PySpark: StreamingQueryListener due to the addition of onQueryIdle</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45670">[SPARK-45670]</a>: SparkSubmit does not support &#8211;total-executor-cores when deploying on K8s</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45678">[SPARK-45678]</a>: Cover BufferReleasingInputStream.available under tryOrFetchFailedException</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45786">[SPARK-45786]</a>: Inaccurate Decimal multiplication and division results</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45814">[SPARK-45814]</a>: ArrowConverters.createEmptyArrowBatch may cause memory leak</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45896">[SPARK-45896]</a>: Expression encoding fails for Seq/Map of <code class="language-plaintext highlighter-rouge">Option[Seq/Date/Timestamp/BigDecimal]</code></li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45920">[SPARK-45920]</a>: group by ordinal should be idempotent</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46006">[SPARK-46006]</a>: YarnAllocator miss clean targetNumExecutorsPerResourceProfileId after YarnSchedulerBackend call stop</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46016">[SPARK-46016]</a>: Fix pandas API support list properly</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46062">[SPARK-46062]</a>: CTE reference node does not inherit the flag <code class="language-plaintext highlighter-rouge">isStreaming</code> from CTE definition node</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46064">[SPARK-46064]</a>: EliminateEventTimeWatermark does not consider the fact that isStreaming flag can change for current child during resolution</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46092">[SPARK-46092]</a>: Overflow in Parquet row group filter creation causes incorrect results</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46189">[SPARK-46189]</a>: Various Pandas functions fail in interpreted mode</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46239">[SPARK-46239]</a>: Hide Jetty info</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46274">[SPARK-46274]</a>: Range operator computeStats() proper long conversions</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46275">[SPARK-46275]</a>: Protobuf: Permissive mode should return null rather than struct with null fields</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46330">[SPARK-46330]</a>: Loading of Spark UI blocks for a long time when HybridStore enabled</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46339">[SPARK-46339]</a>: Directory with number name should not be treated as metadata log</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46388">[SPARK-46388]</a>: HiveAnalysis misses pattern guard <code class="language-plaintext highlighter-rouge">query.resolved</code></li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46396">[SPARK-46396]</a>: LegacyFastTimestampFormatter.parseOptional should not throw exception</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46443">[SPARK-46443]</a>: Decimal precision and scale should decided by JDBC dialect.</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46453">[SPARK-46453]</a>: SessionHolder doesn&#8217;t throw exceptions from internalError()</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46466">[SPARK-46466]</a>: vectorized parquet reader should never do rebase for timestamp ntz</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46480">[SPARK-46480]</a>: Fix NPE when table cache task attempt</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46535">[SPARK-46535]</a>: NPE when describe extended a column without col stats</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46562">[SPARK-46562]</a>: Remove retrieval of <code class="language-plaintext highlighter-rouge">keytabFile</code> from <code class="language-plaintext highlighter-rouge">UserGroupInformation</code> in <code class="language-plaintext highlighter-rouge">HiveAuthFactory</code></li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46590">[SPARK-46590]</a>: Coalesce partiton assert error after skew join optimization</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46598">[SPARK-46598]</a>: OrcColumnarBatchReader should respect the memory mode when creating column vectors for the missing column</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46602">[SPARK-46602]</a>: CREATE VIEW IF NOT EXISTS should never throw <code class="language-plaintext highlighter-rouge">TABLE_OR_VIEW_ALREADY_EXISTS</code> exception</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46609">[SPARK-46609]</a>: avoid exponential explosion in PartitioningPreservingUnaryExecNode</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46640">[SPARK-46640]</a>: RemoveRedundantAliases does not account for SubqueryExpression when removing aliases</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46663">[SPARK-46663]</a>: Disable memory profiler for pandas UDFs with iterators</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46676">[SPARK-46676]</a>: dropDuplicatesWithinWatermark throws error on canonicalizing plan</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46684">[SPARK-46684]</a>: CoGroup.applyInPandas/Arrow should pass arguments properly</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46700">[SPARK-46700]</a>: count the last spilling for the shuffle disk spilling bytes metric</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46747">[SPARK-46747]</a>: Too Many Shared Locks due to PostgresDialect.getTableExistsQuery - LIMIT 1</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46763">[SPARK-46763]</a>: ReplaceDeduplicateWithAggregate fails when non-grouping keys have duplicate attributes</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46769">[SPARK-46769]</a>: Refine timestamp related schema inference</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46779">[SPARK-46779]</a>: Grouping by subquery with a cached relation can fail</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46786">[SPARK-46786]</a>: Fix MountVolumesFeatureStep to use ReadWriteOncePod instead of ReadWriteOnce</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46794">[SPARK-46794]</a>: Incorrect results due to inferred predicate from checkpoint with subquery</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46796">[SPARK-46796]</a>: RocksDB versionID Mismatch in SST files</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46855">[SPARK-46855]</a>: Add <code class="language-plaintext highlighter-rouge">sketch</code> to the dependencies of the <code class="language-plaintext highlighter-rouge">catalyst</code> module in <code class="language-plaintext highlighter-rouge">module.py</code></li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46861">[SPARK-46861]</a>: Avoid Deadlock in DAGScheduler</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46862">[SPARK-46862]</a>: Incorrect count() of a dataframe loaded from CSV datasource</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46945">[SPARK-46945]</a>: Add <code class="language-plaintext highlighter-rouge">spark.kubernetes.legacy.useReadWriteOnceAccessMode</code> for old K8s clusters</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-47019">[SPARK-47019]</a>: AQE dynamic cache partitioning causes SortMergeJoin to result in data loss</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45360">[SPARK-45360]</a>: Initialize spark session builder configuration from SPARK_REMOTE</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45706">[SPARK-45706]</a>: Makes entire Binder build fails fast during setting up</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46732">[SPARK-46732]</a>: Propagate JobArtifactSet to broadcast execution thread</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44833">[SPARK-44833]</a>: Spark Connect reattach when initial ExecutePlan didn&#8217;t reach server doing too eager Reattach</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-44835">[SPARK-44835]</a>: SparkConnect ReattachExecute could raise before ExecutePlan even attaches.</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45050">[SPARK-45050]</a>: Improve error message for UNKNOWN io.grpc.StatusRuntimeException</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45071">[SPARK-45071]</a>: Optimize the processing speed of <code class="language-plaintext highlighter-rouge">BinaryArithmetic#dataType</code> when processing multi-column data</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45250">[SPARK-45250]</a>: Support stage level task resource profile for yarn cluster when dynamic allocation disabled</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45386">[SPARK-45386]</a>: Correctness issue when persisting using StorageLevel.NONE</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45419">[SPARK-45419]</a>: Avoid reusing rocksdb sst files in a dfferent rocksdb instance by removing file version map entry of larger versions</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45495">[SPARK-45495]</a>: Support stage level task resource profile for k8s cluster when dynamic allocation disabled</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45538">[SPARK-45538]</a>: pyspark connect overwrite_partitions bug</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45770">[SPARK-45770]</a>: Fix column resolution in DataFrame.drop</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45882">[SPARK-45882]</a>: BroadcastHashJoinExec propagate partitioning should respect CoalescedHashPartitioning</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45974">[SPARK-45974]</a>: Add scan.filterAttributes non-empty judgment for RowLevelOperationRuntimeGroupFiltering</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46170">[SPARK-46170]</a>: Support inject adaptive query post planner strategy rules in SparkSessionExtensions</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46380">[SPARK-46380]</a>: Replacing current time prior to inline table eval</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46600">[SPARK-46600]</a>: Move shared code between SqlConf and SqlApiConf to another object</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46610">[SPARK-46610]</a>: Create table should throw exception when no value for a key in options</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45189">[SPARK-45189]</a>: Creating UnresolvedRelation from TableIdentifier should include the catalog field</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46182">[SPARK-46182]</a>: Shuffle data lost on decommissioned executor caused by race condition between lastTaskRunningTime and lastShuffleMigrationTime</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46547">[SPARK-46547]</a>: Fix deadlock issue between maintenance thread and streaming agg physical operators</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46628">[SPARK-46628]</a>: Use SPDX short identifier in <code class="language-plaintext highlighter-rouge">licenses</code> name</li>
+</ul>
+
+<h3 id="dependency-changes">Dependency Changes</h3>
+
+<p>While being a maintenance release we did still upgrade some dependencies in this release they are:</p>
+
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-47023">[SPARK-47023]</a>: Upgrade <code class="language-plaintext highlighter-rouge">aircompressor</code> to 0.26</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-47023">[SPARK-45883]</a>: Upgrade ORC to 1.9.2</li>
+</ul>
+
+<p>You can consult JIRA for the <a href="https://s.apache.org/spark-3.5.1">detailed changes</a>.</p>
+
+<p>We would like to acknowledge all community members for contributing patches to this release.</p>
+
+
+<p>
+<br/>
+<a href="/news/">Spark News Archive</a>
+</p>
+
+    </div>
+    <div class="col-12 col-md-3">
+      <div class="news" style="margin-bottom: 20px;">
+        <h5>Latest News</h5>
+        <ul class="list-unstyled">
+          
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
+          <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
+            <span class="small">(Dec 16, 2023)</span></li>
+          
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
+          <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
+            <span class="small">(Sep 13, 2023)</span></li>
+          
+        </ul>
+        <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
+      </div>
+      <div style="text-align:center; margin-bottom: 20px;">
+        <a href="https://www.apache.org/events/current-event.html">
+          <img src="https://www.apache.org/events/current-event-234x60.png" style="max-width: 100%;"/>
+        </a>
+      </div>
+      <div class="hidden-xs hidden-sm">
+        <a href="/downloads.html" class="btn btn-cta btn-lg d-grid" style="margin-bottom: 30px;">
+          Download Spark
+        </a>
+        <p style="font-size: 16px; font-weight: 500; color: #555;">
+          Built-in Libraries:
+        </p>
+        <ul class="list-none">
+          <li><a href="/sql/">SQL and DataFrames</a></li>
+          <li><a href="/streaming/">Spark Streaming</a></li>
+          <li><a href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a href="/graphx/">GraphX (graph)</a></li>
+        </ul>
+        <a href="/third-party-projects.html">Third-Party Projects</a>
+      </div>
+    </div>
+  </div>
+
+  
+
+  <footer class="small">
+    <hr>
+    Apache Spark, Spark, Apache, the Apache feather logo, and the Apache Spark project logo are either registered
+    trademarks or trademarks of The Apache Software Foundation in the United States and other countries.
+    See guidance on use of Apache Spark <a href="/trademarks.html">trademarks</a>.
+    All other marks mentioned may be trademarks or registered trademarks of their respective owners.
+    Copyright &copy; 2018 The Apache Software Foundation, Licensed under the
+    <a href="https://www.apache.org/licenses/">Apache License, Version 2.0</a>.
+  </footer>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+        crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery.js"></script>
+<script src="/js/lang-tabs.js"></script>
+<script src="/js/downloads.js"></script>
+</body>
+</html>

--- a/site/research.html
+++ b/site/research.html
@@ -204,6 +204,9 @@ Spark offers an abstraction called <a href="http://people.csail.mit.edu/matei/pa
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -212,9 +215,6 @@ Spark offers an abstraction called <a href="http://people.csail.mit.edu/matei/pa
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -166,6 +166,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -174,9 +177,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -166,6 +166,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -174,9 +177,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -162,6 +162,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -170,9 +173,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -160,6 +160,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -168,9 +171,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -188,6 +188,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -196,9 +199,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/security.html
+++ b/site/security.html
@@ -667,6 +667,9 @@ PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -675,9 +678,6 @@ PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -144,6 +144,14 @@
 </url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
+  <loc>https://spark.apache.org/releases/spark-release-3-5-1.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/news/spark-3-5-1-released.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/releases/spark-release-3-3-4.html</loc>
   <changefreq>weekly</changefreq>
 </url>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -302,6 +302,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -310,9 +313,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -244,6 +244,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -252,9 +255,6 @@
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -252,6 +252,9 @@ transforming, and analyzing genomic data using Apache Spark</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -260,9 +263,6 @@ transforming, and analyzing genomic data using Apache Spark</li>
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -206,6 +206,9 @@ If you have any questions about the Apache trademark policy, please email
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -214,9 +217,6 @@ If you have any questions about the Apache trademark policy, please email
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -308,6 +308,9 @@ For example, 2.4.0 was released in November 2nd 2018 and had been maintained for
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
           <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
             <span class="small">(Dec 16, 2023)</span></li>
           
@@ -316,9 +319,6 @@ For example, 2.4.0 was released in November 2nd 2018 and had been maintained for
           
           <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
             <span class="small">(Sep 13, 2023)</span></li>
-          
-          <li><a href="/news/spark-3-3-3-released.html">Spark 3.3.3 released</a>
-            <span class="small">(Aug 21, 2023)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>


### PR DESCRIPTION
* Vote Result: https://lists.apache.org/thread/hpkrbdwfrzq3r19z89zn4wd9gt0dhwvo
* Documentation: https://spark.apache.org/docs/3.5.1/
* Binary: https://downloads.apache.org/spark/spark-3.5.1/
* PySpark: https://pypi.org/project/pyspark/3.5.1/
* Maven Central: https://repo1.maven.org/maven2/org/apache/spark/spark-core_2.13/3.5.1/

![127 0 0 1_4000_downloads_v2 html](https://github.com/apache/spark-website/assets/1317309/9f4f1553-e124-4b2e-a164-81848fc4896b)

![127 0 0 1_4000_news_spark-3-5-1-released html](https://github.com/apache/spark-website/assets/1317309/6b574328-bc15-4ac1-9cf1-f4fe8d25edd6)

![127 0 0 1_4000_releases_spark-release-3-5-1 html](https://github.com/apache/spark-website/assets/1317309/5f03f13e-2f11-4867-926c-81c06277cfb0)
