### PR TITLE
Update committer guidelines about The Apache Way

### DIFF
--- a/committers.md
+++ b/committers.md
@@ -127,6 +127,9 @@ assessing quality. Contributors to these areas will face more review of their ch
 community interactions. They should also be active on the dev and user list and help mentor 
 newer contributors and users. In design discussions, committers should maintain a professional 
 and diplomatic approach, even in the face of disagreement.
+4. [The Apache Way](https://www.apache.org/theapacheway/): Committers should follow and understand [The Apache Way](https://www.apache.org/theapacheway/) such as [Lazy Consensus](https://community.apache.org/committers/decisionMaking.html#lazy-consensus). [Apache projects are managed independently](https://community.apache.org/projectIndependence.html#apache-projects-are-managed-independently).
+
+    > A community that obviously favors one specific vendor in some exclusive way will often discourage new contributors from competing vendors, and this would be an issue for the long-term health of the project.
 
 The type and level of contributions considered may vary by project area -- for example, we 
 greatly encourage contributors who want to work on mainly the documentation, or mainly on 

--- a/committers.md
+++ b/committers.md
@@ -127,9 +127,14 @@ assessing quality. Contributors to these areas will face more review of their ch
 community interactions. They should also be active on the dev and user list and help mentor 
 newer contributors and users. In design discussions, committers should maintain a professional 
 and diplomatic approach, even in the face of disagreement.
-4. [The Apache Way](https://www.apache.org/theapacheway/): Committers should follow and understand [The Apache Way](https://www.apache.org/theapacheway/) such as [Lazy Consensus](https://community.apache.org/committers/decisionMaking.html#lazy-consensus). [Apache projects are managed independently](https://community.apache.org/projectIndependence.html#apache-projects-are-managed-independently).
+4. [The Apache Way](https://www.apache.org/theapacheway/): Committers should follow and
+understand [The Apache Way](https://www.apache.org/theapacheway/) such as
+[Lazy Consensus](https://community.apache.org/committers/decisionMaking.html#lazy-consensus).
+[Apache projects are managed independently](https://community.apache.org/projectIndependence.html#apache-projects-are-managed-independently).
 
-    > A community that obviously favors one specific vendor in some exclusive way will often discourage new contributors from competing vendors, and this would be an issue for the long-term health of the project.
+  > A community that obviously favors one specific vendor in some exclusive way will often
+  > discourage new contributors from competing vendors, and this would be an issue for the
+  > long-term health of the project.
 
 The type and level of contributions considered may vary by project area -- for example, we 
 greatly encourage contributors who want to work on mainly the documentation, or mainly on 

--- a/site/committers.html
+++ b/site/committers.html
@@ -544,14 +544,17 @@ assessing quality. Contributors to these areas will face more review of their ch
 community interactions. They should also be active on the dev and user list and help mentor 
 newer contributors and users. In design discussions, committers should maintain a professional 
 and diplomatic approach, even in the face of disagreement.</li>
-  <li>
-    <p><a href="https://www.apache.org/theapacheway/">The Apache Way</a>: Committers should follow and understand <a href="https://www.apache.org/theapacheway/">The Apache Way</a> such as <a href="https://community.apache.org/committers/decisionMaking.html#lazy-consensus">Lazy Consensus</a>. <a href="https://community.apache.org/projectIndependence.html#apache-projects-are-managed-independently">Apache projects are managed independently</a>.</p>
-
-    <blockquote>
-      <p>A community that obviously favors one specific vendor in some exclusive way will often discourage new contributors from competing vendors, and this would be an issue for the long-term health of the project.</p>
-    </blockquote>
-  </li>
+  <li><a href="https://www.apache.org/theapacheway/">The Apache Way</a>: Committers should follow and
+understand <a href="https://www.apache.org/theapacheway/">The Apache Way</a> such as
+<a href="https://community.apache.org/committers/decisionMaking.html#lazy-consensus">Lazy Consensus</a>.
+<a href="https://community.apache.org/projectIndependence.html#apache-projects-are-managed-independently">Apache projects are managed independently</a>.</li>
 </ol>
+
+<blockquote>
+  <p>A community that obviously favors one specific vendor in some exclusive way will often
+discourage new contributors from competing vendors, and this would be an issue for the
+long-term health of the project.</p>
+</blockquote>
 
 <p>The type and level of contributions considered may vary by project area &#8211; for example, we 
 greatly encourage contributors who want to work on mainly the documentation, or mainly on 

--- a/site/committers.html
+++ b/site/committers.html
@@ -544,6 +544,13 @@ assessing quality. Contributors to these areas will face more review of their ch
 community interactions. They should also be active on the dev and user list and help mentor 
 newer contributors and users. In design discussions, committers should maintain a professional 
 and diplomatic approach, even in the face of disagreement.</li>
+  <li>
+    <p><a href="https://www.apache.org/theapacheway/">The Apache Way</a>: Committers should follow and understand <a href="https://www.apache.org/theapacheway/">The Apache Way</a> such as <a href="https://community.apache.org/committers/decisionMaking.html#lazy-consensus">Lazy Consensus</a>. <a href="https://community.apache.org/projectIndependence.html#apache-projects-are-managed-independently">Apache projects are managed independently</a>.</p>
+
+    <blockquote>
+      <p>A community that obviously favors one specific vendor in some exclusive way will often discourage new contributors from competing vendors, and this would be an issue for the long-term health of the project.</p>
+    </blockquote>
+  </li>
 </ol>
 
 <p>The type and level of contributions considered may vary by project area &#8211; for example, we 


### PR DESCRIPTION
Per the discussion in private mailing list, I am updating Committer guidelines to highlight The Apache Way.

![Screenshot 2024-07-14 at 10 34 38 AM](https://github.com/user-attachments/assets/8151b948-7b0a-4888-b6e3-533ce17c2924)
