### PR TITLE
Slight correction of introduction for 3.5.1

### DIFF
--- a/releases/_posts/2024-02-23-spark-release-3-5-1.md
+++ b/releases/_posts/2024-02-23-spark-release-3-5-1.md
@@ -11,7 +11,7 @@ meta:
   _wpas_done_all: '1'
 ---
 
-Spark 3.5.1 is the last maintenance release containing security and correctness fixes. This release is based on the branch-3.5 maintenance branch of Spark. We strongly recommend all 3.5 users to upgrade to this stable release.
+Spark 3.5.1 is the first maintenance release containing security and correctness fixes. This release is based on the branch-3.5 maintenance branch of Spark. We strongly recommend all 3.5 users to upgrade to this stable release.
 
 ### Notable changes
 

--- a/site/releases/spark-release-3-5-1.html
+++ b/site/releases/spark-release-3-5-1.html
@@ -142,7 +142,7 @@
       <h2>Spark Release 3.5.1</h2>
 
 
-<p>Spark 3.5.1 is the last maintenance release containing security and correctness fixes. This release is based on the branch-3.5 maintenance branch of Spark. We strongly recommend all 3.5 users to upgrade to this stable release.</p>
+<p>Spark 3.5.1 is the first maintenance release containing security and correctness fixes. This release is based on the branch-3.5 maintenance branch of Spark. We strongly recommend all 3.5 users to upgrade to this stable release.</p>
 
 <h3 id="notable-changes">Notable changes</h3>
 


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->

This PR fixes a silly mistake on introducing 3.5.1, it's the **first** maintenance release of 3.5 version line, not **last**. Directly modified the html as the change is just several characters.