### PR TITLE
Remove the extra text on page sql-error-conditions-sqlstates

### DIFF
--- a/site/docs/3.4.0/sql-error-conditions-sqlstates.html
+++ b/site/docs/3.4.0/sql-error-conditions-sqlstates.html
@@ -1149,8 +1149,6 @@ Each character must be a digit <code class="language-plaintext highlighter-rouge
     
 </table>
 
-<p>.. include:: /shared/replacements.md</p>
-
 
                 </div>
             

--- a/site/docs/3.4.1/sql-error-conditions-sqlstates.html
+++ b/site/docs/3.4.1/sql-error-conditions-sqlstates.html
@@ -1149,8 +1149,6 @@ Each character must be a digit <code class="language-plaintext highlighter-rouge
     
 </table>
 
-<p>.. include:: /shared/replacements.md</p>
-
 
                 </div>
             

--- a/site/docs/3.4.2/sql-error-conditions-sqlstates.html
+++ b/site/docs/3.4.2/sql-error-conditions-sqlstates.html
@@ -1152,8 +1152,6 @@ Each character must be a digit <code class="language-plaintext highlighter-rouge
     
 </table>
 
-<p>.. include:: /shared/replacements.md</p>
-
 
                 </div>
             

--- a/site/docs/3.5.0/sql-error-conditions-sqlstates.html
+++ b/site/docs/3.5.0/sql-error-conditions-sqlstates.html
@@ -1160,8 +1160,6 @@ Each character must be a digit <code class="language-plaintext highlighter-rouge
 
 </table>
 
-<p>.. include:: /shared/replacements.md</p>
-
 
                 </div>
             

--- a/site/docs/3.5.1/sql-error-conditions-sqlstates.html
+++ b/site/docs/3.5.1/sql-error-conditions-sqlstates.html
@@ -1163,8 +1163,6 @@ Each character must be a digit <code class="language-plaintext highlighter-rouge
 
 </table>
 
-<p>.. include:: /shared/replacements.md</p>
-
 
                 </div>
             


### PR DESCRIPTION
The pr aims to remove the extra text `.. include:: /shared/replacements.md` on page `sql-error-conditions-sqlstates.html`.

The original PR is here: https://github.com/apache/spark/pull/45469
