### PR TITLE
Update docker links on the download page

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -41,9 +41,11 @@ Spark artifacts are [hosted in Maven Central](https://search.maven.org/search?q=
 <a href="https://pypi.org/project/pyspark/">PySpark</a> is now available in pypi. To install just run `pip install pyspark`.
 
 
-### Convenience Docker Container Images
+### Installing with Docker
 
-[Spark Docker Container images are available from DockerHub](https://hub.docker.com/r/apache/spark-py/tags), these images contain non-ASF software and may be subject to different license terms.
+Spark docker images are available from Dockerhub under the accounts of both [The Apache Software Foundation](https://hub.docker.com/r/apache/spark/) and [Official Images](https://hub.docker.com/_/spark).
+
+Note that, these images contain non-ASF software and may be subject to different license terms. Please check their [Dockerfiles](https://github.com/apache/spark-docker) to verify whether to verify whether they are compatible with your deployment.
 
 ### Release notes for stable releases
 

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -182,9 +182,11 @@ version: 3.5.1
 <h3 id="installing-with-pypi">Installing with PyPi</h3>
 <p><a href="https://pypi.org/project/pyspark/">PySpark</a> is now available in pypi. To install just run <code class="language-plaintext highlighter-rouge">pip install pyspark</code>.</p>
 
-<h3 id="convenience-docker-container-images">Convenience Docker Container Images</h3>
+<h3 id="installing-with-docker">Installing with Docker</h3>
 
-<p><a href="https://hub.docker.com/r/apache/spark-py/tags">Spark Docker Container images are available from DockerHub</a>, these images contain non-ASF software and may be subject to different license terms.</p>
+<p>Spark docker images are available from Dockerhub under the accounts of both <a href="https://hub.docker.com/r/apache/spark/">The Apache Software Foundation</a> and <a href="https://hub.docker.com/_/spark">Official Images</a>.</p>
+
+<p>Note that, these images contain non-ASF software and may be subject to different license terms. Please check their <a href="https://github.com/apache/spark-docker">Dockerfiles</a> to verify whether to verify whether they are compatible with your deployment.</p>
 
 <h3 id="release-notes-for-stable-releases">Release notes for stable releases</h3>
 


### PR DESCRIPTION
https://hub.docker.com/r/apache/spark-py/tags has not been active since 3.4.0