### PR TITLE
The file `versions.json` should be updated when releasing a new spark version

### DIFF
--- a/release-process.md
+++ b/release-process.md
@@ -327,6 +327,7 @@ Next, update the rest of the Spark website. See how the previous releases are do
 * update `_layouts/global.html` if the new release is the latest one
 * update `documentation.md` to add link to the docs for the new release
 * add the new release to `js/downloads.js` (attention to the order of releases)
+* add the new release to `site/static/versions.json` (attention to the order of releases) [for `spark version drop down` of the `PySpark` docs]
 * check `security.md` for anything to update
 
 ```


### PR DESCRIPTION
The pr aims to add `a note` for file `release-process.md`
When we release a `new` Spark version, we need to update the file `site/static/versions.json`
This way, we can display the `latest version` in the `drop-down` menu on the following page:
https://spark.apache.org/docs/4.0.0-preview1/api/python/index.html
<img width="1384" alt="image" src="https://github.com/apache/spark/assets/15246973/40d37913-a23c-43a4-b95e-391ad4a0edc9">
