### PR TITLE
Wrong documentation for DoubleType on Python

### DIFF
--- a/site/docs/3.5.3/sql-ref-datatypes.html
+++ b/site/docs/3.5.3/sql-ref-datatypes.html
@@ -566,7 +566,7 @@ You can access them by doing</p>
         </tr>
         <tr>
           <td><strong>DoubleType</strong></td>
-          <td>float</td>
+          <td>double</td>
           <td>DoubleType()</td>
         </tr>
         <tr>


### PR DESCRIPTION
Hi,

Sorry to open this incomplete pull request, but I just wanted to report this error in pyspark documentation. It seems like this change should be applied on many other versions of spark.

If someone could direct me since which version this change happened, I can do the necessary change and ofc complete the PR properly with the `build` command

[Current doc](https://spark.apache.org/docs/latest/sql-ref-datatypes.html): says that `DoubleType()` has `float` as python value type, 

however running the following test fails:
```python
import pytest
from pyspark.sql import types as T

def test_spark_DoubleType_name():
    assert T.DoubleType().typeName() == "float"
```

**Test Result:**

> =================================== FAILURES ===================================
> _____________________________ test_spark_DoubleType_name _____________________________
> 
> def test_spark_DoubleType_name():
> \>       assert T.DoubleType().typeName() == "float"
>
> E       AssertionError: assert 'double' == 'float'
> E         
> E         - float
> E         + double
> 
> tests/my_test.py:6: AssertionError
> =========================== short test summary info ============================
> FAILED ests/my_test.py::test_spark_DoubleType_name - AssertionE...
> ============================== 1 failed in 0.05s ===============================
> Finished running tests!
> 

<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->
