### PR TITLE
Add Hamilton integration

### DIFF
--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -153,6 +153,7 @@
   <li><a href="https://github.com/awslabs/python-deequ">python-deequ</a> - Measures data quality in large datasets</li>
   <li><a href="https://github.com/datahub-project/datahub">datahub</a> - Metadata platform for the modern data stack</li>
   <li><a href="https://github.com/dbt-labs/dbt-spark">dbt-spark</a> - Enables dbt to work with Apache Spark</li>
+  <li><a href="https://github.com/DAGWorks-Inc/hamilton">Hamilton</a> - Enables one to declaratively describe PySpark transformations that helps keep code testable, modular, and logically visualizable.</li>
 </ul>
 
 <h2 id="connectors">Connectors</h2>

--- a/third-party-projects.md
+++ b/third-party-projects.md
@@ -18,6 +18,7 @@ This page tracks external software projects that supplement Apache Spark and add
 - [python-deequ](https://github.com/awslabs/python-deequ) - Measures data quality in large datasets
 - [datahub](https://github.com/datahub-project/datahub) - Metadata platform for the modern data stack
 - [dbt-spark](https://github.com/dbt-labs/dbt-spark) - Enables dbt to work with Apache Spark
+- [Hamilton](https://github.com/DAGWorks-Inc/hamilton) - Enables one to declaratively describe PySpark transformations that helps keep code testable, modular, and logically visualizable. 
 
 ## Connectors
 


### PR DESCRIPTION
This adds [Hamilton](https://github.com/DAGWorks-Inc/hamilton) to the list of libraries with integrations.

Hamilton has PySpark support (e.g. [examples](https://github.com/DAGWorks-Inc/hamilton/tree/main/examples/spark)) and this specific
functionality is utilized by several enterprises in production.