### PR TITLE
Remove `AppVeyor` and `Scaleway`

### DIFF
--- a/developer-tools.md
+++ b/developer-tools.md
@@ -35,17 +35,6 @@ Apache Spark community uses various resources to maintain the community test cov
 - Daily JDBC Docker integration tests with Java 8 and Scala 2.13/SBT
 - Daily TPC-DS benchmark with scale factor 1 with Java 8 and Scala 2.12/SBT
 
-<h3 id="appveyor">AppVeyor</h3>
-
-[AppVeyor](https://ci.appveyor.com/project/ApacheSoftwareFoundation/spark) provides the following on Windows.
-- R unit tests with Java 17/Scala 2.13/SBT
-
-<h3 id="scaleway">Scaleway</h3>
-
-[Scaleway](https://www.scaleway.com) provides the following on MacOS and Apple Silicon.
-- [Java/Scala/Python/R unit tests with Java 17/Scala 2.12/SBT](https://apache-spark.s3.fr-par.scw.cloud/index.html)
-- K8s integration tests (TBD)
-
 <h2>Useful developer tools</h2>
 
 <h3 id="reducing-build-times">Reducing build times</h3>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -185,21 +185,6 @@
   <li>Daily TPC-DS benchmark with scale factor 1 with Java 8 and Scala 2.12/SBT</li>
 </ul>
 
-<h3 id="appveyor">AppVeyor</h3>
-
-<p><a href="https://ci.appveyor.com/project/ApacheSoftwareFoundation/spark">AppVeyor</a> provides the following on Windows.</p>
-<ul>
-  <li>R unit tests with Java 17/Scala 2.13/SBT</li>
-</ul>
-
-<h3 id="scaleway">Scaleway</h3>
-
-<p><a href="https://www.scaleway.com">Scaleway</a> provides the following on MacOS and Apple Silicon.</p>
-<ul>
-  <li><a href="https://apache-spark.s3.fr-par.scw.cloud/index.html">Java/Scala/Python/R unit tests with Java 17/Scala 2.12/SBT</a></li>
-  <li>K8s integration tests (TBD)</li>
-</ul>
-
 <h2>Useful developer tools</h2>
 
 <h3 id="reducing-build-times">Reducing build times</h3>


### PR DESCRIPTION
This PR aims to remove outdated `AppVeyor` and `Scaleway` information from Apache Spark website.

Apache Spark CI migrated from `AppVeyor` and `Sacleway` CI jobs into `GitHub Action` jobs since February 2024.
- https://github.com/apache/spark/pull/45175
- https://github.com/apache/spark/pull/45126

Please see the following GitHub Action CIs.
- https://github.com/apache/spark/actions/workflows/build_sparkr_window.yml
- https://github.com/apache/spark/actions/workflows/build_maven_java21_macos15.yml