### PR TITLE
fix site build failure

### DIFF
--- a/.github/workflows/doc_gen.yml
+++ b/.github/workflows/doc_gen.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   lint:
     name: check whether all documentation was generated with the right Jekyll version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: dongjoon/apache-spark-github-action-image:20201025
     steps:

--- a/site/news/spark-3-5-5-released.html
+++ b/site/news/spark-3-5-5-released.html
@@ -142,7 +142,6 @@
           <li><a class="dropdown-item"
                  href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
           <li><a class="dropdown-item" href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
-          <li><a class="dropdown-item" href="https://www.apache.org/security/">Security</a></li>
           <li><a class="dropdown-item" href="https://www.apache.org/events/current-event">Event</a></li>
         </ul>
       </li>

--- a/site/releases/spark-release-3-5-5.html
+++ b/site/releases/spark-release-3-5-5.html
@@ -142,7 +142,6 @@
           <li><a class="dropdown-item"
                  href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
           <li><a class="dropdown-item" href="https://www.apache.org/foundation/thanks.html">Thanks</a></li>
-          <li><a class="dropdown-item" href="https://www.apache.org/security/">Security</a></li>
           <li><a class="dropdown-item" href="https://www.apache.org/events/current-event">Event</a></li>
         </ul>
       </li>


### PR DESCRIPTION
caused by https://github.com/apache/spark-website/pull/593 and https://github.com/apache/spark-website/pull/590 getting merged in parallel

<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->
