### PR TITLE
add pandas on spark page

### DIFF
--- a/_layouts/global.html
+++ b/_layouts/global.html
@@ -71,6 +71,7 @@
           <li><a class="dropdown-item" href="{{site.baseurl}}/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="{{site.baseurl}}/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="{{site.baseurl}}/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="{{site.baseurl}}/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="{{site.baseurl}}/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="{{site.baseurl}}/graphx/">GraphX (graph)</a></li>
           <li>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -75,6 +75,7 @@
           <li><a class="dropdown-item" href="{{site.baseurl}}/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="{{site.baseurl}}/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="{{site.baseurl}}/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="{{site.baseurl}}/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="{{site.baseurl}}/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="{{site.baseurl}}/graphx/">GraphX (graph)</a></li>
           <li>

--- a/pandas-on-spark/index.md
+++ b/pandas-on-spark/index.md
@@ -1,0 +1,194 @@
+---
+layout: global
+type: "page singular"
+title: pandas API on Spark
+description: The pandas API on Spark offers the familiarity of pandas with the power of Spark.
+subproject: pandas API on Spark
+---
+
+# pandas API on Spark
+
+This page describes the advantages of the pandas API on Spark (“pandas on Spark”) and when you should use it instead of pandas (or in conjunction with pandas).
+
+pandas on Spark can be much faster than pandas and offers syntax that is familiar to pandas users.  It offers the power of Spark with the familiarity of pandas.
+
+Here are the main advantages of pandas on Spark:
+
+* Faster query execution on single-machine workloads (because pandas on Spark uses all available cores, processes queries in parallel, and optimizes queries)
+* pandas on Spark is scalable to multiple machines in a cluster and can process big data
+* pandas on Spark allows queries to be run on larger than memory datasets
+* pandas on Spark provides familiar syntax for pandas users
+
+pandas has many limitations:
+
+* pandas must load all data into memory before running a query which can be slow
+* pandas cannot process datasets that are larger than the available memory on a single machine (because all data must be loaded into memory)
+* pandas computations are run on a single core and don't leverage all available cores of a single machine
+* pandas computations cannot be scaled out to multiple machines
+* pandas doesn't have a query optimizer, so users have to manually code optimizations or suffer from slow code
+
+Let's look at some simple examples to get a better understanding of how pandas on Spark overcomes the limitations of pandas.  We’ll also investigate the limitations of pandas on Spark.
+
+At the end of this page, you will see how you can use both pandas and pandas on Spark in conjunction.  It’s not an either/or decision - in many situations using both is a great option.
+
+## pandas on Spark example
+
+This section demonstrates how pandas on Spark can run a query on a single file on localhost faster than pandas.  pandas on Spark isn’t necessarily faster for all queries, but this example shows when it provides a nice speed-up.
+
+Suppose you have a Parquet file with 9 columns and 1 billion rows of data.  Here are the first three rows of the file:
+
+```
++-------+-------+--------------+-------+-------+--------+------+------+---------+
+| id1   | id2   | id3          |   id4 |   id5 |    id6 |   v1 |   v2 |      v3 |
+|-------+-------+--------------+-------+-------+--------+------+------+---------|
+| id016 | id046 | id0000109363 |    88 |    13 | 146094 |    4 |    6 | 18.8377 |
+| id039 | id087 | id0000466766 |    14 |    30 | 111330 |    4 |   14 | 46.7973 |
+| id047 | id098 | id0000307804 |    85 |    23 | 187639 |    3 |    5 | 47.5773 |
++-------+-------+--------------+-------+-------+--------+------+------+---------+
+```
+
+Here is how you can use pandas on Spark to read the file and run a group by aggregation.
+
+```python
+import pyspark.pandas as ps
+
+df = ps.read_parquet("G1_1e9_1e2_0_0.parquet")[
+    ["id1", "id2", "v3"]
+]
+df.query("id1 > 'id098'").groupby("id2").sum().head(3)
+```
+
+This query runs in 62 seconds when executed on a 2020 M1 Macbook with 64 GB of RAM with Spark 3.5.0.
+
+Let's compare this with unoptimized pandas code.
+
+```python
+import pandas as pd
+
+df = pd.read_parquet("G1_1e9_1e2_0_0.parquet")[
+    ["id1", "id2", "v3"]
+]
+df.query("id1 > 'id098'").groupby("id2").sum().head(3)
+```
+
+This query errors out because the machine with 64GB of RAM does not have enough space to store 1 billion rows of data in memory.
+
+Let’s manually add some pandas optimizations to make the query run:
+
+```python
+df = pd.read_parquet(
+    "G1_1e9_1e2_0_0.parquet",
+    columns=["id1", "id2", "v3"],
+    filters=[("id1", ">", "id098")],
+    engine="pyarrow",
+)
+df.query("id1 > 'id098'").groupby("id2").sum().head(3)
+```
+
+This query runs in 275 seconds with pandas 2.2.0.
+
+Coding these optimizations manually with pandas can potentially give the wrong results.  Here’s an example of a group by query that’s correct, but with a row-group filtering predicate that’s wrong:
+
+```python
+df = pd.read_parquet(
+    "G1_1e9_1e2_0_0.parquet",
+    columns=["id1", "id2", "v3"],
+    filters=[("id1", "==", "id001")],
+    engine="pyarrow",
+)
+df.query("id1 > 'id098'").groupby("id2").sum().head(3)
+```
+
+This returns the wrong result, even though the group by aggregation logic is right!
+
+With pandas, you need to manually apply column pruning and row-group filtering when reading a Parquet file.  With pandas on Spark, the Spark optimizer automatically applies these query enhancements, so you do not need to type them manually.
+
+Lets investigate the advantages of pandas on Spark in more detail.
+
+## Advantages of pandas on Spark
+
+Let's recap the advantages of pandas on Spark:
+
+**Faster query execution**
+
+pandas on Spark can execute queries faster than pandas because it uses all the available cores to parallelize computations and optimizes queries before running them to allow for efficient execution.
+
+pandas computations only run on a single core.
+
+**Scalable to larger-than-memory datasets**
+
+pandas loads data in memory before running queries, so it can only query datasets that fit into memory.
+
+Spark can query datasets that are larger than memory by streaming the data and incrementally running computations.
+
+pandas is notorious for erroring out when dataset sizes grow and Spark doesn't have this limitation.
+
+**Runnable on a cluster of many machines**
+
+Spark can be run on a single machine or distributed to many machines in a cluster.
+
+When Spark is run on a single machine, the computations are run on all available cores.  This is faster than pandas which only runs computations on a single core.
+
+Scaling computations on multiple machines is great for when you want to run computations on larger data sets or simply access more RAM/cores so the queries run faster.
+
+**Familiar syntax for pandas users**
+
+pandas on Spark was designed to provide familiar syntax for pandas users.
+
+The familiar syntax is the whole point - pandas on Spark provides the power of Spark with the same syntax that pandas users are accustomed to.
+
+**Provides access to Spark's battle-tested query optimizer**
+
+pandas on Spark computations are optimized by Spark’s Catalyst optimizer before they're executed.
+
+These optimizations simplify queries and add optimizations.
+
+Earlier in this post, we saw how Spark automatically adds the column pruning/row group filtering optimizations when reading Parquet files for example.  pandas doesn't have a query optimizer, so you need to add these optimizations yourself.  Manually adding optimizations is tedious and error-prone.  If you don't manually apply the right optimizations, your query will return the wrong result.
+
+## Limitations of pandas on Spark
+
+pandas on Spark doesn't support all the APIs that pandas supports for two reasons:
+
+* some features haven't been added to pandas on Spark yet
+
+* some pandas features don't make sense with Spark's distributed, parallel execution model
+
+Spark breaks up DataFrames into multiple chunks so they can be processed in parallel, so certain pandas operations don't transition well to Spark's execution model.
+
+## Using pandas on Spark in conjunction with regular pandas
+
+It’s often useful to use pandas on Spark and pandas to get the best of both worlds.
+
+Suppose you have a large dataset that you clean and aggregate into a smaller dataset that’s passed into a scikit-learn machine learning model.  
+
+You can clean and aggregate the dataset with pandas on Spark to take advantage of fast query times and parallel execution.  Once the dataset is processed, you can convert it to a pandas DataFrame with `to_pandas()` and then run the machine learning model with scikit-learn.  This approach works well if the dataset can be reduced enough to fit in a pandas DataFrame.
+
+## The pandas on Spark query execution model is different
+
+pandas on Spark executes queries completely differently than pandas.
+
+pandas on Spark converts the query to an unresolved logical plan, optimizes it with Spark, and then executes it.
+
+pandas loads all the data into memory and then executes the query with the pandas engine.  There are not any query optimization and all the data must be loaded into memory before the query is executed.
+
+When comparing pandas on Spark and pandas, you must be careful to factor in how much time it takes to load the data into memory and how much time it takes to run the query.  A lot of datasets take a long time to load into pandas.
+
+You can also load data into memory with pandas on Spark, but this is often considered an anti-pattern.  A dataset that’s loaded into memory won’t be updated if the data in storage changes (via an append, merge, or deletion).  Persisting a Spark DataFrame is wise in certain situations to speed up query times, but must be used carefully because it can cause incorrect query results.
+
+## How pandas on Spark and PySpark differ
+
+pandas on Spark and PySpark both take queries, convert them to unresolved logical plans, and then execute them with Spark.
+
+PySpark and pandas on Spark both have similar query execution models.  Converting a query to an unresolved logical plan is relatively quick.  Optimizing the query and executing it takes much more time.  So PySpark and pandas on Spark should have similar performance.
+
+The main difference between pandas on Spark and PySpark is just the syntax.  
+
+## Conclusion
+
+pandas on Spark is a great alternative for pandas users who would like to run their queries faster and want to leverage Spark’s optimizer rather than writing their own optimizations.
+
+pandas on Spark uses syntax that’s familiar to pandas users, so it’s easy to learn.
+
+pandas on Spark is also a great technology to be used in conjunction with pandas.  You can use the big-data and performant processing capabilities of pandas on Spark to process datasets before they’re converted into pandas DataFrames that are compatible with other technologies.
+
+Check out [the docs](https://spark.apache.org/docs/latest/api/python/user_guide/pandas_on_spark/index.html) to learn more about how to use pandas on Spark.

--- a/pandas-on-spark/index.md
+++ b/pandas-on-spark/index.md
@@ -103,7 +103,7 @@ This returns the wrong result, even though the group by aggregation logic is rig
 
 With pandas, you need to manually apply column pruning and row-group filtering when reading a Parquet file.  With pandas on Spark, the Spark optimizer automatically applies these query enhancements, so you do not need to type them manually.
 
-Lets investigate the advantages of pandas on Spark in more detail.
+Let's investigate the advantages of pandas on Spark in more detail.
 
 ## Advantages of pandas on Spark
 
@@ -127,7 +127,7 @@ pandas is notorious for erroring out when dataset sizes grow and Spark doesn't h
 
 Spark can be run on a single machine or distributed to many machines in a cluster.
 
-When Spark is run on a single machine, the computations are run on all available cores.  This is faster than pandas which only runs computations on a single core.
+When Spark is run on a single machine, the computations are run on all available cores.  This is often faster than pandas which only runs computations on a single core.
 
 Scaling computations on multiple machines is great for when you want to run computations on larger data sets or simply access more RAM/cores so the queries run faster.
 
@@ -167,9 +167,9 @@ You can clean and aggregate the dataset with pandas on Spark to take advantage o
 
 pandas on Spark executes queries completely differently than pandas.
 
-pandas on Spark converts the query to an unresolved logical plan, optimizes it with Spark, and then executes it.
+pandas on Spark uses lazy evaluation.  It converts the query to an unresolved logical plan, optimizes it with Spark, and only runs computations when results are requested.
 
-pandas loads all the data into memory and then executes the query with the pandas engine.  There are not any query optimization and all the data must be loaded into memory before the query is executed.
+pandas uses eager evaluation.  It loads all the data into memory and executes operations immediately when they are invoked.  pandas does not apply query optimization and all the data must be loaded into memory before the query is executed.
 
 When comparing pandas on Spark and pandas, you must be careful to factor in how much time it takes to load the data into memory and how much time it takes to run the query.  A lot of datasets take a long time to load into pandas.
 

--- a/site/committers.html
+++ b/site/committers.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/community.html
+++ b/site/community.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/error-message-guidelines.html
+++ b/site/error-message-guidelines.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/examples.html
+++ b/site/examples.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/faq.html
+++ b/site/faq.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -67,6 +67,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/history.html
+++ b/site/history.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/index.html
+++ b/site/index.html
@@ -71,6 +71,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -68,6 +68,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -67,6 +67,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/3-1-3-released.html
+++ b/site/news/3-1-3-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/new-repository-service.html
+++ b/site/news/new-repository-service.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/next-official-release-spark-3.1.1.html
+++ b/site/news/next-official-release-spark-3.1.1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/plan-for-dropping-python-2-support.html
+++ b/site/news/plan-for-dropping-python-2-support.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/sigmod-system-award.html
+++ b/site/news/sigmod-system-award.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-1-3-released.html
+++ b/site/news/spark-2-1-3-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-2-2-released.html
+++ b/site/news/spark-2-2-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-3-1-released.html
+++ b/site/news/spark-2-3-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-3-2-released.html
+++ b/site/news/spark-2-3-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-3-3-released.html
+++ b/site/news/spark-2-3-3-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-3-4-released.html
+++ b/site/news/spark-2-3-4-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-4-0-released.html
+++ b/site/news/spark-2-4-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-4-1-released.html
+++ b/site/news/spark-2-4-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-4-2-released.html
+++ b/site/news/spark-2-4-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-4-3-released.html
+++ b/site/news/spark-2-4-3-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-4-4-released.html
+++ b/site/news/spark-2-4-4-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-4-5-released.html
+++ b/site/news/spark-2-4-5-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-4-6.html
+++ b/site/news/spark-2-4-6.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-4-7-released.html
+++ b/site/news/spark-2-4-7-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2-4-8-released.html
+++ b/site/news/spark-2-4-8-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-0-0-released.html
+++ b/site/news/spark-3-0-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-0-1-released.html
+++ b/site/news/spark-3-0-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-0-2-released.html
+++ b/site/news/spark-3-0-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-0-3-released.html
+++ b/site/news/spark-3-0-3-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-1-1-released.html
+++ b/site/news/spark-3-1-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-1-2-released.html
+++ b/site/news/spark-3-1-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-2-0-released.html
+++ b/site/news/spark-3-2-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-2-1-released.html
+++ b/site/news/spark-3-2-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-2-2-released.html
+++ b/site/news/spark-3-2-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-2-3-released.html
+++ b/site/news/spark-3-2-3-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-2-4-released.html
+++ b/site/news/spark-3-2-4-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-3-0-released.html
+++ b/site/news/spark-3-3-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-3-1-released.html
+++ b/site/news/spark-3-3-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-3-2-released.html
+++ b/site/news/spark-3-3-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-3-3-released.html
+++ b/site/news/spark-3-3-3-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-3-4-released.html
+++ b/site/news/spark-3-3-4-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-4-0-released.html
+++ b/site/news/spark-3-4-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-4-1-released.html
+++ b/site/news/spark-3-4-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-4-2-released.html
+++ b/site/news/spark-3-4-2-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-5-0-released.html
+++ b/site/news/spark-3-5-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3-5-1-released.html
+++ b/site/news/spark-3-5-1-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3.0.0-preview.html
+++ b/site/news/spark-3.0.0-preview.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-3.0.0-preview2.html
+++ b/site/news/spark-3.0.0-preview2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-ai-summit-apr-2019-agenda-posted.html
+++ b/site/news/spark-ai-summit-apr-2019-agenda-posted.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-ai-summit-june-2020-agenda-posted.html
+++ b/site/news/spark-ai-summit-june-2020-agenda-posted.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-release-2-2-3.html
+++ b/site/news/spark-release-2-2-3.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-summit-east-agenda-posted-2015.html
+++ b/site/news/spark-summit-east-agenda-posted-2015.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-summit-east-agenda-posted-2016.html
+++ b/site/news/spark-summit-east-agenda-posted-2016.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-summit-oct-2018-agenda-posted.html
+++ b/site/news/spark-summit-oct-2018-agenda-posted.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/pandas-on-spark/index.html
+++ b/site/pandas-on-spark/index.html
@@ -239,7 +239,7 @@
 
 <p>With pandas, you need to manually apply column pruning and row-group filtering when reading a Parquet file.  With pandas on Spark, the Spark optimizer automatically applies these query enhancements, so you do not need to type them manually.</p>
 
-<p>Lets investigate the advantages of pandas on Spark in more detail.</p>
+<p>Let&#8217;s investigate the advantages of pandas on Spark in more detail.</p>
 
 <h2 id="advantages-of-pandas-on-spark">Advantages of pandas on Spark</h2>
 
@@ -263,7 +263,7 @@
 
 <p>Spark can be run on a single machine or distributed to many machines in a cluster.</p>
 
-<p>When Spark is run on a single machine, the computations are run on all available cores.  This is faster than pandas which only runs computations on a single core.</p>
+<p>When Spark is run on a single machine, the computations are run on all available cores.  This is often faster than pandas which only runs computations on a single core.</p>
 
 <p>Scaling computations on multiple machines is great for when you want to run computations on larger data sets or simply access more RAM/cores so the queries run faster.</p>
 
@@ -308,9 +308,9 @@
 
 <p>pandas on Spark executes queries completely differently than pandas.</p>
 
-<p>pandas on Spark converts the query to an unresolved logical plan, optimizes it with Spark, and then executes it.</p>
+<p>pandas on Spark uses lazy evaluation.  It converts the query to an unresolved logical plan, optimizes it with Spark, and only runs computations when results are requested.</p>
 
-<p>pandas loads all the data into memory and then executes the query with the pandas engine.  There are not any query optimization and all the data must be loaded into memory before the query is executed.</p>
+<p>pandas uses eager evaluation.  It loads all the data into memory and executes operations immediately when they are invoked.  pandas does not apply query optimization and all the data must be loaded into memory before the query is executed.</p>
 
 <p>When comparing pandas on Spark and pandas, you must be careful to factor in how much time it takes to load the data into memory and how much time it takes to run the query.  A lot of datasets take a long time to load into pandas.</p>
 

--- a/site/pandas-on-spark/index.html
+++ b/site/pandas-on-spark/index.html
@@ -1,0 +1,401 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>
+     pandas API on Spark | Apache Spark
+    
+  </title>
+
+  
+
+  
+    <meta name="description" content="The pandas API on Spark offers the familiarity of pandas with the power of Spark.">
+  
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
+  <link href="/css/custom.css" rel="stylesheet">
+  <!-- Code highlighter CSS -->
+  <link href="/css/pygments-default.css" rel="stylesheet">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+  <!-- Matomo -->
+  <script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["disableCookies"]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="https://analytics.apache.org/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '40']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
+</head>
+<body class="global">
+<nav class="navbar navbar-expand-lg navbar-dark p-0 px-4" style="background: #1D6890;">
+  <a class="navbar-brand" href="/">
+    <img src="/images/spark-logo-rev.svg" alt="" width="141" height="72">
+  </a>
+  <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent"
+          aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse col-md-12 col-lg-auto pt-4" id="navbarContent">
+
+    <ul class="navbar-nav me-auto">
+      <li class="nav-item">
+        <a class="nav-link active" aria-current="page" href="/downloads.html">Download</a>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="libraries" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Libraries
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="libraries">
+          <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
+          <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
+          <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
+          <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
+          <li>
+            <hr class="dropdown-divider">
+          </li>
+          <li><a class="dropdown-item" href="/third-party-projects.html">Third-Party Projects</a></li>
+        </ul>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="documentation" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Documentation
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="documentation">
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release</a></li>
+          <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
+          <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
+        </ul>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link active" aria-current="page" href="/examples.html">Examples</a>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="community" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Community
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="community">
+          <li><a class="dropdown-item" href="/community.html">Mailing Lists &amp; Resources</a></li>
+          <li><a class="dropdown-item" href="/contributing.html">Contributing to Spark</a></li>
+          <li><a class="dropdown-item" href="/improvement-proposals.html">Improvement Proposals (SPIP)</a>
+          </li>
+          <li><a class="dropdown-item" href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a>
+          </li>
+          <li><a class="dropdown-item" href="/powered-by.html">Powered By</a></li>
+          <li><a class="dropdown-item" href="/committers.html">Project Committers</a></li>
+          <li><a class="dropdown-item" href="/history.html">Project History</a></li>
+        </ul>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="developers" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Developers
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="developers">
+          <li><a class="dropdown-item" href="/developer-tools.html">Useful Developer Tools</a></li>
+          <li><a class="dropdown-item" href="/versioning-policy.html">Versioning Policy</a></li>
+          <li><a class="dropdown-item" href="/release-process.html">Release Process</a></li>
+          <li><a class="dropdown-item" href="/security.html">Security</a></li>
+        </ul>
+      </li>
+    </ul>
+    <ul class="navbar-nav ml-auto">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="apacheFoundation" role="button"
+           data-bs-toggle="dropdown" aria-expanded="false">
+          Apache Software Foundation
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="apacheFoundation">
+          <li><a class="dropdown-item" href="https://www.apache.org/">Apache Homepage</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/licenses/">License</a></li>
+          <li><a class="dropdown-item"
+                 href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/security/">Security</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/events/current-event">Event</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</nav>
+
+<div class="container">
+  <div class="row mt-4">
+    <div class="col-12 col-md-9">
+      <h1 id="pandas-api-on-spark">pandas API on Spark</h1>
+
+<p>This page describes the advantages of the pandas API on Spark (“pandas on Spark”) and when you should use it instead of pandas (or in conjunction with pandas).</p>
+
+<p>pandas on Spark can be much faster than pandas and offers syntax that is familiar to pandas users.  It offers the power of Spark with the familiarity of pandas.</p>
+
+<p>Here are the main advantages of pandas on Spark:</p>
+
+<ul>
+  <li>Faster query execution on single-machine workloads (because pandas on Spark uses all available cores, processes queries in parallel, and optimizes queries)</li>
+  <li>pandas on Spark is scalable to multiple machines in a cluster and can process big data</li>
+  <li>pandas on Spark allows queries to be run on larger than memory datasets</li>
+  <li>pandas on Spark provides familiar syntax for pandas users</li>
+</ul>
+
+<p>pandas has many limitations:</p>
+
+<ul>
+  <li>pandas must load all data into memory before running a query which can be slow</li>
+  <li>pandas cannot process datasets that are larger than the available memory on a single machine (because all data must be loaded into memory)</li>
+  <li>pandas computations are run on a single core and don&#8217;t leverage all available cores of a single machine</li>
+  <li>pandas computations cannot be scaled out to multiple machines</li>
+  <li>pandas doesn&#8217;t have a query optimizer, so users have to manually code optimizations or suffer from slow code</li>
+</ul>
+
+<p>Let&#8217;s look at some simple examples to get a better understanding of how pandas on Spark overcomes the limitations of pandas.  We’ll also investigate the limitations of pandas on Spark.</p>
+
+<p>At the end of this page, you will see how you can use both pandas and pandas on Spark in conjunction.  It’s not an either/or decision - in many situations using both is a great option.</p>
+
+<h2 id="pandas-on-spark-example">pandas on Spark example</h2>
+
+<p>This section demonstrates how pandas on Spark can run a query on a single file on localhost faster than pandas.  pandas on Spark isn’t necessarily faster for all queries, but this example shows when it provides a nice speed-up.</p>
+
+<p>Suppose you have a Parquet file with 9 columns and 1 billion rows of data.  Here are the first three rows of the file:</p>
+
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>+-------+-------+--------------+-------+-------+--------+------+------+---------+
+| id1   | id2   | id3          |   id4 |   id5 |    id6 |   v1 |   v2 |      v3 |
+|-------+-------+--------------+-------+-------+--------+------+------+---------|
+| id016 | id046 | id0000109363 |    88 |    13 | 146094 |    4 |    6 | 18.8377 |
+| id039 | id087 | id0000466766 |    14 |    30 | 111330 |    4 |   14 | 46.7973 |
+| id047 | id098 | id0000307804 |    85 |    23 | 187639 |    3 |    5 | 47.5773 |
++-------+-------+--------------+-------+-------+--------+------+------+---------+
+</code></pre></div></div>
+
+<p>Here is how you can use pandas on Spark to read the file and run a group by aggregation.</p>
+
+<div class="language-python highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="kn">import</span> <span class="nn">pyspark.pandas</span> <span class="k">as</span> <span class="n">ps</span>
+
+<span class="n">df</span> <span class="o">=</span> <span class="n">ps</span><span class="p">.</span><span class="n">read_parquet</span><span class="p">(</span><span class="s">"G1_1e9_1e2_0_0.parquet"</span><span class="p">)[</span>
+    <span class="p">[</span><span class="s">"id1"</span><span class="p">,</span> <span class="s">"id2"</span><span class="p">,</span> <span class="s">"v3"</span><span class="p">]</span>
+<span class="p">]</span>
+<span class="n">df</span><span class="p">.</span><span class="n">query</span><span class="p">(</span><span class="s">"id1 &gt; 'id098'"</span><span class="p">).</span><span class="n">groupby</span><span class="p">(</span><span class="s">"id2"</span><span class="p">).</span><span class="nb">sum</span><span class="p">().</span><span class="n">head</span><span class="p">(</span><span class="mi">3</span><span class="p">)</span>
+</code></pre></div></div>
+
+<p>This query runs in 62 seconds when executed on a 2020 M1 Macbook with 64 GB of RAM with Spark 3.5.0.</p>
+
+<p>Let&#8217;s compare this with unoptimized pandas code.</p>
+
+<div class="language-python highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="kn">import</span> <span class="nn">pandas</span> <span class="k">as</span> <span class="n">pd</span>
+
+<span class="n">df</span> <span class="o">=</span> <span class="n">pd</span><span class="p">.</span><span class="n">read_parquet</span><span class="p">(</span><span class="s">"G1_1e9_1e2_0_0.parquet"</span><span class="p">)[</span>
+    <span class="p">[</span><span class="s">"id1"</span><span class="p">,</span> <span class="s">"id2"</span><span class="p">,</span> <span class="s">"v3"</span><span class="p">]</span>
+<span class="p">]</span>
+<span class="n">df</span><span class="p">.</span><span class="n">query</span><span class="p">(</span><span class="s">"id1 &gt; 'id098'"</span><span class="p">).</span><span class="n">groupby</span><span class="p">(</span><span class="s">"id2"</span><span class="p">).</span><span class="nb">sum</span><span class="p">().</span><span class="n">head</span><span class="p">(</span><span class="mi">3</span><span class="p">)</span>
+</code></pre></div></div>
+
+<p>This query errors out because the machine with 64GB of RAM does not have enough space to store 1 billion rows of data in memory.</p>
+
+<p>Let’s manually add some pandas optimizations to make the query run:</p>
+
+<div class="language-python highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="n">df</span> <span class="o">=</span> <span class="n">pd</span><span class="p">.</span><span class="n">read_parquet</span><span class="p">(</span>
+    <span class="s">"G1_1e9_1e2_0_0.parquet"</span><span class="p">,</span>
+    <span class="n">columns</span><span class="o">=</span><span class="p">[</span><span class="s">"id1"</span><span class="p">,</span> <span class="s">"id2"</span><span class="p">,</span> <span class="s">"v3"</span><span class="p">],</span>
+    <span class="n">filters</span><span class="o">=</span><span class="p">[(</span><span class="s">"id1"</span><span class="p">,</span> <span class="s">"&gt;"</span><span class="p">,</span> <span class="s">"id098"</span><span class="p">)],</span>
+    <span class="n">engine</span><span class="o">=</span><span class="s">"pyarrow"</span><span class="p">,</span>
+<span class="p">)</span>
+<span class="n">df</span><span class="p">.</span><span class="n">query</span><span class="p">(</span><span class="s">"id1 &gt; 'id098'"</span><span class="p">).</span><span class="n">groupby</span><span class="p">(</span><span class="s">"id2"</span><span class="p">).</span><span class="nb">sum</span><span class="p">().</span><span class="n">head</span><span class="p">(</span><span class="mi">3</span><span class="p">)</span>
+</code></pre></div></div>
+
+<p>This query runs in 275 seconds with pandas 2.2.0.</p>
+
+<p>Coding these optimizations manually with pandas can potentially give the wrong results.  Here’s an example of a group by query that’s correct, but with a row-group filtering predicate that’s wrong:</p>
+
+<div class="language-python highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="n">df</span> <span class="o">=</span> <span class="n">pd</span><span class="p">.</span><span class="n">read_parquet</span><span class="p">(</span>
+    <span class="s">"G1_1e9_1e2_0_0.parquet"</span><span class="p">,</span>
+    <span class="n">columns</span><span class="o">=</span><span class="p">[</span><span class="s">"id1"</span><span class="p">,</span> <span class="s">"id2"</span><span class="p">,</span> <span class="s">"v3"</span><span class="p">],</span>
+    <span class="n">filters</span><span class="o">=</span><span class="p">[(</span><span class="s">"id1"</span><span class="p">,</span> <span class="s">"=="</span><span class="p">,</span> <span class="s">"id001"</span><span class="p">)],</span>
+    <span class="n">engine</span><span class="o">=</span><span class="s">"pyarrow"</span><span class="p">,</span>
+<span class="p">)</span>
+<span class="n">df</span><span class="p">.</span><span class="n">query</span><span class="p">(</span><span class="s">"id1 &gt; 'id098'"</span><span class="p">).</span><span class="n">groupby</span><span class="p">(</span><span class="s">"id2"</span><span class="p">).</span><span class="nb">sum</span><span class="p">().</span><span class="n">head</span><span class="p">(</span><span class="mi">3</span><span class="p">)</span>
+</code></pre></div></div>
+
+<p>This returns the wrong result, even though the group by aggregation logic is right!</p>
+
+<p>With pandas, you need to manually apply column pruning and row-group filtering when reading a Parquet file.  With pandas on Spark, the Spark optimizer automatically applies these query enhancements, so you do not need to type them manually.</p>
+
+<p>Lets investigate the advantages of pandas on Spark in more detail.</p>
+
+<h2 id="advantages-of-pandas-on-spark">Advantages of pandas on Spark</h2>
+
+<p>Let&#8217;s recap the advantages of pandas on Spark:</p>
+
+<p><strong>Faster query execution</strong></p>
+
+<p>pandas on Spark can execute queries faster than pandas because it uses all the available cores to parallelize computations and optimizes queries before running them to allow for efficient execution.</p>
+
+<p>pandas computations only run on a single core.</p>
+
+<p><strong>Scalable to larger-than-memory datasets</strong></p>
+
+<p>pandas loads data in memory before running queries, so it can only query datasets that fit into memory.</p>
+
+<p>Spark can query datasets that are larger than memory by streaming the data and incrementally running computations.</p>
+
+<p>pandas is notorious for erroring out when dataset sizes grow and Spark doesn&#8217;t have this limitation.</p>
+
+<p><strong>Runnable on a cluster of many machines</strong></p>
+
+<p>Spark can be run on a single machine or distributed to many machines in a cluster.</p>
+
+<p>When Spark is run on a single machine, the computations are run on all available cores.  This is faster than pandas which only runs computations on a single core.</p>
+
+<p>Scaling computations on multiple machines is great for when you want to run computations on larger data sets or simply access more RAM/cores so the queries run faster.</p>
+
+<p><strong>Familiar syntax for pandas users</strong></p>
+
+<p>pandas on Spark was designed to provide familiar syntax for pandas users.</p>
+
+<p>The familiar syntax is the whole point - pandas on Spark provides the power of Spark with the same syntax that pandas users are accustomed to.</p>
+
+<p><strong>Provides access to Spark&#8217;s battle-tested query optimizer</strong></p>
+
+<p>pandas on Spark computations are optimized by Spark’s Catalyst optimizer before they&#8217;re executed.</p>
+
+<p>These optimizations simplify queries and add optimizations.</p>
+
+<p>Earlier in this post, we saw how Spark automatically adds the column pruning/row group filtering optimizations when reading Parquet files for example.  pandas doesn&#8217;t have a query optimizer, so you need to add these optimizations yourself.  Manually adding optimizations is tedious and error-prone.  If you don&#8217;t manually apply the right optimizations, your query will return the wrong result.</p>
+
+<h2 id="limitations-of-pandas-on-spark">Limitations of pandas on Spark</h2>
+
+<p>pandas on Spark doesn&#8217;t support all the APIs that pandas supports for two reasons:</p>
+
+<ul>
+  <li>
+    <p>some features haven&#8217;t been added to pandas on Spark yet</p>
+  </li>
+  <li>
+    <p>some pandas features don&#8217;t make sense with Spark&#8217;s distributed, parallel execution model</p>
+  </li>
+</ul>
+
+<p>Spark breaks up DataFrames into multiple chunks so they can be processed in parallel, so certain pandas operations don&#8217;t transition well to Spark&#8217;s execution model.</p>
+
+<h2 id="using-pandas-on-spark-in-conjunction-with-regular-pandas">Using pandas on Spark in conjunction with regular pandas</h2>
+
+<p>It’s often useful to use pandas on Spark and pandas to get the best of both worlds.</p>
+
+<p>Suppose you have a large dataset that you clean and aggregate into a smaller dataset that’s passed into a scikit-learn machine learning model.</p>
+
+<p>You can clean and aggregate the dataset with pandas on Spark to take advantage of fast query times and parallel execution.  Once the dataset is processed, you can convert it to a pandas DataFrame with <code class="language-plaintext highlighter-rouge">to_pandas()</code> and then run the machine learning model with scikit-learn.  This approach works well if the dataset can be reduced enough to fit in a pandas DataFrame.</p>
+
+<h2 id="the-pandas-on-spark-query-execution-model-is-different">The pandas on Spark query execution model is different</h2>
+
+<p>pandas on Spark executes queries completely differently than pandas.</p>
+
+<p>pandas on Spark converts the query to an unresolved logical plan, optimizes it with Spark, and then executes it.</p>
+
+<p>pandas loads all the data into memory and then executes the query with the pandas engine.  There are not any query optimization and all the data must be loaded into memory before the query is executed.</p>
+
+<p>When comparing pandas on Spark and pandas, you must be careful to factor in how much time it takes to load the data into memory and how much time it takes to run the query.  A lot of datasets take a long time to load into pandas.</p>
+
+<p>You can also load data into memory with pandas on Spark, but this is often considered an anti-pattern.  A dataset that’s loaded into memory won’t be updated if the data in storage changes (via an append, merge, or deletion).  Persisting a Spark DataFrame is wise in certain situations to speed up query times, but must be used carefully because it can cause incorrect query results.</p>
+
+<h2 id="how-pandas-on-spark-and-pyspark-differ">How pandas on Spark and PySpark differ</h2>
+
+<p>pandas on Spark and PySpark both take queries, convert them to unresolved logical plans, and then execute them with Spark.</p>
+
+<p>PySpark and pandas on Spark both have similar query execution models.  Converting a query to an unresolved logical plan is relatively quick.  Optimizing the query and executing it takes much more time.  So PySpark and pandas on Spark should have similar performance.</p>
+
+<p>The main difference between pandas on Spark and PySpark is just the syntax.</p>
+
+<h2 id="conclusion">Conclusion</h2>
+
+<p>pandas on Spark is a great alternative for pandas users who would like to run their queries faster and want to leverage Spark’s optimizer rather than writing their own optimizations.</p>
+
+<p>pandas on Spark uses syntax that’s familiar to pandas users, so it’s easy to learn.</p>
+
+<p>pandas on Spark is also a great technology to be used in conjunction with pandas.  You can use the big-data and performant processing capabilities of pandas on Spark to process datasets before they’re converted into pandas DataFrames that are compatible with other technologies.</p>
+
+<p>Check out <a href="https://spark.apache.org/docs/latest/api/python/user_guide/pandas_on_spark/index.html">the docs</a> to learn more about how to use pandas on Spark.</p>
+
+    </div>
+    <div class="col-12 col-md-3">
+      <div class="news" style="margin-bottom: 20px;">
+        <h5>Latest News</h5>
+        <ul class="list-unstyled">
+          
+          <li><a href="/news/spark-3-5-1-released.html">Spark 3.5.1 released</a>
+            <span class="small">(Feb 23, 2024)</span></li>
+          
+          <li><a href="/news/spark-3-3-4-released.html">Spark 3.3.4 released</a>
+            <span class="small">(Dec 16, 2023)</span></li>
+          
+          <li><a href="/news/spark-3-4-2-released.html">Spark 3.4.2 released</a>
+            <span class="small">(Nov 30, 2023)</span></li>
+          
+          <li><a href="/news/spark-3-5-0-released.html">Spark 3.5.0 released</a>
+            <span class="small">(Sep 13, 2023)</span></li>
+          
+        </ul>
+        <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
+      </div>
+      <div style="text-align:center; margin-bottom: 20px;">
+        <a href="https://www.apache.org/events/current-event.html">
+          <img src="https://www.apache.org/events/current-event-234x60.png" style="max-width: 100%;"/>
+        </a>
+      </div>
+      <div class="hidden-xs hidden-sm">
+        <a href="/downloads.html" class="btn btn-cta btn-lg d-grid" style="margin-bottom: 30px;">
+          Download Spark
+        </a>
+        <p style="font-size: 16px; font-weight: 500; color: #555;">
+          Built-in Libraries:
+        </p>
+        <ul class="list-none">
+          <li><a href="/sql/">SQL and DataFrames</a></li>
+          <li><a href="/streaming/">Spark Streaming</a></li>
+          <li><a href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a href="/graphx/">GraphX (graph)</a></li>
+        </ul>
+        <a href="/third-party-projects.html">Third-Party Projects</a>
+      </div>
+    </div>
+  </div>
+
+  
+
+  <footer class="small">
+    <hr>
+    Apache Spark, Spark, Apache, the Apache feather logo, and the Apache Spark project logo are either registered
+    trademarks or trademarks of The Apache Software Foundation in the United States and other countries.
+    See guidance on use of Apache Spark <a href="/trademarks.html">trademarks</a>.
+    All other marks mentioned may be trademarks or registered trademarks of their respective owners.
+    Copyright &copy; 2018 The Apache Software Foundation, Licensed under the
+    <a href="https://www.apache.org/licenses/">Apache License, Version 2.0</a>.
+  </footer>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+        crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery.js"></script>
+<script src="/js/lang-tabs.js"></script>
+<script src="/js/downloads.js"></script>
+</body>
+</html>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-1-3.html
+++ b/site/releases/spark-release-2-1-3.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-2-2.html
+++ b/site/releases/spark-release-2-2-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-2-3.html
+++ b/site/releases/spark-release-2-2-3.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-3-1.html
+++ b/site/releases/spark-release-2-3-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-3-2.html
+++ b/site/releases/spark-release-2-3-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-3-3.html
+++ b/site/releases/spark-release-2-3-3.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-3-4.html
+++ b/site/releases/spark-release-2-3-4.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-4-0.html
+++ b/site/releases/spark-release-2-4-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-4-1.html
+++ b/site/releases/spark-release-2-4-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-4-2.html
+++ b/site/releases/spark-release-2-4-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-4-3.html
+++ b/site/releases/spark-release-2-4-3.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-4-4.html
+++ b/site/releases/spark-release-2-4-4.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-4-5.html
+++ b/site/releases/spark-release-2-4-5.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-4-6.html
+++ b/site/releases/spark-release-2-4-6.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-4-7.html
+++ b/site/releases/spark-release-2-4-7.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-2-4-8.html
+++ b/site/releases/spark-release-2-4-8.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-0-0.html
+++ b/site/releases/spark-release-3-0-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-0-1.html
+++ b/site/releases/spark-release-3-0-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-0-2.html
+++ b/site/releases/spark-release-3-0-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-0-3.html
+++ b/site/releases/spark-release-3-0-3.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-1-1.html
+++ b/site/releases/spark-release-3-1-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-1-2.html
+++ b/site/releases/spark-release-3-1-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-1-3.html
+++ b/site/releases/spark-release-3-1-3.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-2-0.html
+++ b/site/releases/spark-release-3-2-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-2-1.html
+++ b/site/releases/spark-release-3-2-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-2-2.html
+++ b/site/releases/spark-release-3-2-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-2-3.html
+++ b/site/releases/spark-release-3-2-3.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-2-4.html
+++ b/site/releases/spark-release-3-2-4.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-3-0.html
+++ b/site/releases/spark-release-3-3-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-3-1.html
+++ b/site/releases/spark-release-3-3-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-3-2.html
+++ b/site/releases/spark-release-3-3-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-3-3.html
+++ b/site/releases/spark-release-3-3-3.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-3-4.html
+++ b/site/releases/spark-release-3-3-4.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-4-0.html
+++ b/site/releases/spark-release-3-4-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-4-1.html
+++ b/site/releases/spark-release-3-4-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-4-2.html
+++ b/site/releases/spark-release-3-4-2.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-5-0.html
+++ b/site/releases/spark-release-3-5-0.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/releases/spark-release-3-5-1.html
+++ b/site/releases/spark-release-3-5-1.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/research.html
+++ b/site/research.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/security.html
+++ b/site/security.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1041,15 +1041,7 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/graphx/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>https://spark.apache.org/mllib/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>https://spark.apache.org/streaming/</loc>
+  <loc>https://spark.apache.org/sql/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
@@ -1061,7 +1053,19 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/sql/</loc>
+  <loc>https://spark.apache.org/graphx/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/pandas-on-spark/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/streaming/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/mllib/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>

--- a/site/spark-connect/index.html
+++ b/site/spark-connect/index.html
@@ -67,6 +67,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -67,6 +67,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -67,6 +67,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -65,6 +65,7 @@
           <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
           <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
           <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
           <li>


### PR DESCRIPTION
Sorry for the huge PR!

This PR adds a pandas on Spark page to explain the benefits of pandas on Spark.

The [pandas API on Spark docs](https://spark.apache.org/docs/latest/api/python/user_guide/pandas_on_spark/index.html) are great, but they get right into the details and don't provide a high-level overview of why someone should use pandas on Spark.

I am hoping that this page serves as a nice entry-point to the existing pandas API on Spark docs.