### PR TITLE
[FOLLOWUP] generate `site/release-process.html`

### DIFF
--- a/site/release-process.html
+++ b/site/release-process.html
@@ -461,6 +461,7 @@ $ ln -s 1.1.1 latest
   <li>update <code class="language-plaintext highlighter-rouge">_layouts/global.html</code> if the new release is the latest one</li>
   <li>update <code class="language-plaintext highlighter-rouge">documentation.md</code> to add link to the docs for the new release</li>
   <li>add the new release to <code class="language-plaintext highlighter-rouge">js/downloads.js</code> (attention to the order of releases)</li>
+  <li>add the new release to <code class="language-plaintext highlighter-rouge">site/static/versions.json</code> (attention to the order of releases) [for <code class="language-plaintext highlighter-rouge">spark version drop down</code> of the <code class="language-plaintext highlighter-rouge">PySpark</code> docs]</li>
   <li>check <code class="language-plaintext highlighter-rouge">security.md</code> for anything to update</li>
 </ul>
 


### PR DESCRIPTION
The pr is following up https://github.com/apache/spark-website/pull/528
After updating the doc `release-process.md`, the doc `site/release-process.html` should be updated synchronously.