### PR TITLE
Fix Binder integration in PySpark documentation

### DIFF
--- a/site/docs/3.4.3/api/python/getting_started/index.html
+++ b/site/docs/3.4.3/api/python/getting_started/index.html
@@ -191,9 +191,9 @@ There are more guides shared with other languages such as
 at <a class="reference external" href="https://spark.apache.org/docs/latest/index.html#where-to-go-from-here">the Spark documentation</a>.</p>
 <p>There are live notebooks where you can try PySpark out without any other step:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/1eb558c3a6f?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook: DataFrame</a></p></li>
-<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/1eb558c3a6f?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_connect.ipynb">Live Notebook: Spark Connect</a></p></li>
-<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/1eb558c3a6f?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb">Live Notebook: pandas API on Spark</a></p></li>
+<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/149638e0781?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook: DataFrame</a></p></li>
+<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/149638e0781?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_connect.ipynb">Live Notebook: Spark Connect</a></p></li>
+<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/149638e0781?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb">Live Notebook: pandas API on Spark</a></p></li>
 </ul>
 <p>The list below is the contents of this quickstart page:</p>
 <div class="toctree-wrapper compound">

--- a/site/docs/3.4.3/api/python/index.html
+++ b/site/docs/3.4.3/api/python/index.html
@@ -162,7 +162,7 @@
 <h1>PySpark Overview<a class="headerlink" href="#pyspark-overview" title="Permalink to this headline">¶</a></h1>
 <p><strong>Date</strong>: Apr 15, 2024 <strong>Version</strong>: 3.4.3</p>
 <p><strong>Useful links</strong>:
-<a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/1eb558c3a6f?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook</a> | <a class="reference external" href="https://github.com/apache/spark">GitHub</a> | <a class="reference external" href="https://issues.apache.org/jira/projects/SPARK/issues">Issues</a> | <a class="reference external" href="https://github.com/apache/spark/tree/1eb558c3a6f/examples/src/main/python">Examples</a> | <a class="reference external" href="https://spark.apache.org/community.html">Community</a></p>
+<a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/149638e0781?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook</a> | <a class="reference external" href="https://github.com/apache/spark">GitHub</a> | <a class="reference external" href="https://issues.apache.org/jira/projects/SPARK/issues">Issues</a> | <a class="reference external" href="https://github.com/apache/spark/tree/1eb558c3a6f/examples/src/main/python">Examples</a> | <a class="reference external" href="https://spark.apache.org/community.html">Community</a></p>
 <p>PySpark is the Python API for Apache Spark. It enables you to perform real-time,
 large-scale data processing in a distributed environment using Python. It also provides a PySpark
 shell for interactively analyzing your data.</p>
@@ -216,7 +216,7 @@ Whether you use Python or SQL, the same underlying execution
 engine is used so you will always leverage the full power of Spark.</p>
 <ul class="simple">
 <li><p><a class="reference internal" href="getting_started/quickstart_df.html"><span class="std std-ref">Quickstart: DataFrame</span></a></p></li>
-<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/1eb558c3a6f?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook: DataFrame</a></p></li>
+<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/149638e0781?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook: DataFrame</a></p></li>
 <li><p><a class="reference internal" href="reference/pyspark.sql/index.html"><span class="std std-ref">Spark SQL API Reference</span></a></p></li>
 </ul>
 <p><strong>Pandas API on Spark</strong></p>
@@ -232,7 +232,7 @@ if you are new to Spark or deciding which API to use, we recommend using PySpark
 (see <a class="reference internal" href="#index-page-spark-sql-and-dataframes"><span class="std std-ref">Spark SQL and DataFrames</span></a>).</p>
 <ul class="simple">
 <li><p><a class="reference internal" href="getting_started/quickstart_ps.html"><span class="std std-ref">Quickstart: Pandas API on Spark</span></a></p></li>
-<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/1eb558c3a6f?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb">Live Notebook: pandas API on Spark</a></p></li>
+<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/149638e0781?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb">Live Notebook: pandas API on Spark</a></p></li>
 <li><p><a class="reference internal" href="reference/pyspark.pandas/index.html"><span class="std std-ref">Pandas API on Spark Reference</span></a></p></li>
 </ul>
 <p id="index-page-structured-streaming"><strong>Structured Streaming</strong></p>

--- a/site/docs/3.5.2/api/python/getting_started/index.html
+++ b/site/docs/3.5.2/api/python/getting_started/index.html
@@ -292,9 +292,9 @@ There are more guides shared with other languages such as
 at <a class="reference external" href="https://spark.apache.org/docs/latest/index.html#where-to-go-from-here">the Spark documentation</a>.</p>
 <p>There are live notebooks where you can try PySpark out without any other step:</p>
 <ul class="simple">
