### PR TITLE
Guide release manager to give a last chance to backup docs artifact before removing it

### DIFF
--- a/release-process.md
+++ b/release-process.md
@@ -254,7 +254,7 @@ Since it requires further manual steps, please also contact the <a href="mailto:
 
 <h4>Remove RC artifacts from repositories</h4>
 
-**NOTE! If you did not make a backup of docs for approved RC, this is the last time you can make a backup. Check out docs from svn before removing the directory.**
+**NOTE! If you did not make a backup of docs for approved RC, this is the last time you can make a backup. This will be used to upload the docs to the website in next few step. Check out docs from svn before removing the directory.**
 
 After the vote passes and you moved the approved RC to the release repository, you should delete
 the RC directories from the staging repository. For example:

--- a/release-process.md
+++ b/release-process.md
@@ -254,6 +254,8 @@ Since it requires further manual steps, please also contact the <a href="mailto:
 
 <h4>Remove RC artifacts from repositories</h4>
 
+**NOTE! If you did not make a backup of docs for approved RC, this is the last time you can make a backup. Check out docs from svn before removing the directory.**
+
 After the vote passes and you moved the approved RC to the release repository, you should delete
 the RC directories from the staging repository. For example:
 

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -391,7 +391,7 @@ Since it requires further manual steps, please also contact the <a href="mailto:
 
 <h4>Remove RC artifacts from repositories</h4>
 
-<p><strong>NOTE! If you did not make a backup of docs for approved RC, this is the last time you can make a backup. Check out docs from svn before removing the directory.</strong></p>
+<p><strong>NOTE! If you did not make a backup of docs for approved RC, this is the last time you can make a backup. This will be used to upload the docs to the website in next few step. Check out docs from svn before removing the directory.</strong></p>
 
 <p>After the vote passes and you moved the approved RC to the release repository, you should delete
 the RC directories from the staging repository. For example:</p>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -391,6 +391,8 @@ Since it requires further manual steps, please also contact the <a href="mailto:
 
 <h4>Remove RC artifacts from repositories</h4>
 
+<p><strong>NOTE! If you did not make a backup of docs for approved RC, this is the last time you can make a backup. Check out docs from svn before removing the directory.</strong></p>
+
 <p>After the vote passes and you moved the approved RC to the release repository, you should delete
 the RC directories from the staging repository. For example:</p>
 


### PR DESCRIPTION
In release process page, we guide the release manager "too lately" about keeping the generated docs of the latest RC. The guidance sentence appears later than removing docs from svn.

https://spark.apache.org/release-process.html - read through the section "finalize the release".

If release manager does not have any backup, they are expected to build the docs from scratch, and it's really painful to set up languages and corresponding libraries locally to build the doc (release script with docker is no longer usable at this time). It would be better to remind that they can take a backup before removing the artifact, which they will use the backup very soon.

Here is the screenshot of the change - bold NOTE sentence:

<img width="994" alt="스크린샷 2024-02-26 오후 4 33 07" src="https://github.com/apache/spark-website/assets/1317309/949ab008-bb84-4eaf-880f-084ebca3bd90">
