### PR TITLE
add spark-connector-oceanbase to third-party connectors

### DIFF
--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -185,6 +185,7 @@
   <li><a href="https://github.com/StarRocks/starrocks-connector-for-apache-spark">starrocks-connector-for-apache-spark</a> - StarRocks Apache Spark connector</li>
   <li><a href="https://github.com/pingcap/tispark">tispark</a> - TiSpark is built for running Apache Spark on top of TiDB/TiKV</li>
   <li><a href="https://stabrise.com/spark-pdf/">spark-pdf</a> - PDF Datasource for Apache Spark</li>
+  <li><a href="https://github.com/oceanbase/spark-connector-oceanbase">spark-connector-oceanbase</a> - Apache Spark Connectors for OceanBase</li>
 </ul>
 
 <h2 id="open-table-formats">Open table formats</h2>

--- a/third-party-projects.md
+++ b/third-party-projects.md
@@ -36,6 +36,7 @@ This page tracks external software projects that supplement Apache Spark and add
 - [starrocks-connector-for-apache-spark](https://github.com/StarRocks/starrocks-connector-for-apache-spark) - StarRocks Apache Spark connector
 - [tispark](https://github.com/pingcap/tispark) - TiSpark is built for running Apache Spark on top of TiDB/TiKV
 - [spark-pdf](https://stabrise.com/spark-pdf/) - PDF Datasource for Apache Spark
+- [spark-connector-oceanbase](https://github.com/oceanbase/spark-connector-oceanbase) - Apache Spark Connectors for OceanBase
 
 
 ## Open table formats


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->

Add [spark-connector-oceanbase](https://github.com/oceanbase/spark-connector-oceanbase) to third-party connectors.
