### PR TITLE
match new implementation of the version dropdown menu

### DIFF
--- a/site/static/versions.json
+++ b/site/static/versions.json
@@ -12,66 +12,66 @@
     {
         "name": "3.5.2",
         "version": "3.5.2",
-        "url": "https://spark.apache.org/docs/3.5.2/api/python/"
+        "url": "https://archive.apache.org/dist/spark/docs/3.5.2/api/python/"
     },
     {
         "name": "3.5.1",
         "version": "3.5.1",
-        "url": "https://spark.apache.org/docs/3.5.1/api/python/"
+        "url": "https://archive.apache.org/dist/spark/docs/3.5.1/api/python/"
     },
     {
         "name": "3.5.0",
         "version": "3.5.0",
-        "url": "https://spark.apache.org/docs/3.5.0/api/python/"
+        "url": "https://archive.apache.org/dist/spark/docs/3.5.0/api/python/"
     },
     {
         "name": "3.4.4",
         "version": "3.4.4",
-        "url": "https://spark.apache.org/docs/3.4.4/api/python/"
+        "url": "https://archive.apache.org/dist/spark/docs/3.4.4/api/python/"
     },
     {
         "name": "3.4.3",
         "version": "3.4.3",
-        "url": "https://spark.apache.org/docs/3.4.3/api/python/"
+        "url": "https://archive.apache.org/dist/spark/docs/3.4.3/api/python/"
     },
     {
         "name": "3.4.2",
         "version": "3.4.2",
-        "url": "https://spark.apache.org/docs/3.4.2/api/python/"
+        "url": "https://archive.apache.org/dist/spark/docs/3.4.2/api/python/"
     },
     {
         "name": "3.4.1",
         "version": "3.4.1",
-        "url": "https://spark.apache.org/docs/3.4.1/api/python/"
+        "url": "https://archive.apache.org/dist/spark/docs/3.4.1/api/python/"
     },
     {
         "name": "3.4.0",
         "version": "3.4.0",
-        "url": "https://spark.apache.org/docs/3.4.0/api/python/"
+        "url": "https://archive.apache.org/dist/spark/docs/3.4.0/api/python/"
     },
     {
         "name": "3.3.4",
         "version": "3.3.4",
-        "url": "https://spark.apache.org/docs/3.3.4/api/python/"
+        "url": "https://archive.apache.org/dist/spark/docs/3.3.4/api/python/"
     },
     {
         "name": "3.3.3",
         "version": "3.3.3",
-        "url": "https://spark.apache.org/docs/3.3.3/api/python/"
+        "url": "https://archive.apache.org/dist/spark/docs/3.3.3/api/python/"
     },
     {
         "name": "3.3.2",
         "version": "3.3.2",
-        "url": "https://spark.apache.org/docs/3.3.2/api/python/"
+        "url": "https://archive.apache.org/dist/spark/docs/3.3.2/api/python/"
     },
     {
         "name": "3.3.1",
         "version": "3.3.1",
-        "url": "https://spark.apache.org/docs/3.3.1/api/python/"
+        "url": "https://archive.apache.org/dist/spark/docs/3.3.1/api/python/"
     },
     {
         "name": "3.3.0",
         "version": "3.3.0",
-        "url": "https://spark.apache.org/docs/3.3.0/api/python/"
+        "url": "https://archive.apache.org/dist/spark/docs/3.3.0/api/python/"
     }
 ]

--- a/site/static/versions.json
+++ b/site/static/versions.json
@@ -1,62 +1,77 @@
 [
     {
         "name": "3.5.4",
-        "version": "3.5.4"
+        "version": "3.5.4",
+        "url": "https://spark.apache.org/docs/3.5.4/api/python/"
     },
     {
         "name": "3.5.3",
-        "version": "3.5.3"
+        "version": "3.5.3",
+        "url": "https://spark.apache.org/docs/3.5.3/api/python/"
     },
     {
         "name": "3.5.2",
-        "version": "3.5.2"
+        "version": "3.5.2",
+        "url": "https://spark.apache.org/docs/3.5.2/api/python/"
     },
     {
         "name": "3.5.1",
-        "version": "3.5.1"
+        "version": "3.5.1",
+        "url": "https://spark.apache.org/docs/3.5.1/api/python/"
     },
     {
         "name": "3.5.0",
-        "version": "3.5.0"
+        "version": "3.5.0",
+        "url": "https://spark.apache.org/docs/3.5.0/api/python/"
     },
     {
         "name": "3.4.4",
-        "version": "3.4.4"
+        "version": "3.4.4",
+        "url": "https://spark.apache.org/docs/3.4.4/api/python/"
     },
     {
         "name": "3.4.3",
-        "version": "3.4.3"
+        "version": "3.4.3",
+        "url": "https://spark.apache.org/docs/3.4.3/api/python/"
     },
     {
         "name": "3.4.2",
-        "version": "3.4.2"
+        "version": "3.4.2",
+        "url": "https://spark.apache.org/docs/3.4.2/api/python/"
     },
     {
         "name": "3.4.1",
-        "version": "3.4.1"
+        "version": "3.4.1",
+        "url": "https://spark.apache.org/docs/3.4.1/api/python/"
     },
     {
         "name": "3.4.0",
-        "version": "3.4.0"
+        "version": "3.4.0",
+        "url": "https://spark.apache.org/docs/3.4.0/api/python/"
     },
     {
         "name": "3.3.4",
-        "version": "3.3.4"
+        "version": "3.3.4",
+        "url": "https://spark.apache.org/docs/3.3.4/api/python/"
     },
     {
         "name": "3.3.3",
-        "version": "3.3.3"
+        "version": "3.3.3",
+        "url": "https://spark.apache.org/docs/3.3.3/api/python/"
     },
     {
         "name": "3.3.2",
-        "version": "3.3.2"
+        "version": "3.3.2",
+        "url": "https://spark.apache.org/docs/3.3.2/api/python/"
     },
     {
         "name": "3.3.1",
-        "version": "3.3.1"
+        "version": "3.3.1",
+        "url": "https://spark.apache.org/docs/3.3.1/api/python/"
     },
     {
         "name": "3.3.0",
-        "version": "3.3.0"
+        "version": "3.3.0",
+        "url": "https://spark.apache.org/docs/3.3.0/api/python/"
     }
 ]


### PR DESCRIPTION
The pr aims to update `site/static/versions.json` to match new implementation of the version dropdown menu.
Please refer to the PR related to `Spark repo`: https://github.com/apache/spark/pull/47214
We need to update it.
Afterwards, both the old and new implementations can work normally.