### PR TITLE
Update API-related documentation in Versioning Policy

### DIFF
--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -187,11 +187,8 @@ try to. Once they are marked &#8220;stable&#8221; they have to follow these guid
 
 <h3>API compatibility</h3>
 
-<p>In general, An API is any public class or interface documented in Spark.
-Rrelease A is API compatible with release B if code compiled against release
-A <em>compiles cleanly</em> against B. Currently, does not guarantee that a compiled application that is
-linked against version A will link cleanly against version B without re-compiling. Link-level 
-compatibility is something we&#8217;ll try to guarantee in future releases.</p>
+<p>In general, An API is any public class or interface documented in Spark, e.g., <a href="https://spark.apache.org/docs/latest/api/scala/org/apache/spark/index.html">ScalaDoc</a>.
+We try to guarantee both source compatibility and binary compatibility between releases.</p>
 
 <p>Note, however, that even for features &#8220;developer API&#8221; and &#8220;experimental&#8221;, we strive to maintain 
 maximum compatibility. Code should not be merged into the project as &#8220;experimental&#8221; if there is 

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -187,11 +187,8 @@ try to. Once they are marked &#8220;stable&#8221; they have to follow these guid
 
 <h3>API compatibility</h3>
 
-<p>An API is any public class or interface documented in Spark, see also
-<a href="https://github.com/apache/spark/tree/master/common/tags/src/main/java/org/apache/spark/annotation">AP
-I annotations</a>
-for more details.
-In general, release A is API compatible with release B if code compiled against release
+<p>In general, An API is any public class or interface documented in Spark.
+Rrelease A is API compatible with release B if code compiled against release
 A <em>compiles cleanly</em> against B. Currently, does not guarantee that a compiled application that is
 linked against version A will link cleanly against version B without re-compiling. Link-level 
 compatibility is something we&#8217;ll try to guarantee in future releases.</p>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -187,9 +187,12 @@ try to. Once they are marked &#8220;stable&#8221; they have to follow these guid
 
 <h3>API compatibility</h3>
 
-<p>An API is any public class or interface exposed in Spark that is not marked as &#8220;developer API&#8221; or 
-&#8220;experimental&#8221;. Release A is API compatible with release B if code compiled against release A 
-<em>compiles cleanly</em> against B. Currently, does not guarantee that a compiled application that is 
+<p>An API is any public class or interface documented in Spark, see also
+<a href="https://github.com/apache/spark/tree/master/common/tags/src/main/java/org/apache/spark/annotation">AP
+I annotations</a>
+for more details.
+In general, release A is API compatible with release B if code compiled against release
+A <em>compiles cleanly</em> against B. Currently, does not guarantee that a compiled application that is
 linked against version A will link cleanly against version B without re-compiling. Link-level 
 compatibility is something we&#8217;ll try to guarantee in future releases.</p>
 

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -39,14 +39,11 @@ try to. Once they are marked "stable" they have to follow these guidelines.
 
 <h3>API compatibility</h3>
 
-An API is any public class or interface documented in Spark, see also
-<a href="https://github.com/apache/spark/tree/master/common/tags/src/main/java/org/apache/spark/annotation">AP
-I annotations</a>
-for more details.
-In general, release A is API compatible with release B if code compiled against release
+In general, An API is any public class or interface documented in Spark.
+Rrelease A is API compatible with release B if code compiled against release
 A _compiles cleanly_ against B. Currently, does not guarantee that a compiled application that is
 linked against version A will link cleanly against version B without re-compiling. Link-level 
-compatibility is something we'll try to guarantee in future releases. 
+compatibility is something we'll try to guarantee in future releases.
 
 Note, however, that even for features "developer API" and "experimental", we strive to maintain 
 maximum compatibility. Code should not be merged into the project as "experimental" if there is 

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -39,11 +39,8 @@ try to. Once they are marked "stable" they have to follow these guidelines.
 
 <h3>API compatibility</h3>
 
-In general, An API is any public class or interface documented in Spark.
-Rrelease A is API compatible with release B if code compiled against release
-A _compiles cleanly_ against B. Currently, does not guarantee that a compiled application that is
-linked against version A will link cleanly against version B without re-compiling. Link-level 
-compatibility is something we'll try to guarantee in future releases.
+In general, An API is any public class or interface documented in Spark, e.g., <a href="https://spark.apache.org/docs/latest/api/scala/org/apache/spark/index.html">ScalaDoc</a>.
+We try to guarantee both source compatibility and binary compatibility between releases.
 
 Note, however, that even for features "developer API" and "experimental", we strive to maintain 
 maximum compatibility. Code should not be merged into the project as "experimental" if there is 

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -39,9 +39,12 @@ try to. Once they are marked "stable" they have to follow these guidelines.
 
 <h3>API compatibility</h3>
 
-An API is any public class or interface exposed in Spark that is not marked as "developer API" or 
-"experimental". Release A is API compatible with release B if code compiled against release A 
-_compiles cleanly_ against B. Currently, does not guarantee that a compiled application that is 
+An API is any public class or interface documented in Spark, see also
+<a href="https://github.com/apache/spark/tree/master/common/tags/src/main/java/org/apache/spark/annotation">AP
+I annotations</a>
+for more details.
+In general, release A is API compatible with release B if code compiled against release
+A _compiles cleanly_ against B. Currently, does not guarantee that a compiled application that is
 linked against version A will link cleanly against version B without re-compiling. Link-level 
 compatibility is something we'll try to guarantee in future releases. 
 


### PR DESCRIPTION
This PR updates API-related documentation in Versioning Policy. It is an API when it is documented - we intentionally do not document some.