-<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/bb7846dd487?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook: DataFrame</a></p></li>
-<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/bb7846dd487?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_connect.ipynb">Live Notebook: Spark Connect</a></p></li>
-<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/bb7846dd487?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb">Live Notebook: pandas API on Spark</a></p></li>
+<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/e1b425fd7d5?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook: DataFrame</a></p></li>
+<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/e1b425fd7d5?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_connect.ipynb">Live Notebook: Spark Connect</a></p></li>
+<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/e1b425fd7d5?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb">Live Notebook: pandas API on Spark</a></p></li>
 </ul>
 <p>The list below is the contents of this quickstart page:</p>
 <div class="toctree-wrapper compound">

--- a/site/docs/3.5.2/api/python/index.html
+++ b/site/docs/3.5.2/api/python/index.html
@@ -260,7 +260,7 @@ function checkPageExistsAndRedirect(event) {
 <h1>PySpark Overview<a class="headerlink" href="#pyspark-overview" title="Permalink to this headline">¶</a></h1>
 <p><strong>Date</strong>: Aug 06, 2024 <strong>Version</strong>: 3.5.2</p>
 <p><strong>Useful links</strong>:
-<a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/bb7846dd487?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook</a> | <a class="reference external" href="https://github.com/apache/spark">GitHub</a> | <a class="reference external" href="https://issues.apache.org/jira/projects/SPARK/issues">Issues</a> | <a class="reference external" href="https://github.com/apache/spark/tree/bb7846dd487/examples/src/main/python">Examples</a> | <a class="reference external" href="https://spark.apache.org/community.html">Community</a></p>
+<a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/e1b425fd7d5?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook</a> | <a class="reference external" href="https://github.com/apache/spark">GitHub</a> | <a class="reference external" href="https://issues.apache.org/jira/projects/SPARK/issues">Issues</a> | <a class="reference external" href="https://github.com/apache/spark/tree/bb7846dd487/examples/src/main/python">Examples</a> | <a class="reference external" href="https://spark.apache.org/community.html">Community</a></p>
 <p>PySpark is the Python API for Apache Spark. It enables you to perform real-time,
 large-scale data processing in a distributed environment using Python. It also provides a PySpark
 shell for interactively analyzing your data.</p>
@@ -314,7 +314,7 @@ Whether you use Python or SQL, the same underlying execution
 engine is used so you will always leverage the full power of Spark.</p>
 <ul class="simple">
 <li><p><a class="reference internal" href="getting_started/quickstart_df.html"><span class="std std-ref">Quickstart: DataFrame</span></a></p></li>
-<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/bb7846dd487?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook: DataFrame</a></p></li>
+<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/e1b425fd7d5?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb">Live Notebook: DataFrame</a></p></li>
 <li><p><a class="reference internal" href="reference/pyspark.sql/index.html"><span class="std std-ref">Spark SQL API Reference</span></a></p></li>
 </ul>
 <p><strong>Pandas API on Spark</strong></p>
@@ -330,7 +330,7 @@ if you are new to Spark or deciding which API to use, we recommend using PySpark
 (see <a class="reference internal" href="#index-page-spark-sql-and-dataframes"><span class="std std-ref">Spark SQL and DataFrames</span></a>).</p>
 <ul class="simple">
 <li><p><a class="reference internal" href="getting_started/quickstart_ps.html"><span class="std std-ref">Quickstart: Pandas API on Spark</span></a></p></li>
-<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/bb7846dd487?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb">Live Notebook: pandas API on Spark</a></p></li>
+<li><p><a class="reference external" href="https://mybinder.org/v2/gh/apache/spark/e1b425fd7d5?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb">Live Notebook: pandas API on Spark</a></p></li>
 <li><p><a class="reference internal" href="reference/pyspark.pandas/index.html"><span class="std std-ref">Pandas API on Spark Reference</span></a></p></li>
 </ul>
 <p id="index-page-structured-streaming"><strong>Structured Streaming</strong></p>


### PR DESCRIPTION
This PR proposes to fix the Binder links for 3.5.2 and 3.4.3.

Manually tested:

3.4.3:
https://mybinder.org/v2/gh/apache/spark/149638e0781?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb
https://mybinder.org/v2/gh/apache/spark/149638e0781?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_connect.ipynb
https://mybinder.org/v2/gh/apache/spark/149638e0781?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb

3.5.2:
https://mybinder.org/v2/gh/apache/spark/e1b425fd7d5?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb
https://mybinder.org/v2/gh/apache/spark/e1b425fd7d5?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_connect.ipynb
https://mybinder.org/v2/gh/apache/spark/e1b425fd7d5?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_ps.ipynb

