### PR TITLE
Document Spark 4.0 release window

### DIFF
--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -281,7 +281,7 @@ available APIs.</p>
 Hence, Spark 2.3.0 would generally be released about 6 months after 2.2.0. Maintenance releases happen as needed
 in between feature releases. Major releases do not happen according to a fixed schedule.</p>
 
-<h3>Spark 3.5 release window</h3>
+<h3>Spark 4.0 release window</h3>
 
 <table>
   <thead>
@@ -292,15 +292,15 @@ in between feature releases. Major releases do not happen according to a fixed s
   </thead>
   <tbody>
     <tr>
-      <td>July 16th 2023</td>
+      <td>January 15th 2025</td>
       <td>Code freeze. Release branch cut.</td>
     </tr>
     <tr>
-      <td>Late July 2023</td>
+      <td>February 1st 2025</td>
       <td>QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.</td>
     </tr>
     <tr>
-      <td>August 2023</td>
+      <td>February 15th 2025</td>
       <td>Release candidates (RC), voting, etc. until final release passes</td>
     </tr>
   </tbody>

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -103,13 +103,13 @@ The branch is cut every January and July, so feature ("minor") releases occur ab
 Hence, Spark 2.3.0 would generally be released about 6 months after 2.2.0. Maintenance releases happen as needed
 in between feature releases. Major releases do not happen according to a fixed schedule.
 
-<h3>Spark 3.5 release window</h3>
+<h3>Spark 4.0 release window</h3>
 
 | Date  | Event |
 | ----- | ----- |
-| July 16th 2023 | Code freeze. Release branch cut.|
-| Late July 2023 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
-| August 2023 | Release candidates (RC), voting, etc. until final release passes|
+| January 15th 2025 | Code freeze. Release branch cut.|
+| February 1st 2025 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
+| February 15th 2025 | Release candidates (RC), voting, etc. until final release passes|
 
 <h2>Maintenance releases and EOL</h2>
 


### PR DESCRIPTION
This PR aims to document Spark 4.0 release window based on the discussion on dev mailing list.

https://lists.apache.org/thread/408wkyyow602ty14llqlxdzxojcrqgkg

| DATE | DESCRIPTION |
| ------------- | ------------- |
| January 15th 2025 | Code freeze. Release branch cut.|
| February 1st 2025 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
| February 15th 2025 | Release candidates (RC), voting, etc. until final release passes|