### PR TITLE
Add v3.4.4 docs and news

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -16,6 +16,7 @@ navigation:
   <li><a href="{{site.baseurl}}/docs/3.5.2/">Spark 3.5.2</a></li>
   <li><a href="{{site.baseurl}}/docs/3.5.1/">Spark 3.5.1</a></li>
   <li><a href="{{site.baseurl}}/docs/3.5.0/">Spark 3.5.0</a></li>
+  <li><a href="{{site.baseurl}}/docs/3.4.4/">Spark 3.4.4</a></li>
   <li><a href="{{site.baseurl}}/docs/3.4.3/">Spark 3.4.3</a></li>
   <li><a href="{{site.baseurl}}/docs/3.4.2/">Spark 3.4.2</a></li>
   <li><a href="{{site.baseurl}}/docs/3.4.1/">Spark 3.4.1</a></li>

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -20,7 +20,7 @@ var hadoop3pscala213 = {pretty: "Pre-built for Apache Hadoop 3.3 and later (Scal
 var packagesV14 = [hadoop3p, hadoop3pscala213, hadoopFree, sources];
 
 addRelease("3.5.3", new Date("09/24/2024"), packagesV14, true);
-addRelease("3.4.3", new Date("04/18/2024"), packagesV14, true);
+addRelease("3.4.4", new Date("10/27/2024"), packagesV14, true);
 
 function append(el, contents) {
   el.innerHTML += contents;

--- a/news/_posts/2024-10-27-spark-3-4-4-released.md
+++ b/news/_posts/2024-10-27-spark-3-4-4-released.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: Spark 3.4.4 released
+categories:
+- News
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+We are happy to announce the availability of <a href="{{site.baseurl}}/releases/spark-release-3-4-4.html" title="Spark Release 3.4.4">Spark 3.4.4</a>! Visit the <a href="{{site.baseurl}}/releases/spark-release-3-4-4.html" title="Spark Release 3.4.4">release notes</a> to read about the new features, or <a href="{{site.baseurl}}/downloads.html">download</a> the release today.

--- a/releases/_posts/2024-10-27-spark-release-3-4-4.md
+++ b/releases/_posts/2024-10-27-spark-release-3-4-4.md
@@ -1,0 +1,84 @@
+---
+layout: post
+title: Spark Release 3.4.4
+categories: []
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+
+Spark 3.4.4 is the last maintenance release containing security and correctness fixes. This release is based on the branch-3.4 maintenance branch of Spark. We strongly recommend all 3.4 users to upgrade to this stable release.
+
+### Notable changes
+
+  - [[SPARK-43242]](https://issues.apache.org/jira/browse/SPARK-43242): Fix throw 'Unexpected type of BlockId' in shuffle corruption diagnose
+  - [[SPARK-45988]](https://issues.apache.org/jira/browse/SPARK-45988): Fix typehints to handle `list` GenericAlias in Python 3.11+
+  - [[SPARK-46535]](https://issues.apache.org/jira/browse/SPARK-46535): Fix NPE when describe extended a column without col stats
+  - [[SPARK-46957]](https://issues.apache.org/jira/browse/SPARK-46957): Decommission migrated shuffle files should be able to cleanup from executor
+  - [[SPARK-47129]](https://issues.apache.org/jira/browse/SPARK-47129): Make ResolveRelations cache connect plan properly
+  - [[SPARK-47172]](https://issues.apache.org/jira/browse/SPARK-47172): Add support for AES-GCM for RPC encryption
+  - [[SPARK-47828]](https://issues.apache.org/jira/browse/SPARK-47828): DataFrameWriterV2.overwrite fails with invalid plan
+  - [[SPARK-47895]](https://issues.apache.org/jira/browse/SPARK-47895): group by all should be idempotent
+  - [[SPARK-47897]](https://issues.apache.org/jira/browse/SPARK-47897): Fix ExpressionSet performance regression in scala 2.12
+  - [[SPARK-47927]](https://issues.apache.org/jira/browse/SPARK-47927): Fix nullability attribute in UDF decoder
+  - [[SPARK-48016]](https://issues.apache.org/jira/browse/SPARK-48016): Fix a bug in try_divide function when with decimals
+  - [[SPARK-48019]](https://issues.apache.org/jira/browse/SPARK-48019): Fix incorrect behavior in ColumnVector/ColumnarArray with dictionary and nulls
+  - [[SPARK-48037]](https://issues.apache.org/jira/browse/SPARK-48037): Fix SortShuffleWriter lacks shuffle write related metrics resulting in potentially inaccurate data
+  - [[SPARK-48081]](https://issues.apache.org/jira/browse/SPARK-48081): Fix ClassCastException in NTile.checkInputDataTypes() when argument is non-foldable or of wrong type
+  - [[SPARK-48105]](https://issues.apache.org/jira/browse/SPARK-48105): Fix the race condition between state store unloading and snapshotting
+  - [[SPARK-48128]](https://issues.apache.org/jira/browse/SPARK-48128): For BitwiseCount / bit_count expression, fix codegen syntax error for boolean type inputs
+  - [[SPARK-48155]](https://issues.apache.org/jira/browse/SPARK-48155): AQEPropagateEmptyRelation for join should check if remain child is just BroadcastQueryStageExec
+  - [[SPARK-48172]](https://issues.apache.org/jira/browse/SPARK-48172): Fix escaping issues in JDBCDialects
+  - [[SPARK-48248]](https://issues.apache.org/jira/browse/SPARK-48248): Fix nested array to respect legacy conf of inferArrayTypeFromFirstElement
+  - [[SPARK-48292]](https://issues.apache.org/jira/browse/SPARK-48292): Revert SPARK-39195 Spark OutputCommitCoordinator should abort stage when committed file not consistent with task status
+  - [[SPARK-48484]](https://issues.apache.org/jira/browse/SPARK-48484): Fix: V2Write use the same TaskAttemptId for different task attempts
+  - [[SPARK-48642]](https://issues.apache.org/jira/browse/SPARK-48642): False SparkOutOfMemoryError caused by killing task on spilling
+  - [[SPARK-48710]](https://issues.apache.org/jira/browse/SPARK-48710): Limit NumPy version to supported range (>=1.15,<2)
+  - [[SPARK-48759]](https://issues.apache.org/jira/browse/SPARK-48759): Add migration doc for CREATE TABLE AS SELECT behavior change behavior change since Spark 3.4
+  - [[SPARK-48791]](https://issues.apache.org/jira/browse/SPARK-48791): Fix perf regression caused by the accumulators registration overhead using CopyOnWriteArrayList
+  - [[SPARK-48930]](https://issues.apache.org/jira/browse/SPARK-48930): Redact `awsAccessKeyId` by including `accesskey` pattern
+  - [[SPARK-48934]](https://issues.apache.org/jira/browse/SPARK-48934): Python datetime types converted incorrectly for setting timeout in applyInPandasWithState
+  - [[SPARK-48965]](https://issues.apache.org/jira/browse/SPARK-48965): Use the correct schema in `Dataset#toJSON`
+  - [[SPARK-48991]](https://issues.apache.org/jira/browse/SPARK-48991): Move path initialization into try-catch block in FileStreamSink.hasMetadata
+  - [[SPARK-49000]](https://issues.apache.org/jira/browse/SPARK-49000): Fix "select count(distinct 1) from t" where t is empty table by expanding RewriteDistinctAggregates
+  - [[SPARK-49005]](https://issues.apache.org/jira/browse/SPARK-49005): Use `17-jammy` tag instead of `17-jre` to prevent Python 3.12
+  - [[SPARK-49038]](https://issues.apache.org/jira/browse/SPARK-49038): SQLMetric should report the raw value in the accumulator update event
+  - [[SPARK-49039]](https://issues.apache.org/jira/browse/SPARK-49039): Reset checkbox when executor metrics are loaded in the Stages tab
+  - [[SPARK-49094]](https://issues.apache.org/jira/browse/SPARK-49094): Fix ignoreCorruptFiles non-functioning for hive orc impl with mergeSchema off
+  - [[SPARK-49176]](https://issues.apache.org/jira/browse/SPARK-49176): Fix `spark.ui.custom.executor.log.url` docs by adding K8s
+  - [[SPARK-49179]](https://issues.apache.org/jira/browse/SPARK-49179): Fix v2 multi bucketed inner joins throw AssertionError
+  - [[SPARK-49182]](https://issues.apache.org/jira/browse/SPARK-49182): Stop publish site/docs/{version}/api/python/_sources dir
+  - [[SPARK-49193]](https://issues.apache.org/jira/browse/SPARK-49193): Improve the performance of RowSetUtils.toColumnBasedSet
+  - [[SPARK-49197]](https://issues.apache.org/jira/browse/SPARK-49197): Redact `Spark Command` output in `launcher` module
+  - [[SPARK-49261]](https://issues.apache.org/jira/browse/SPARK-49261): Don't replace literals in aggregate expressions with group-by expressions
+  - [[SPARK-49352]](https://issues.apache.org/jira/browse/SPARK-49352): Avoid redundant array transform for identical expression
+  - [[SPARK-49385]](https://issues.apache.org/jira/browse/SPARK-49385): Fix `getReusablePVCs` to use `podCreationTimeout` instead of `podAllocationDelay`
+  - [[SPARK-49408]](https://issues.apache.org/jira/browse/SPARK-49408): Use IndexedSeq in ProjectingInternalRow
+  - [[SPARK-49595]](https://issues.apache.org/jira/browse/SPARK-49595): Fix `DataFrame.unpivot/melt` in Spark Connect Scala Client
+  - [[SPARK-49628]](https://issues.apache.org/jira/browse/SPARK-49628): ConstantFolding should copy stateful expression before evaluating
+  - [[SPARK-49750]](https://issues.apache.org/jira/browse/SPARK-49750): Mention delegation token support in K8s mode
+  - [[SPARK-49760]](https://issues.apache.org/jira/browse/SPARK-49760): Correct handling of `SPARK_USER` env variable override in app master
+  - [[SPARK-49804]](https://issues.apache.org/jira/browse/SPARK-49804): Fix to use the exit code of executor container always
+  - [[SPARK-49836]](https://issues.apache.org/jira/browse/SPARK-49836): Fix possibly broken query when window is provided to window/session_window fn
+  - [[SPARK-49843]](https://issues.apache.org/jira/browse/SPARK-49843): Fix change comment on char/varchar columns
+  - [[SPARK-49959]](https://issues.apache.org/jira/browse/SPARK-49959): Fix ColumnarArray.copy() to read nulls from the correct offset
+  - [[SPARK-50021]](https://issues.apache.org/jira/browse/SPARK-50021): Fix `ApplicationPage` to hide App UI links when UI is disabled
+  - [[SPARK-50022]](https://issues.apache.org/jira/browse/SPARK-50022): Fix `MasterPage` to hide App UI links when UI is disabled
+
+### Dependency Changes
+
+While being a maintenance release we did still upgrade some dependencies in this release they are:
+
+  - [[SPARK-43394]](https://issues.apache.org/jira/browse/SPARK-43394): Upgrade maven to 3.8.8
+  - [[SPARK-45590]](https://issues.apache.org/jira/browse/SPARK-45590): Upgrade okio to 1.17.6 from 1.15.0
+
+You can consult JIRA for the [detailed changes](https://s.apache.org/spark-3.4.4).
+
+We would like to acknowledge all community members for contributing patches to this release.
+
+
+

--- a/site/404.html
+++ b/site/404.html
@@ -179,6 +179,9 @@ to find the information you need.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -187,9 +190,6 @@ to find the information you need.</p>
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/committers.html
+++ b/site/committers.html
@@ -714,6 +714,9 @@ of the immediate bug being fixed.</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -722,9 +725,6 @@ of the immediate bug being fixed.</li>
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/community.html
+++ b/site/community.html
@@ -379,6 +379,9 @@ Add yours by emailing `dev@spark.apache.org`.
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -387,9 +390,6 @@ Add yours by emailing `dev@spark.apache.org`.
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -722,6 +722,9 @@ to ask on the <code class="language-plaintext highlighter-rouge">dev@spark.apach
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -730,9 +733,6 @@ to ask on the <code class="language-plaintext highlighter-rouge">dev@spark.apach
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -723,6 +723,9 @@ compatible with usage in an Open Source project and inclusion of the generated c
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -731,9 +734,6 @@ compatible with usage in an Open Source project and inclusion of the generated c
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/docs/3.4.4/index.html
+++ b/site/docs/3.4.4/index.html
@@ -1,0 +1,28 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!DOCTYPE html>
+<html lang="en-US">
+<meta charset="utf-8">
+<title>Redirecting&hellip;</title>
+<link rel="canonical" href="https://archive.apache.org/dist/spark/docs/3.4.4/">
+<script>location="https://archive.apache.org/dist/spark/docs/3.4.4/"</script>
+<meta http-equiv="refresh" content="0; url=https://archive.apache.org/dist/spark/docs/3.4.4/">
+<meta name="robots" content="noindex">
+<h1>Redirecting&hellip;</h1>
+<a href="https://archive.apache.org/dist/spark/docs/3.4.4/">Click here if you are not redirected.</a>
+</html>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -162,6 +162,7 @@
   <li><a href="/docs/3.5.2/">Spark 3.5.2</a></li>
   <li><a href="/docs/3.5.1/">Spark 3.5.1</a></li>
   <li><a href="/docs/3.5.0/">Spark 3.5.0</a></li>
+  <li><a href="/docs/3.4.4/">Spark 3.4.4</a></li>
   <li><a href="/docs/3.4.3/">Spark 3.4.3</a></li>
   <li><a href="/docs/3.4.2/">Spark 3.4.2</a></li>
   <li><a href="/docs/3.4.1/">Spark 3.4.1</a></li>
@@ -380,6 +381,9 @@ The <a href="/research.html">research page</a> lists some of the original motiva
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -388,9 +392,6 @@ The <a href="/research.html">research page</a> lists some of the original motiva
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -219,6 +219,9 @@ before deciding to use it.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -227,9 +230,6 @@ before deciding to use it.</p>
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/error-message-guidelines.html
+++ b/site/error-message-guidelines.html
@@ -556,6 +556,9 @@ be redundant; you may skip an explicit explanation in this case.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -564,9 +567,6 @@ be redundant; you may skip an explicit explanation in this case.</p>
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/examples.html
+++ b/site/examples.html
@@ -504,6 +504,9 @@ counts = (
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -512,9 +515,6 @@ counts = (
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/faq.html
+++ b/site/faq.html
@@ -226,6 +226,9 @@ Please also refer to our
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -234,9 +237,6 @@ Please also refer to our
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -271,6 +271,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -279,9 +282,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/history.html
+++ b/site/history.html
@@ -180,6 +180,9 @@ You can get involved in Apache Spark development by reading
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -188,9 +191,6 @@ You can get involved in Apache Spark development by reading
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -252,6 +252,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -260,9 +263,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -20,7 +20,7 @@ var hadoop3pscala213 = {pretty: "Pre-built for Apache Hadoop 3.3 and later (Scal
 var packagesV14 = [hadoop3p, hadoop3pscala213, hadoopFree, sources];
 
 addRelease("3.5.3", new Date("09/24/2024"), packagesV14, true);
-addRelease("3.4.3", new Date("04/18/2024"), packagesV14, true);
+addRelease("3.4.4", new Date("10/27/2024"), packagesV14, true);
 
 function append(el, contents) {
   el.innerHTML += contents;

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -164,6 +164,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -172,9 +175,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -317,6 +317,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -325,9 +328,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/3-1-3-released.html
+++ b/site/news/3-1-3-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -157,6 +157,15 @@
 
 <article class="hentry">
     <header class="entry-header">
+      <h3 class="entry-title"><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a></h3>
+      <div class="entry-date">October 27, 2024</div>
+    </header>
+    <div class="entry-content"><p>We are happy to announce the availability of <a href="/releases/spark-release-3-4-4.html" title="Spark Release 3.4.4">Spark 3.4.4</a>! Visit the <a href="/releases/spark-release-3-4-4.html" title="Spark Release 3.4.4">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+</div>
+  </article>
+
+<article class="hentry">
+    <header class="entry-header">
       <h3 class="entry-title"><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a></h3>
       <div class="entry-date">September 26, 2024</div>
     </header>
@@ -1422,6 +1431,9 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -1430,9 +1442,6 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/new-repository-service.html
+++ b/site/news/new-repository-service.html
@@ -176,6 +176,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -184,9 +187,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/next-official-release-spark-3.1.1.html
+++ b/site/news/next-official-release-spark-3.1.1.html
@@ -182,6 +182,9 @@ are no guarantees on using it such as binary compatibility.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -190,9 +193,6 @@ are no guarantees on using it such as binary compatibility.</p>
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -176,6 +176,9 @@ online to attend in person. We hope you enjoy the event!</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -184,9 +187,6 @@ online to attend in person. We hope you enjoy the event!</p>
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/plan-for-dropping-python-2-support.html
+++ b/site/news/plan-for-dropping-python-2-support.html
@@ -186,6 +186,9 @@ Python 2. However, after Python 2 EOL, we might not take patches that are specif
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -194,9 +197,6 @@ Python 2. However, after Python 2 EOL, we might not take patches that are specif
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/sigmod-system-award.html
+++ b/site/news/sigmod-system-award.html
@@ -181,6 +181,9 @@ the whole community earned together.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -189,9 +192,6 @@ the whole community earned together.</p>
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -177,6 +177,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -185,9 +188,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -176,6 +176,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -184,9 +187,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -175,6 +175,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -183,9 +186,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -173,6 +173,9 @@ This release expands Spark&#8217;s standard libraries, introducing a new SQL pac
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -181,9 +184,6 @@ This release expands Spark&#8217;s standard libraries, introducing a new SQL pac
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -176,6 +176,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -184,9 +187,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-3-released.html
+++ b/site/news/spark-2-1-3-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-2-released.html
+++ b/site/news/spark-2-2-2-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-1-released.html
+++ b/site/news/spark-2-3-1-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-2-released.html
+++ b/site/news/spark-2-3-2-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-3-released.html
+++ b/site/news/spark-2-3-3-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-4-released.html
+++ b/site/news/spark-2-3-4-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-0-released.html
+++ b/site/news/spark-2-4-0-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-1-released.html
+++ b/site/news/spark-2-4-1-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-2-released.html
+++ b/site/news/spark-2-4-2-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-3-released.html
+++ b/site/news/spark-2-4-3-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-4-released.html
+++ b/site/news/spark-2-4-4-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-5-released.html
+++ b/site/news/spark-2-4-5-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-6.html
+++ b/site/news/spark-2-4-6.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-7-released.html
+++ b/site/news/spark-2-4-7-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-8-released.html
+++ b/site/news/spark-2-4-8-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-0-released.html
+++ b/site/news/spark-3-0-0-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-1-released.html
+++ b/site/news/spark-3-0-1-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-2-released.html
+++ b/site/news/spark-3-0-2-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-3-released.html
+++ b/site/news/spark-3-0-3-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-1-released.html
+++ b/site/news/spark-3-1-1-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-2-released.html
+++ b/site/news/spark-3-1-2-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-0-released.html
+++ b/site/news/spark-3-2-0-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-1-released.html
+++ b/site/news/spark-3-2-1-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-2-released.html
+++ b/site/news/spark-3-2-2-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-3-released.html
+++ b/site/news/spark-3-2-3-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-4-released.html
+++ b/site/news/spark-3-2-4-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-0-released.html
+++ b/site/news/spark-3-3-0-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-1-released.html
+++ b/site/news/spark-3-3-1-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-2-released.html
+++ b/site/news/spark-3-3-2-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-3-released.html
+++ b/site/news/spark-3-3-3-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-4-released.html
+++ b/site/news/spark-3-3-4-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-4-0-released.html
+++ b/site/news/spark-3-4-0-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-4-1-released.html
+++ b/site/news/spark-3-4-1-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-4-2-released.html
+++ b/site/news/spark-3-4-2-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-4-3-released.html
+++ b/site/news/spark-3-4-3-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-4-4-released.html
+++ b/site/news/spark-3-4-4-released.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>
+     Spark 3.4.4 released | Apache Spark
+    
+  </title>
+
+  
+
+  
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
+  <link href="/css/custom.css" rel="stylesheet">
+  <!-- Code highlighter CSS -->
+  <link href="/css/pygments-default.css" rel="stylesheet">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+  <!-- Matomo -->
+  <script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["disableCookies"]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="https://analytics.apache.org/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '40']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
+</head>
+<body class="global">
+<nav class="navbar navbar-expand-lg navbar-dark p-0 px-4" style="background: #1D6890;">
+  <a class="navbar-brand" href="/">
+    <img src="/images/spark-logo-rev.svg" alt="" width="141" height="72">
+  </a>
+  <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent"
+          aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse col-md-12 col-lg-auto pt-4" id="navbarContent">
+
+    <ul class="navbar-nav me-auto">
+      <li class="nav-item">
+        <a class="nav-link active" aria-current="page" href="/downloads.html">Download</a>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="libraries" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Libraries
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="libraries">
+          <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
+          <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
+          <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
+          <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
+          <li>
+            <hr class="dropdown-divider">
+          </li>
+          <li><a class="dropdown-item" href="/third-party-projects.html">Third-Party Projects</a></li>
+        </ul>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="documentation" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Documentation
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="documentation">
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release</a></li>
+          <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
+          <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
+        </ul>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link active" aria-current="page" href="/examples.html">Examples</a>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="community" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Community
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="community">
+          <li><a class="dropdown-item" href="/community.html">Mailing Lists &amp; Resources</a></li>
+          <li><a class="dropdown-item" href="/contributing.html">Contributing to Spark</a></li>
+          <li><a class="dropdown-item" href="/improvement-proposals.html">Improvement Proposals (SPIP)</a>
+          </li>
+          <li><a class="dropdown-item" href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a>
+          </li>
+          <li><a class="dropdown-item" href="/powered-by.html">Powered By</a></li>
+          <li><a class="dropdown-item" href="/committers.html">Project Committers</a></li>
+          <li><a class="dropdown-item" href="/history.html">Project History</a></li>
+        </ul>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="developers" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Developers
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="developers">
+          <li><a class="dropdown-item" href="/developer-tools.html">Useful Developer Tools</a></li>
+          <li><a class="dropdown-item" href="/versioning-policy.html">Versioning Policy</a></li>
+          <li><a class="dropdown-item" href="/release-process.html">Release Process</a></li>
+          <li><a class="dropdown-item" href="/security.html">Security</a></li>
+        </ul>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="github" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+          GitHub
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="github">
+          <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>
+        </ul>
+      </li>
+    </ul>
+    <ul class="navbar-nav ml-auto">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="apacheFoundation" role="button"
+           data-bs-toggle="dropdown" aria-expanded="false">
+          Apache Software Foundation
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="apacheFoundation">
+          <li><a class="dropdown-item" href="https://www.apache.org/">Apache Homepage</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/licenses/">License</a></li>
+          <li><a class="dropdown-item"
+                 href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/security/">Security</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/events/current-event">Event</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</nav>
+
+<div class="container">
+  <div class="row mt-4">
+    <div class="col-12 col-md-9">
+      <h2>Spark 3.4.4 released</h2>
+
+
+<p>We are happy to announce the availability of <a href="/releases/spark-release-3-4-4.html" title="Spark Release 3.4.4">Spark 3.4.4</a>! Visit the <a href="/releases/spark-release-3-4-4.html" title="Spark Release 3.4.4">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+
+
+<p>
+<br/>
+<a href="/news/">Spark News Archive</a>
+</p>
+
+    </div>
+    <div class="col-12 col-md-3">
+      <div class="news" style="margin-bottom: 20px;">
+        <h5>Latest News</h5>
+        <ul class="list-unstyled">
+          
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
+          <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
+            <span class="small">(Sep 26, 2024)</span></li>
+          
+          <li><a href="/news/spark-3-5-3-released.html">Spark 3.5.3 released</a>
+            <span class="small">(Sep 24, 2024)</span></li>
+          
+          <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
+            <span class="small">(Aug 10, 2024)</span></li>
+          
+        </ul>
+        <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
+      </div>
+      <div style="text-align:center; margin-bottom: 20px;">
+        <a href="https://www.apache.org/events/current-event.html">
+          <img src="https://www.apache.org/events/current-event-234x60.png" style="max-width: 100%;"/>
+        </a>
+      </div>
+      <div class="hidden-xs hidden-sm">
+        <a href="/downloads.html" class="btn btn-cta btn-lg d-grid" style="margin-bottom: 30px;">
+          Download Spark
+        </a>
+        <p style="font-size: 16px; font-weight: 500; color: #555;">
+          Built-in Libraries:
+        </p>
+        <ul class="list-none">
+          <li><a href="/sql/">SQL and DataFrames</a></li>
+          <li><a href="/streaming/">Spark Streaming</a></li>
+          <li><a href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a href="/graphx/">GraphX (graph)</a></li>
+        </ul>
+        <a href="/third-party-projects.html">Third-Party Projects</a>
+      </div>
+    </div>
+  </div>
+
+  
+
+  <footer class="small">
+    <hr>
+    Apache Spark, Spark, Apache, the Apache feather logo, and the Apache Spark project logo are either registered
+    trademarks or trademarks of The Apache Software Foundation in the United States and other countries.
+    See guidance on use of Apache Spark <a href="/trademarks.html">trademarks</a>.
+    All other marks mentioned may be trademarks or registered trademarks of their respective owners.
+    Copyright &copy; 2018 The Apache Software Foundation, Licensed under the
+    <a href="https://www.apache.org/licenses/">Apache License, Version 2.0</a>.
+  </footer>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+        crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery.js"></script>
+<script src="/js/lang-tabs.js"></script>
+<script src="/js/downloads.js"></script>
+</body>
+</html>

--- a/site/news/spark-3-5-0-released.html
+++ b/site/news/spark-3-5-0-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-5-1-released.html
+++ b/site/news/spark-3-5-1-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-5-2-released.html
+++ b/site/news/spark-3-5-2-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-5-3-released.html
+++ b/site/news/spark-3-5-3-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview.html
+++ b/site/news/spark-3.0.0-preview.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview2.html
+++ b/site/news/spark-3.0.0-preview2.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-4.0.0-preview1.html
+++ b/site/news/spark-4.0.0-preview1.html
@@ -183,6 +183,9 @@ It&#8217;s also available in PyPI, with version name &#8220;4.0.0.dev1&#8221;.</
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -191,9 +194,6 @@ It&#8217;s also available in PyPI, with version name &#8220;4.0.0.dev1&#8221;.</
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-4.0.0-preview2.html
+++ b/site/news/spark-4.0.0-preview2.html
@@ -184,6 +184,9 @@ been possible without you.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -192,9 +195,6 @@ been possible without you.</p>
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-apr-2019-agenda-posted.html
+++ b/site/news/spark-ai-summit-apr-2019-agenda-posted.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-june-2020-agenda-posted.html
+++ b/site/news/spark-ai-summit-june-2020-agenda-posted.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -180,6 +180,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -188,9 +191,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -181,6 +181,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -189,9 +192,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-release-2-2-3.html
+++ b/site/news/spark-release-2-2-3.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -176,6 +176,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -184,9 +187,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -176,6 +176,9 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -184,9 +187,6 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -178,6 +178,9 @@ about the latest happenings in Spark.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -186,9 +189,6 @@ about the latest happenings in Spark.</p>
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2015.html
+++ b/site/news/spark-summit-east-agenda-posted-2015.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2016.html
+++ b/site/news/spark-summit-east-agenda-posted-2016.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-oct-2018-agenda-posted.html
+++ b/site/news/spark-summit-oct-2018-agenda-posted.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -175,6 +175,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -183,9 +186,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -177,6 +177,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -185,9 +188,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -176,6 +176,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -184,9 +187,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -179,6 +179,9 @@ on Spark.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -187,9 +190,6 @@ on Spark.</p>
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -180,6 +180,9 @@ online to attend in person. Otherwise, the Summit will offer a free live video s
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -188,9 +191,6 @@ online to attend in person. Otherwise, the Summit will offer a free live video s
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/pandas-on-spark/index.html
+++ b/site/pandas-on-spark/index.html
@@ -352,6 +352,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -360,9 +363,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -521,6 +521,9 @@ to process islands identified from a search robor</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -529,9 +532,6 @@ to process islands identified from a search robor</li>
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -601,6 +601,9 @@ and then send an e-mail to the mailing list with a subject that looks something 
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -609,9 +612,6 @@ and then send an e-mail to the mailing list with a subject that looks something 
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -221,6 +221,9 @@ squares.saveAsSequenceFile(<span class="string">"hdfs://..."</span>)
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -229,9 +232,6 @@ squares.saveAsSequenceFile(<span class="string">"hdfs://..."</span>)
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -193,6 +193,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -201,9 +204,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -203,6 +203,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -211,9 +214,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -172,6 +172,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -180,9 +183,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -247,6 +247,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -255,9 +258,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -187,6 +187,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -195,9 +198,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -200,6 +200,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -208,9 +211,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -269,6 +269,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -277,9 +280,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -211,6 +211,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -219,9 +222,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -205,6 +205,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -213,9 +216,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -300,6 +300,9 @@ We’d especially like to thank Patrick Wendell for acting as the release manage
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -308,9 +311,6 @@ We’d especially like to thank Patrick Wendell for acting as the release manage
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -264,6 +264,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -272,9 +275,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -358,6 +358,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -366,9 +369,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -276,6 +276,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -284,9 +287,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -249,6 +249,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -257,9 +260,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -342,6 +342,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -350,9 +353,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -300,6 +300,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -308,9 +311,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -257,6 +257,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -265,9 +268,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -393,6 +393,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -401,9 +404,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -279,6 +279,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -287,9 +290,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -407,6 +407,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -415,9 +418,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -279,6 +279,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -287,9 +290,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -239,6 +239,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -247,9 +250,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -384,6 +384,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -392,9 +395,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -271,6 +271,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -279,9 +282,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -498,6 +498,9 @@ Python coverage. MLlib also adds several new algorithms.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -506,9 +509,6 @@ Python coverage. MLlib also adds several new algorithms.</p>
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -303,6 +303,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -311,9 +314,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -436,6 +436,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -444,9 +447,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -175,6 +175,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -183,9 +186,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -312,6 +312,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -320,9 +323,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -408,6 +408,9 @@ yzhou2001, zhonghaihua, zhuol, zlpmichelle, Örjan Lundberg, Łukasz Gieroń</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -416,9 +419,6 @@ yzhou2001, zhonghaihua, zhuol, zlpmichelle, Örjan Lundberg, Łukasz Gieroń</p>
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -176,6 +176,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -184,9 +187,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -320,6 +320,9 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Roberts, Adrian Petrescu, Ahmed Mahran
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -328,9 +331,6 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Roberts, Adrian Petrescu, Ahmed Mahran
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-3.html
+++ b/site/releases/spark-release-2-1-3.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -386,6 +386,9 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Budde, Adam Roberts, Adrian Ionescu, A
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -394,9 +397,6 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Budde, Adam Roberts, Adrian Ionescu, A
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -184,6 +184,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -192,9 +195,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-2.html
+++ b/site/releases/spark-release-2-2-2.html
@@ -176,6 +176,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -184,9 +187,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-3.html
+++ b/site/releases/spark-release-2-2-3.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -396,6 +396,9 @@ ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Albe
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -404,9 +407,6 @@ ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Albe
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-1.html
+++ b/site/releases/spark-release-2-3-1.html
@@ -184,6 +184,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -192,9 +195,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-2.html
+++ b/site/releases/spark-release-2-3-2.html
@@ -184,6 +184,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -192,9 +195,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-3.html
+++ b/site/releases/spark-release-2-3-3.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-4.html
+++ b/site/releases/spark-release-2-3-4.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-0.html
+++ b/site/releases/spark-release-2-4-0.html
@@ -402,6 +402,9 @@ Achuth17, Adam Bradbury, Adamyuanyuan, Adelbert Chang, Ala Luszczak, Aleksandr K
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -410,9 +413,6 @@ Achuth17, Adam Bradbury, Adamyuanyuan, Adelbert Chang, Ala Luszczak, Aleksandr K
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-1.html
+++ b/site/releases/spark-release-2-4-1.html
@@ -212,6 +212,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -220,9 +223,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-2.html
+++ b/site/releases/spark-release-2-4-2.html
@@ -184,6 +184,9 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -192,9 +195,6 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-3.html
+++ b/site/releases/spark-release-2-4-3.html
@@ -182,6 +182,9 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -190,9 +193,6 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-4.html
+++ b/site/releases/spark-release-2-4-4.html
@@ -188,6 +188,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -196,9 +199,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-5.html
+++ b/site/releases/spark-release-2-4-5.html
@@ -202,6 +202,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -210,9 +213,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-6.html
+++ b/site/releases/spark-release-2-4-6.html
@@ -210,6 +210,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -218,9 +221,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-7.html
+++ b/site/releases/spark-release-2-4-7.html
@@ -252,6 +252,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -260,9 +263,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-8.html
+++ b/site/releases/spark-release-2-4-8.html
@@ -253,6 +253,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -261,9 +264,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-0.html
+++ b/site/releases/spark-release-3-0-0.html
@@ -562,6 +562,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -570,9 +573,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-1.html
+++ b/site/releases/spark-release-3-0-1.html
@@ -211,6 +211,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -219,9 +222,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-2.html
+++ b/site/releases/spark-release-3-0-2.html
@@ -221,6 +221,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -229,9 +232,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-3.html
+++ b/site/releases/spark-release-3-0-3.html
@@ -238,6 +238,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -246,9 +249,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-1.html
+++ b/site/releases/spark-release-3-1-1.html
@@ -599,6 +599,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -607,9 +610,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-2.html
+++ b/site/releases/spark-release-3-1-2.html
@@ -286,6 +286,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -294,9 +297,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-3.html
+++ b/site/releases/spark-release-3-1-3.html
@@ -200,6 +200,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -208,9 +211,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-0.html
+++ b/site/releases/spark-release-3-2-0.html
@@ -572,6 +572,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -580,9 +583,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-1.html
+++ b/site/releases/spark-release-3-2-1.html
@@ -205,6 +205,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -213,9 +216,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-2.html
+++ b/site/releases/spark-release-3-2-2.html
@@ -280,6 +280,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -288,9 +291,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-3.html
+++ b/site/releases/spark-release-3-2-3.html
@@ -253,6 +253,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -261,9 +264,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-4.html
+++ b/site/releases/spark-release-3-2-4.html
@@ -215,6 +215,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -223,9 +226,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-0.html
+++ b/site/releases/spark-release-3-3-0.html
@@ -752,6 +752,9 @@ Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</sp
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -760,9 +763,6 @@ Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</sp
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-1.html
+++ b/site/releases/spark-release-3-3-1.html
@@ -262,6 +262,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -270,9 +273,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-2.html
+++ b/site/releases/spark-release-3-3-2.html
@@ -339,6 +339,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -347,9 +350,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-3.html
+++ b/site/releases/spark-release-3-3-3.html
@@ -194,6 +194,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -202,9 +205,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-4.html
+++ b/site/releases/spark-release-3-3-4.html
@@ -221,6 +221,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -229,9 +232,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-4-0.html
+++ b/site/releases/spark-release-3-4-0.html
@@ -580,6 +580,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -588,9 +591,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-4-1.html
+++ b/site/releases/spark-release-3-4-1.html
@@ -267,6 +267,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -275,9 +278,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-4-2.html
+++ b/site/releases/spark-release-3-4-2.html
@@ -263,6 +263,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -271,9 +274,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-4-3.html
+++ b/site/releases/spark-release-3-4-3.html
@@ -241,6 +241,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -249,9 +252,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-4-4.html
+++ b/site/releases/spark-release-3-4-4.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <title>
+     Spark Release 3.4.4 | Apache Spark
+    
+  </title>
+
+  
+
+  
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&Courier+Prime:wght@400;700&display=swap" rel="stylesheet">
+  <link href="/css/custom.css" rel="stylesheet">
+  <!-- Code highlighter CSS -->
+  <link href="/css/pygments-default.css" rel="stylesheet">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+
+  <!-- Matomo -->
+  <script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["disableCookies"]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="https://analytics.apache.org/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '40']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
+</head>
+<body class="global">
+<nav class="navbar navbar-expand-lg navbar-dark p-0 px-4" style="background: #1D6890;">
+  <a class="navbar-brand" href="/">
+    <img src="/images/spark-logo-rev.svg" alt="" width="141" height="72">
+  </a>
+  <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent"
+          aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse col-md-12 col-lg-auto pt-4" id="navbarContent">
+
+    <ul class="navbar-nav me-auto">
+      <li class="nav-item">
+        <a class="nav-link active" aria-current="page" href="/downloads.html">Download</a>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="libraries" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Libraries
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="libraries">
+          <li><a class="dropdown-item" href="/sql/">SQL and DataFrames</a></li>
+          <li><a class="dropdown-item" href="/spark-connect/">Spark Connect</a></li>
+          <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
+          <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
+          <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
+          <li>
+            <hr class="dropdown-divider">
+          </li>
+          <li><a class="dropdown-item" href="/third-party-projects.html">Third-Party Projects</a></li>
+        </ul>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="documentation" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Documentation
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="documentation">
+          <li><a class="dropdown-item" href="/docs/latest/">Latest Release</a></li>
+          <li><a class="dropdown-item" href="/documentation.html">Older Versions and Other Resources</a></li>
+          <li><a class="dropdown-item" href="/faq.html">Frequently Asked Questions</a></li>
+        </ul>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link active" aria-current="page" href="/examples.html">Examples</a>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="community" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Community
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="community">
+          <li><a class="dropdown-item" href="/community.html">Mailing Lists &amp; Resources</a></li>
+          <li><a class="dropdown-item" href="/contributing.html">Contributing to Spark</a></li>
+          <li><a class="dropdown-item" href="/improvement-proposals.html">Improvement Proposals (SPIP)</a>
+          </li>
+          <li><a class="dropdown-item" href="https://issues.apache.org/jira/browse/SPARK">Issue Tracker</a>
+          </li>
+          <li><a class="dropdown-item" href="/powered-by.html">Powered By</a></li>
+          <li><a class="dropdown-item" href="/committers.html">Project Committers</a></li>
+          <li><a class="dropdown-item" href="/history.html">Project History</a></li>
+        </ul>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="developers" role="button" data-bs-toggle="dropdown"
+           aria-expanded="false">
+          Developers
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="developers">
+          <li><a class="dropdown-item" href="/developer-tools.html">Useful Developer Tools</a></li>
+          <li><a class="dropdown-item" href="/versioning-policy.html">Versioning Policy</a></li>
+          <li><a class="dropdown-item" href="/release-process.html">Release Process</a></li>
+          <li><a class="dropdown-item" href="/security.html">Security</a></li>
+        </ul>
+      </li>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="github" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+          GitHub
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="github">
+          <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>
+        </ul>
+      </li>
+    </ul>
+    <ul class="navbar-nav ml-auto">
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="apacheFoundation" role="button"
+           data-bs-toggle="dropdown" aria-expanded="false">
+          Apache Software Foundation
+        </a>
+        <ul class="dropdown-menu" aria-labelledby="apacheFoundation">
+          <li><a class="dropdown-item" href="https://www.apache.org/">Apache Homepage</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/licenses/">License</a></li>
+          <li><a class="dropdown-item"
+                 href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/security/">Security</a></li>
+          <li><a class="dropdown-item" href="https://www.apache.org/events/current-event">Event</a></li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</nav>
+
+<div class="container">
+  <div class="row mt-4">
+    <div class="col-12 col-md-9">
+      <h2>Spark Release 3.4.4</h2>
+
+
+<p>Spark 3.4.4 is the last maintenance release containing security and correctness fixes. This release is based on the branch-3.4 maintenance branch of Spark. We strongly recommend all 3.4 users to upgrade to this stable release.</p>
+
+<h3 id="notable-changes">Notable changes</h3>
+
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-43242">[SPARK-43242]</a>: Fix throw &#8216;Unexpected type of BlockId&#8217; in shuffle corruption diagnose</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45988">[SPARK-45988]</a>: Fix typehints to handle <code class="language-plaintext highlighter-rouge">list</code> GenericAlias in Python 3.11+</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46535">[SPARK-46535]</a>: Fix NPE when describe extended a column without col stats</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46957">[SPARK-46957]</a>: Decommission migrated shuffle files should be able to cleanup from executor</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-47129">[SPARK-47129]</a>: Make ResolveRelations cache connect plan properly</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-47172">[SPARK-47172]</a>: Add support for AES-GCM for RPC encryption</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-47828">[SPARK-47828]</a>: DataFrameWriterV2.overwrite fails with invalid plan</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-47895">[SPARK-47895]</a>: group by all should be idempotent</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-47897">[SPARK-47897]</a>: Fix ExpressionSet performance regression in scala 2.12</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-47927">[SPARK-47927]</a>: Fix nullability attribute in UDF decoder</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48016">[SPARK-48016]</a>: Fix a bug in try_divide function when with decimals</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48019">[SPARK-48019]</a>: Fix incorrect behavior in ColumnVector/ColumnarArray with dictionary and nulls</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48037">[SPARK-48037]</a>: Fix SortShuffleWriter lacks shuffle write related metrics resulting in potentially inaccurate data</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48081">[SPARK-48081]</a>: Fix ClassCastException in NTile.checkInputDataTypes() when argument is non-foldable or of wrong type</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48105">[SPARK-48105]</a>: Fix the race condition between state store unloading and snapshotting</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48128">[SPARK-48128]</a>: For BitwiseCount / bit_count expression, fix codegen syntax error for boolean type inputs</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48155">[SPARK-48155]</a>: AQEPropagateEmptyRelation for join should check if remain child is just BroadcastQueryStageExec</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48172">[SPARK-48172]</a>: Fix escaping issues in JDBCDialects</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48248">[SPARK-48248]</a>: Fix nested array to respect legacy conf of inferArrayTypeFromFirstElement</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48292">[SPARK-48292]</a>: Revert SPARK-39195 Spark OutputCommitCoordinator should abort stage when committed file not consistent with task status</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48484">[SPARK-48484]</a>: Fix: V2Write use the same TaskAttemptId for different task attempts</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48642">[SPARK-48642]</a>: False SparkOutOfMemoryError caused by killing task on spilling</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48710">[SPARK-48710]</a>: Limit NumPy version to supported range (&gt;=1.15,&lt;2)</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48759">[SPARK-48759]</a>: Add migration doc for CREATE TABLE AS SELECT behavior change behavior change since Spark 3.4</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48791">[SPARK-48791]</a>: Fix perf regression caused by the accumulators registration overhead using CopyOnWriteArrayList</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48930">[SPARK-48930]</a>: Redact <code class="language-plaintext highlighter-rouge">awsAccessKeyId</code> by including <code class="language-plaintext highlighter-rouge">accesskey</code> pattern</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48934">[SPARK-48934]</a>: Python datetime types converted incorrectly for setting timeout in applyInPandasWithState</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48965">[SPARK-48965]</a>: Use the correct schema in <code class="language-plaintext highlighter-rouge">Dataset#toJSON</code></li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-48991">[SPARK-48991]</a>: Move path initialization into try-catch block in FileStreamSink.hasMetadata</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49000">[SPARK-49000]</a>: Fix &#8220;select count(distinct 1) from t&#8221; where t is empty table by expanding RewriteDistinctAggregates</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49005">[SPARK-49005]</a>: Use <code class="language-plaintext highlighter-rouge">17-jammy</code> tag instead of <code class="language-plaintext highlighter-rouge">17-jre</code> to prevent Python 3.12</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49038">[SPARK-49038]</a>: SQLMetric should report the raw value in the accumulator update event</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49039">[SPARK-49039]</a>: Reset checkbox when executor metrics are loaded in the Stages tab</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49094">[SPARK-49094]</a>: Fix ignoreCorruptFiles non-functioning for hive orc impl with mergeSchema off</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49176">[SPARK-49176]</a>: Fix <code class="language-plaintext highlighter-rouge">spark.ui.custom.executor.log.url</code> docs by adding K8s</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49179">[SPARK-49179]</a>: Fix v2 multi bucketed inner joins throw AssertionError</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49182">[SPARK-49182]</a>: Stop publish site/docs/{version}/api/python/_sources dir</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49193">[SPARK-49193]</a>: Improve the performance of RowSetUtils.toColumnBasedSet</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49197">[SPARK-49197]</a>: Redact <code class="language-plaintext highlighter-rouge">Spark Command</code> output in <code class="language-plaintext highlighter-rouge">launcher</code> module</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49261">[SPARK-49261]</a>: Don&#8217;t replace literals in aggregate expressions with group-by expressions</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49352">[SPARK-49352]</a>: Avoid redundant array transform for identical expression</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49385">[SPARK-49385]</a>: Fix <code class="language-plaintext highlighter-rouge">getReusablePVCs</code> to use <code class="language-plaintext highlighter-rouge">podCreationTimeout</code> instead of <code class="language-plaintext highlighter-rouge">podAllocationDelay</code></li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49408">[SPARK-49408]</a>: Use IndexedSeq in ProjectingInternalRow</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49595">[SPARK-49595]</a>: Fix <code class="language-plaintext highlighter-rouge">DataFrame.unpivot/melt</code> in Spark Connect Scala Client</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49628">[SPARK-49628]</a>: ConstantFolding should copy stateful expression before evaluating</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49750">[SPARK-49750]</a>: Mention delegation token support in K8s mode</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49760">[SPARK-49760]</a>: Correct handling of <code class="language-plaintext highlighter-rouge">SPARK_USER</code> env variable override in app master</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49804">[SPARK-49804]</a>: Fix to use the exit code of executor container always</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49836">[SPARK-49836]</a>: Fix possibly broken query when window is provided to window/session_window fn</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49843">[SPARK-49843]</a>: Fix change comment on char/varchar columns</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49959">[SPARK-49959]</a>: Fix ColumnarArray.copy() to read nulls from the correct offset</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-50021">[SPARK-50021]</a>: Fix <code class="language-plaintext highlighter-rouge">ApplicationPage</code> to hide App UI links when UI is disabled</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-50022">[SPARK-50022]</a>: Fix <code class="language-plaintext highlighter-rouge">MasterPage</code> to hide App UI links when UI is disabled</li>
+</ul>
+
+<h3 id="dependency-changes">Dependency Changes</h3>
+
+<p>While being a maintenance release we did still upgrade some dependencies in this release they are:</p>
+
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-43394">[SPARK-43394]</a>: Upgrade maven to 3.8.8</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-45590">[SPARK-45590]</a>: Upgrade okio to 1.17.6 from 1.15.0</li>
+</ul>
+
+<p>You can consult JIRA for the <a href="https://s.apache.org/spark-3.4.4">detailed changes</a>.</p>
+
+<p>We would like to acknowledge all community members for contributing patches to this release.</p>
+
+
+
+<p>
+<br/>
+<a href="/news/">Spark News Archive</a>
+</p>
+
+    </div>
+    <div class="col-12 col-md-3">
+      <div class="news" style="margin-bottom: 20px;">
+        <h5>Latest News</h5>
+        <ul class="list-unstyled">
+          
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
+          <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
+            <span class="small">(Sep 26, 2024)</span></li>
+          
+          <li><a href="/news/spark-3-5-3-released.html">Spark 3.5.3 released</a>
+            <span class="small">(Sep 24, 2024)</span></li>
+          
+          <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
+            <span class="small">(Aug 10, 2024)</span></li>
+          
+        </ul>
+        <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>
+      </div>
+      <div style="text-align:center; margin-bottom: 20px;">
+        <a href="https://www.apache.org/events/current-event.html">
+          <img src="https://www.apache.org/events/current-event-234x60.png" style="max-width: 100%;"/>
+        </a>
+      </div>
+      <div class="hidden-xs hidden-sm">
+        <a href="/downloads.html" class="btn btn-cta btn-lg d-grid" style="margin-bottom: 30px;">
+          Download Spark
+        </a>
+        <p style="font-size: 16px; font-weight: 500; color: #555;">
+          Built-in Libraries:
+        </p>
+        <ul class="list-none">
+          <li><a href="/sql/">SQL and DataFrames</a></li>
+          <li><a href="/streaming/">Spark Streaming</a></li>
+          <li><a href="/mllib/">MLlib (machine learning)</a></li>
+          <li><a href="/graphx/">GraphX (graph)</a></li>
+        </ul>
+        <a href="/third-party-projects.html">Third-Party Projects</a>
+      </div>
+    </div>
+  </div>
+
+  
+
+  <footer class="small">
+    <hr>
+    Apache Spark, Spark, Apache, the Apache feather logo, and the Apache Spark project logo are either registered
+    trademarks or trademarks of The Apache Software Foundation in the United States and other countries.
+    See guidance on use of Apache Spark <a href="/trademarks.html">trademarks</a>.
+    All other marks mentioned may be trademarks or registered trademarks of their respective owners.
+    Copyright &copy; 2018 The Apache Software Foundation, Licensed under the
+    <a href="https://www.apache.org/licenses/">Apache License, Version 2.0</a>.
+  </footer>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+        crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery.js"></script>
+<script src="/js/lang-tabs.js"></script>
+<script src="/js/downloads.js"></script>
+</body>
+</html>

--- a/site/releases/spark-release-3-5-0.html
+++ b/site/releases/spark-release-3-5-0.html
@@ -549,6 +549,9 @@ Adam Binford, Ahmed Hussein, Alex Jing, Alice Sayutina, Alkis Evlogimenos, Allan
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -557,9 +560,6 @@ Adam Binford, Ahmed Hussein, Alex Jing, Alice Sayutina, Alkis Evlogimenos, Allan
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-5-1.html
+++ b/site/releases/spark-release-3-5-1.html
@@ -309,6 +309,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -317,9 +320,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-5-2.html
+++ b/site/releases/spark-release-3-5-2.html
@@ -316,6 +316,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -324,9 +327,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-5-3.html
+++ b/site/releases/spark-release-3-5-3.html
@@ -213,6 +213,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -221,9 +224,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/research.html
+++ b/site/research.html
@@ -218,6 +218,9 @@ Spark offers an abstraction called <a href="http://people.csail.mit.edu/matei/pa
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -226,9 +229,6 @@ Spark offers an abstraction called <a href="http://people.csail.mit.edu/matei/pa
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -180,6 +180,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -188,9 +191,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -180,6 +180,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -188,9 +191,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -176,6 +176,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -184,9 +187,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -202,6 +202,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -210,9 +213,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/security.html
+++ b/site/security.html
@@ -681,6 +681,9 @@ PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -689,9 +692,6 @@ PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -144,6 +144,14 @@
 </url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
+  <loc>https://spark.apache.org/releases/spark-release-3-4-4.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/news/spark-3-4-4-released.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/news/spark-4.0.0-preview2.html</loc>
   <changefreq>weekly</changefreq>
 </url>

--- a/site/spark-connect/index.html
+++ b/site/spark-connect/index.html
@@ -305,6 +305,9 @@ df.Show(100, false)
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -313,9 +316,6 @@ df.Show(100, false)
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -316,6 +316,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -324,9 +327,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -258,6 +258,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -266,9 +269,6 @@
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -268,6 +268,9 @@ transforming, and analyzing genomic data using Apache Spark</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -276,9 +279,6 @@ transforming, and analyzing genomic data using Apache Spark</li>
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -220,6 +220,9 @@ If you have any questions about the Apache trademark policy, please email
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -228,9 +231,6 @@ If you have any questions about the Apache trademark policy, please email
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -322,6 +322,9 @@ For example, 2.4.0 was released in November 2nd 2018 and had been maintained for
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-4-4-released.html">Spark 3.4.4 released</a>
+            <span class="small">(Oct 27, 2024)</span></li>
+          
           <li><a href="/news/spark-4.0.0-preview2.html">Preview release of Spark 4.0</a>
             <span class="small">(Sep 26, 2024)</span></li>
           
@@ -330,9 +333,6 @@ For example, 2.4.0 was released in November 2nd 2018 and had been maintained for
           
           <li><a href="/news/spark-3-5-2-released.html">Spark 3.5.2 released</a>
             <span class="small">(Aug 10, 2024)</span></li>
-          
-          <li><a href="/news/spark-4.0.0-preview1.html">Preview release of Spark 4.0</a>
-            <span class="small">(Jun 03, 2024)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>


### PR DESCRIPTION
Apache Spark 3.4.4 is ready like the following.
- https://downloads.apache.org/spark/spark-3.4.4/
- https://pypi.org/project/pyspark/3.4.4/
- https://repo1.maven.org/maven2/org/apache/spark/spark-core_2.12/3.4.4/
- https://repo1.maven.org/maven2/org/apache/spark/spark-core_2.13/3.4.4/
- https://hub.docker.com/r/apache/spark/tags?name=3.4.4

<img width="521" alt="Screenshot 2024-10-27 at 11 12 42" src="https://github.com/user-attachments/assets/c16d8e2a-9e21-451c-9f77-1d38da93b838">
<img width="332" alt="Screenshot 2024-10-27 at 11 12 25" src="https://github.com/user-attachments/assets/101ac12e-d99f-4d94-a5cf-fdd6fb86625a">
<img width="625" alt="Screenshot 2024-10-27 at 11 12 21" src="https://github.com/user-attachments/assets/52fc81b8-0502-409e-b714-beef54bb901b">
<img width="100%" alt="Screenshot 2024-10-27 at 11 13 08" src="https://github.com/user-attachments/assets/c57d1f15-3ac4-4fec-8ad6-ad4aae7ed6ac">
