### PR TITLE
Update `committers` page

### DIFF
--- a/committers.md
+++ b/committers.md
@@ -10,20 +10,20 @@ navigation:
 
 |Name|Organization|
 |----|------------|
-|Sameer Agarwal|Facebook|
+|Sameer Agarwal|Deductive AI|
 |Michael Armbrust|Databricks|
 |Dilip Biswal|Adobe|
-|Ryan Blue|Netflix|
+|Ryan Blue|Tabular|
 |Joseph Bradley|Databricks|
 |Matthew Cheah|Palantir|
-|Felix Cheung|SafeGraph|
+|Felix Cheung|NVIDIA|
 |Mosharaf Chowdhury|University of Michigan, Ann Arbor|
 |Bryan Cutler|IBM|
 |Jason Dai|Intel|
 |Tathagata Das|Databricks|
-|Ankur Dave|UC Berkeley|
+|Ankur Dave|Databricks|
 |Aaron Davidson|Databricks|
-|Thomas Dudziak|Facebook|
+|Thomas Dudziak|Meta|
 |Erik Erlandson|Red Hat|
 |Robert Evans|NVIDIA|
 |Wenchen Fan|Databricks|
@@ -34,7 +34,7 @@ navigation:
 |Thomas Graves|NVIDIA|
 |Stephen Haberman|LinkedIn|
 |Mark Hamstra|ClearStory Data|
-|Seth Hendrickson|Cloudera|
+|Seth Hendrickson|Stripe|
 |Herman van Hovell|Databricks|
 |Liang-Chi Hsieh|Apple|
 |Yin Huai|Databricks|
@@ -43,7 +43,7 @@ navigation:
 |Kazuaki Ishizaki|IBM|
 |Xingbo Jiang|Databricks|
 |Yikun Jiang|Huawei|
-|Holden Karau|Apple|
+|Holden Karau|Netflix|
 |Shane Knapp|UC Berkeley|
 |Cody Koeninger|Nexstar Digital|
 |Andy Konwinski|Databricks|
@@ -61,23 +61,23 @@ navigation:
 |Xiangrui Meng|Databricks|
 |Xinrong Meng|Databricks|
 |Mridul Muralidharan|LinkedIn|
-|Andrew Or|Princeton University|
+|Andrew Or|Facebook|
 |Kay Ousterhout|LightStep|
 |Sean Owen|Databricks|
-|Tejas Patil|Facebook|
-|Nick Pentreath|IBM|
+|Tejas Patil|Meta|
+|Nick Pentreath|Automattic|
 |Attila Zsolt Piros|Cloudera|
-|Anirudh Ramanathan|Rockset|
+|Anirudh Ramanathan|Signadot|
 |Imran Rashid|Cloudera|
 |Charles Reiss|University of Virginia|
-|Josh Rosen|Stripe|
-|Sandy Ryza|Remix|
+|Josh Rosen|Databricks|
+|Sandy Ryza|Dagster|
 |Kousuke Saruta|NTT Data|
 |Saisai Shao|Datastrato|
 |Prashant Sharma|IBM|
 |Gabor Somogyi|Apple|
-|Ram Sriharsha|Databricks|
-|Chao Sun|Apple|
+|Ram Sriharsha|Pinecone|
+|Chao Sun|OpenAI|
 |Maciej Szymkiewicz||
 |Jose Torres|Databricks|
 |Peter Toth|Cloudera|

--- a/site/committers.html
+++ b/site/committers.html
@@ -153,7 +153,7 @@
   <tbody>
     <tr>
       <td>Sameer Agarwal</td>
-      <td>Facebook</td>
+      <td>Deductive AI</td>
     </tr>
     <tr>
       <td>Michael Armbrust</td>
@@ -165,7 +165,7 @@
     </tr>
     <tr>
       <td>Ryan Blue</td>
-      <td>Netflix</td>
+      <td>Tabular</td>
     </tr>
     <tr>
       <td>Joseph Bradley</td>
@@ -177,7 +177,7 @@
     </tr>
     <tr>
       <td>Felix Cheung</td>
-      <td>SafeGraph</td>
+      <td>NVIDIA</td>
     </tr>
     <tr>
       <td>Mosharaf Chowdhury</td>
@@ -197,7 +197,7 @@
     </tr>
     <tr>
       <td>Ankur Dave</td>
-      <td>UC Berkeley</td>
+      <td>Databricks</td>
     </tr>
     <tr>
       <td>Aaron Davidson</td>
@@ -205,7 +205,7 @@
     </tr>
     <tr>
       <td>Thomas Dudziak</td>
-      <td>Facebook</td>
+      <td>Meta</td>
     </tr>
     <tr>
       <td>Erik Erlandson</td>
@@ -249,7 +249,7 @@
     </tr>
     <tr>
       <td>Seth Hendrickson</td>
-      <td>Cloudera</td>
+      <td>Stripe</td>
     </tr>
     <tr>
       <td>Herman van Hovell</td>
@@ -285,7 +285,7 @@
     </tr>
     <tr>
       <td>Holden Karau</td>
-      <td>Apple</td>
+      <td>Netflix</td>
     </tr>
     <tr>
       <td>Shane Knapp</td>
@@ -357,7 +357,7 @@
     </tr>
     <tr>
       <td>Andrew Or</td>
-      <td>Princeton University</td>
+      <td>Facebook</td>
     </tr>
     <tr>
       <td>Kay Ousterhout</td>
@@ -369,11 +369,11 @@
     </tr>
     <tr>
       <td>Tejas Patil</td>
-      <td>Facebook</td>
+      <td>Meta</td>
     </tr>
     <tr>
       <td>Nick Pentreath</td>
-      <td>IBM</td>
+      <td>Automattic</td>
     </tr>
     <tr>
       <td>Attila Zsolt Piros</td>
@@ -381,7 +381,7 @@
     </tr>
     <tr>
       <td>Anirudh Ramanathan</td>
-      <td>Rockset</td>
+      <td>Signadot</td>
     </tr>
     <tr>
       <td>Imran Rashid</td>
@@ -393,11 +393,11 @@
     </tr>
     <tr>
       <td>Josh Rosen</td>
-      <td>Stripe</td>
+      <td>Databricks</td>
     </tr>
     <tr>
       <td>Sandy Ryza</td>
-      <td>Remix</td>
+      <td>Dagster</td>
     </tr>
     <tr>
       <td>Kousuke Saruta</td>
@@ -417,11 +417,11 @@
     </tr>
     <tr>
       <td>Ram Sriharsha</td>
-      <td>Databricks</td>
+      <td>Pinecone</td>
     </tr>
     <tr>
       <td>Chao Sun</td>
-      <td>Apple</td>
+      <td>OpenAI</td>
     </tr>
     <tr>
       <td>Maciej Szymkiewicz</td>


### PR DESCRIPTION
This PR aims to update `committers` page because `Apache Spark 4.0.0-preview` is going to be ready this week soon.
- https://spark.apache.org/committers.html