### PR TITLE
Make `committers.md` up-to-date

### DIFF
--- a/committers.md
+++ b/committers.md
@@ -13,7 +13,7 @@ navigation:
 |Sameer Agarwal|Deductive AI|
 |Michael Armbrust|Databricks|
 |Dilip Biswal|Adobe|
-|Ryan Blue|Tabular|
+|Ryan Blue|Databricks|
 |Joseph Bradley|Databricks|
 |Matthew Cheah|Palantir|
 |Felix Cheung|NVIDIA|
@@ -37,16 +37,16 @@ navigation:
 |Mark Hamstra|ClearStory Data|
 |Seth Hendrickson|Stripe|
 |Herman van Hovell|Databricks|
-|Liang-Chi Hsieh|Apple|
+|Liang-Chi Hsieh|Databricks|
 |Yin Huai|Databricks|
 |Shane Huang|Intel|
 |Dongjoon Hyun|Apple|
 |Kazuaki Ishizaki|IBM|
 |Xingbo Jiang|Databricks|
 |Yikun Jiang|Huawei|
-|Holden Karau|Netflix|
+|Holden Karau|Fight Health Insurance|
 |Shane Knapp|UC Berkeley|
-|Cody Koeninger|Nexstar Digital|
+|Cody Koeninger||
 |Andy Konwinski|Databricks|
 |Hyukjin Kwon|Databricks|
 |Ryan LeCompte|Quantifind|
@@ -74,7 +74,7 @@ navigation:
 |Imran Rashid|Cloudera|
 |Charles Reiss|University of Virginia|
 |Josh Rosen|Databricks|
-|Sandy Ryza|Dagster|
+|Sandy Ryza|Databricks|
 |Kousuke Saruta|NTT Data|
 |Saisai Shao|Datastrato|
 |Prashant Sharma|IBM|
@@ -84,7 +84,7 @@ navigation:
 |Maciej Szymkiewicz||
 |Jose Torres|Databricks|
 |Peter Toth|Cloudera|
-|DB Tsai|Apple|
+|DB Tsai|Databricks|
 |Takuya Ueshin|Databricks|
 |Marcelo Vanzin|Cloudera|
 |Shivaram Venkataraman|University of Wisconsin, Madison|

--- a/site/committers.html
+++ b/site/committers.html
@@ -176,7 +176,7 @@
     </tr>
     <tr>
       <td>Ryan Blue</td>
-      <td>Tabular</td>
+      <td>Databricks</td>
     </tr>
     <tr>
       <td>Joseph Bradley</td>
@@ -272,7 +272,7 @@
     </tr>
     <tr>
       <td>Liang-Chi Hsieh</td>
-      <td>Apple</td>
+      <td>Databricks</td>
     </tr>
     <tr>
       <td>Yin Huai</td>
@@ -300,7 +300,7 @@
     </tr>
     <tr>
       <td>Holden Karau</td>
-      <td>Netflix</td>
+      <td>Fight Health Insurance</td>
     </tr>
     <tr>
       <td>Shane Knapp</td>
@@ -308,7 +308,7 @@
     </tr>
     <tr>
       <td>Cody Koeninger</td>
-      <td>Nexstar Digital</td>
+      <td>&#160;</td>
     </tr>
     <tr>
       <td>Andy Konwinski</td>
@@ -420,7 +420,7 @@
     </tr>
     <tr>
       <td>Sandy Ryza</td>
-      <td>Dagster</td>
+      <td>Databricks</td>
     </tr>
     <tr>
       <td>Kousuke Saruta</td>
@@ -460,7 +460,7 @@
     </tr>
     <tr>
       <td>DB Tsai</td>
-      <td>Apple</td>
+      <td>Databricks</td>
     </tr>
     <tr>
       <td>Takuya Ueshin</td>


### PR DESCRIPTION
This PR aims to update `committers` page in line with Apache Spark 4.0.0 RC1 vote.
- https://spark.apache.org/committers.html

<img width="448" alt="Screenshot 2025-02-14 at 15 46 43" src="https://github.com/user-attachments/assets/89de5177-b97a-4436-a028-4a263421be74" />

<img width="461" alt="Screenshot 2025-02-14 at 15 46 53" src="https://github.com/user-attachments/assets/423c863e-3d5d-4683-97b4-9ed93389f682" />

<img width="453" alt="Screenshot 2025-02-14 at 15 47 01" src="https://github.com/user-attachments/assets/5b832703-b186-4b6a-9859-4b9767feab6f" />
