### PR TITLE
Update release process for PyPI accounts

### DIFF
--- a/release-process.md
+++ b/release-process.md
@@ -231,9 +231,7 @@ and the same under [https://repository.apache.org/content/groups/maven-staging-g
 
 <h4>Upload to PyPI</h4>
 
-You'll need the credentials for the `spark-upload` account, which can be found in
-<a href="https://lists.apache.org/thread.html/2789e448cd8a95361a3164b48f3f8b73a6d9d82aeb228bae2bc4dc7f@%3Cprivate.spark.apache.org%3E">this message</a> and <a href="https://lists.apache.org/thread/37j2x1d32bj320g4fx784rnhj3bf1zzk">this message</a>
-(only visible to PMC members).
+You'll need your own PyPI account. If you do not have a PyPI account that has access to the `pyspark` and `pyspark-connect` projects on PyPI, please ask the <a href="mailto:private@spark.apache.org">PMC</a> to grant permission for both.
 
 The artifacts can be uploaded using <a href="https://pypi.org/project/twine/">twine</a>. Just run:
 

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -373,9 +373,7 @@ and the same under <a href="https://repository.apache.org/content/groups/maven-s
 
 <h4>Upload to PyPI</h4>
 
-<p>You&#8217;ll need the credentials for the <code class="language-plaintext highlighter-rouge">spark-upload</code> account, which can be found in
-<a href="https://lists.apache.org/thread.html/2789e448cd8a95361a3164b48f3f8b73a6d9d82aeb228bae2bc4dc7f@%3Cprivate.spark.apache.org%3E">this message</a> and <a href="https://lists.apache.org/thread/37j2x1d32bj320g4fx784rnhj3bf1zzk">this message</a>
-(only visible to PMC members).</p>
+<p>You&#8217;ll need your own PyPI account. If you do not have a PyPI account that has access to the <code class="language-plaintext highlighter-rouge">pyspark</code> and <code class="language-plaintext highlighter-rouge">pyspark-connect</code> projects on PyPI, please ask the <a href="mailto:private@spark.apache.org">PMC</a> to grant permission for both.</p>
 
 <p>The artifacts can be uploaded using <a href="https://pypi.org/project/twine/">twine</a>. Just run:</p>
 


### PR DESCRIPTION
This PR proposes to update release process about PyPI accounts. For PyPI account permissions, they have to be asked to the Spark PMC.