### PR TITLE
Add an example for get_json_object when the JSON object is of JSON array type

### DIFF
--- a/site/docs/4.0.0-preview2/generated-json-funcs-examples.html
+++ b/site/docs/4.0.0-preview2/generated-json-funcs-examples.html
@@ -28,6 +28,13 @@
 <span class="o">|</span><span class="w">                              </span><span class="n">b</span><span class="o">|</span>
 <span class="o">+</span><span class="c1">-------------------------------+</span>
 
+<span class="k">SELECT</span><span class="w"> </span><span class="n">get_json_object</span><span class="p">(</span><span class="s1">&#39;[{&quot;a&quot;:&quot;b&quot;},{&quot;a&quot;:&quot;c&quot;}]&#39;</span><span class="p">,</span><span class="w"> </span><span class="s1">&#39;$[*].a&#39;</span><span class="p">);</span>
+<span class="o">+</span><span class="c1">----------------------------------------------+</span>
+<span class="o">|</span><span class="n">get_json_object</span><span class="p">(</span><span class="ss">[{&quot;a&quot;:&quot;b&quot;},{&quot;a&quot;:&quot;c&quot;}]</span><span class="p">,</span><span class="w"> </span><span class="err">$[*]</span><span class="p">.</span><span class="n">a</span><span class="p">)</span><span class="o">|</span>
+<span class="o">+</span><span class="c1">----------------------------------------------+</span>
+<span class="o">|</span><span class="w">                                     </span><span class="n">[&quot;b&quot;,&quot;c&quot;]</span><span class="o">|</span>
+<span class="o">+</span><span class="c1">----------------------------------------------+</span>
+
 <span class="c1">-- json_array_length</span>
 <span class="k">SELECT</span><span class="w"> </span><span class="n">json_array_length</span><span class="p">(</span><span class="s1">&#39;[1,2,3,4]&#39;</span><span class="p">);</span>
 <span class="o">+</span><span class="c1">----------------------------+</span>


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->
Most users are unaware of how to retrieve the corresponding JSON object using get_json_object when the JSON object is of a JSON array type. 
Before this PR,  the example:
```java
SELECT get_json_object('{"a":"b"}', '$.a');
+-------------------------------+
|get_json_object({"a":"b"}, $.a)|
+-------------------------------+
|                              b|
+-------------------------------+
``` 

After this PR, the example of get_json_object has been changed to look like this:
```java
SELECT get_json_object('{"a":"b"}', '$.a');
+-------------------------------+
|get_json_object({"a":"b"}, $.a)|
+-------------------------------+
|                              b|
+-------------------------------+

SELECT get_json_object('[{"a":"b"},{"a":"c"}]', '$[*].a');
+----------------------------------------------+
|get_json_object([{"a":"b"},{"a":"c"}], $[*].a)|
+----------------------------------------------+
|                                     ["b","c"]|
+----------------------------------------------+
``` 
