### PR TITLE
[SPARK-51470] Add `spark-connect-swift` repo to Apache Spark website `GitHub` page

### DIFF
--- a/_layouts/global.html
+++ b/_layouts/global.html
@@ -129,6 +129,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -134,6 +134,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/404.html
+++ b/site/404.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/committers.html
+++ b/site/committers.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/community.html
+++ b/site/community.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/error-message-guidelines.html
+++ b/site/error-message-guidelines.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/examples.html
+++ b/site/examples.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/faq.html
+++ b/site/faq.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -125,6 +125,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/history.html
+++ b/site/history.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/index.html
+++ b/site/index.html
@@ -130,6 +130,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -126,6 +126,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -125,6 +125,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/3-1-3-released.html
+++ b/site/news/3-1-3-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/new-repository-service.html
+++ b/site/news/new-repository-service.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/next-official-release-spark-3.1.1.html
+++ b/site/news/next-official-release-spark-3.1.1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/plan-for-dropping-python-2-support.html
+++ b/site/news/plan-for-dropping-python-2-support.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/sigmod-system-award.html
+++ b/site/news/sigmod-system-award.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-2-2-released.html
+++ b/site/news/spark-1-2-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-1-3-released.html
+++ b/site/news/spark-2-1-3-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-2-2-released.html
+++ b/site/news/spark-2-2-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-3-1-released.html
+++ b/site/news/spark-2-3-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-3-2-released.html
+++ b/site/news/spark-2-3-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-3-3-released.html
+++ b/site/news/spark-2-3-3-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-3-4-released.html
+++ b/site/news/spark-2-3-4-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-4-0-released.html
+++ b/site/news/spark-2-4-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-4-1-released.html
+++ b/site/news/spark-2-4-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-4-2-released.html
+++ b/site/news/spark-2-4-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-4-3-released.html
+++ b/site/news/spark-2-4-3-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-4-4-released.html
+++ b/site/news/spark-2-4-4-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-4-5-released.html
+++ b/site/news/spark-2-4-5-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-4-6.html
+++ b/site/news/spark-2-4-6.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-4-7-released.html
+++ b/site/news/spark-2-4-7-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2-4-8-released.html
+++ b/site/news/spark-2-4-8-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-0-0-released.html
+++ b/site/news/spark-3-0-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-0-1-released.html
+++ b/site/news/spark-3-0-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-0-2-released.html
+++ b/site/news/spark-3-0-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-0-3-released.html
+++ b/site/news/spark-3-0-3-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-1-1-released.html
+++ b/site/news/spark-3-1-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-1-2-released.html
+++ b/site/news/spark-3-1-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-2-0-released.html
+++ b/site/news/spark-3-2-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-2-1-released.html
+++ b/site/news/spark-3-2-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-2-2-released.html
+++ b/site/news/spark-3-2-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-2-3-released.html
+++ b/site/news/spark-3-2-3-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-2-4-released.html
+++ b/site/news/spark-3-2-4-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-3-0-released.html
+++ b/site/news/spark-3-3-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-3-1-released.html
+++ b/site/news/spark-3-3-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-3-2-released.html
+++ b/site/news/spark-3-3-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-3-3-released.html
+++ b/site/news/spark-3-3-3-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-3-4-released.html
+++ b/site/news/spark-3-3-4-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-4-0-released.html
+++ b/site/news/spark-3-4-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-4-1-released.html
+++ b/site/news/spark-3-4-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-4-2-released.html
+++ b/site/news/spark-3-4-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-4-3-released.html
+++ b/site/news/spark-3-4-3-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-4-4-released.html
+++ b/site/news/spark-3-4-4-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-5-0-released.html
+++ b/site/news/spark-3-5-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-5-1-released.html
+++ b/site/news/spark-3-5-1-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-5-2-released.html
+++ b/site/news/spark-3-5-2-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-5-3-released.html
+++ b/site/news/spark-3-5-3-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-5-4-released.html
+++ b/site/news/spark-3-5-4-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3-5-5-released.html
+++ b/site/news/spark-3-5-5-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3.0.0-preview.html
+++ b/site/news/spark-3.0.0-preview.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-3.0.0-preview2.html
+++ b/site/news/spark-3.0.0-preview2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-4.0.0-preview1.html
+++ b/site/news/spark-4.0.0-preview1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-4.0.0-preview2.html
+++ b/site/news/spark-4.0.0-preview2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-ai-summit-apr-2019-agenda-posted.html
+++ b/site/news/spark-ai-summit-apr-2019-agenda-posted.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-ai-summit-june-2020-agenda-posted.html
+++ b/site/news/spark-ai-summit-june-2020-agenda-posted.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-release-2-2-3.html
+++ b/site/news/spark-release-2-2-3.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-summit-east-agenda-posted-2015.html
+++ b/site/news/spark-summit-east-agenda-posted-2015.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-summit-east-agenda-posted-2016.html
+++ b/site/news/spark-summit-east-agenda-posted-2016.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-summit-oct-2018-agenda-posted.html
+++ b/site/news/spark-summit-oct-2018-agenda-posted.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/pandas-on-spark/index.html
+++ b/site/pandas-on-spark/index.html
@@ -125,6 +125,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-1-3.html
+++ b/site/releases/spark-release-2-1-3.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-2-2.html
+++ b/site/releases/spark-release-2-2-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-2-3.html
+++ b/site/releases/spark-release-2-2-3.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-3-1.html
+++ b/site/releases/spark-release-2-3-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-3-2.html
+++ b/site/releases/spark-release-2-3-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-3-3.html
+++ b/site/releases/spark-release-2-3-3.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-3-4.html
+++ b/site/releases/spark-release-2-3-4.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-4-0.html
+++ b/site/releases/spark-release-2-4-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-4-1.html
+++ b/site/releases/spark-release-2-4-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-4-2.html
+++ b/site/releases/spark-release-2-4-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-4-3.html
+++ b/site/releases/spark-release-2-4-3.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-4-4.html
+++ b/site/releases/spark-release-2-4-4.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-4-5.html
+++ b/site/releases/spark-release-2-4-5.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-4-6.html
+++ b/site/releases/spark-release-2-4-6.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-4-7.html
+++ b/site/releases/spark-release-2-4-7.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-2-4-8.html
+++ b/site/releases/spark-release-2-4-8.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-0-0.html
+++ b/site/releases/spark-release-3-0-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-0-1.html
+++ b/site/releases/spark-release-3-0-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-0-2.html
+++ b/site/releases/spark-release-3-0-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-0-3.html
+++ b/site/releases/spark-release-3-0-3.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-1-1.html
+++ b/site/releases/spark-release-3-1-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-1-2.html
+++ b/site/releases/spark-release-3-1-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-1-3.html
+++ b/site/releases/spark-release-3-1-3.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-2-0.html
+++ b/site/releases/spark-release-3-2-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-2-1.html
+++ b/site/releases/spark-release-3-2-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-2-2.html
+++ b/site/releases/spark-release-3-2-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-2-3.html
+++ b/site/releases/spark-release-3-2-3.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-2-4.html
+++ b/site/releases/spark-release-3-2-4.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-3-0.html
+++ b/site/releases/spark-release-3-3-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-3-1.html
+++ b/site/releases/spark-release-3-3-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-3-2.html
+++ b/site/releases/spark-release-3-3-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-3-3.html
+++ b/site/releases/spark-release-3-3-3.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-3-4.html
+++ b/site/releases/spark-release-3-3-4.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-4-0.html
+++ b/site/releases/spark-release-3-4-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-4-1.html
+++ b/site/releases/spark-release-3-4-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-4-2.html
+++ b/site/releases/spark-release-3-4-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-4-3.html
+++ b/site/releases/spark-release-3-4-3.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-4-4.html
+++ b/site/releases/spark-release-3-4-4.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-5-0.html
+++ b/site/releases/spark-release-3-5-0.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-5-1.html
+++ b/site/releases/spark-release-3-5-1.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-5-2.html
+++ b/site/releases/spark-release-3-5-2.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-5-3.html
+++ b/site/releases/spark-release-3-5-3.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-5-4.html
+++ b/site/releases/spark-release-3-5-4.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/releases/spark-release-3-5-5.html
+++ b/site/releases/spark-release-3-5-5.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/research.html
+++ b/site/research.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/security.html
+++ b/site/security.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/spark-connect/index.html
+++ b/site/spark-connect/index.html
@@ -125,6 +125,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -125,6 +125,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -125,6 +125,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -123,6 +123,7 @@
         <ul class="dropdown-menu" aria-labelledby="github">
           <li><a class="dropdown-item" href="https://github.com/apache/spark">spark</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-go">spark-connect-go</a></li>
+          <li><a class="dropdown-item" href="https://github.com/apache/spark-connect-swift">spark-connect-swift</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-docker">spark-docker</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-kubernetes-operator">spark-kubernetes-operator</a></li>
           <li><a class="dropdown-item" href="https://github.com/apache/spark-website">spark-website</a></li>


### PR DESCRIPTION
This PR aims to update the drop-down menu, `GitHub`, of `Apache Spark` website by adding a newly registered `spark-connect-swift` repository.

Newly updated page looks like the following.

![Screenshot 2025-03-11 at 06 59 32](https://github.com/user-attachments/assets/d304a06d-7907-44ea-9088-708d9a102db4)
