### PR TITLE
Fix typo in downloads.md

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -45,7 +45,7 @@ Spark artifacts are [hosted in Maven Central](https://search.maven.org/search?q=
 
 Spark docker images are available from Dockerhub under the accounts of both [The Apache Software Foundation](https://hub.docker.com/r/apache/spark/) and [Official Images](https://hub.docker.com/_/spark).
 
-Note that, these images contain non-ASF software and may be subject to different license terms. Please check their [Dockerfiles](https://github.com/apache/spark-docker) to verify whether to verify whether they are compatible with your deployment.
+Note that, these images contain non-ASF software and may be subject to different license terms. Please check their [Dockerfiles](https://github.com/apache/spark-docker) to verify whether they are compatible with your deployment.
 
 ### Release notes for stable releases
 

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -198,7 +198,7 @@ version: 3.5.2
 
 <p>Spark docker images are available from Dockerhub under the accounts of both <a href="https://hub.docker.com/r/apache/spark/">The Apache Software Foundation</a> and <a href="https://hub.docker.com/_/spark">Official Images</a>.</p>
 
-<p>Note that, these images contain non-ASF software and may be subject to different license terms. Please check their <a href="https://github.com/apache/spark-docker">Dockerfiles</a> to verify whether to verify whether they are compatible with your deployment.</p>
+<p>Note that, these images contain non-ASF software and may be subject to different license terms. Please check their <a href="https://github.com/apache/spark-docker">Dockerfiles</a> to verify whether they are compatible with your deployment.</p>
 
 <h3 id="release-notes-for-stable-releases">Release notes for stable releases</h3>
 

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1061,19 +1061,27 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/spark-connect/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
   <loc>https://spark.apache.org/pandas-on-spark/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/graphx/</loc>
+  <loc>https://spark.apache.org/screencasts/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/spark-connect/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/sql/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
   <loc>https://spark.apache.org/mllib/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/graphx/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
@@ -1082,14 +1090,6 @@
 </url>
 <url>
   <loc>https://spark.apache.org/news/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>https://spark.apache.org/screencasts/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>https://spark.apache.org/sql/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1061,27 +1061,19 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/pandas-on-spark/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>https://spark.apache.org/screencasts/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
   <loc>https://spark.apache.org/spark-connect/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/sql/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>https://spark.apache.org/mllib/</loc>
+  <loc>https://spark.apache.org/pandas-on-spark/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
   <loc>https://spark.apache.org/graphx/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/mllib/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
@@ -1090,6 +1082,14 @@
 </url>
 <url>
   <loc>https://spark.apache.org/news/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/screencasts/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/sql/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>


### PR DESCRIPTION
There seems to have been a small typo in the Docker section of downloads.

<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->
