### PR TITLE
Fix CSP Violation Issues

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,1 +1,4 @@
 ErrorDocument 404 /404.html
+<IfModule mod_headers.c>
+  Header set Content-Security-Policy "default-src 'self'; connect-src 'self' https://*.algolia.net https://*.algolianet.com https://*.algolia.io; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;"
+</IfModule>

--- a/site/.htaccess
+++ b/site/.htaccess
@@ -1,1 +1,4 @@
 ErrorDocument 404 /404.html
+<IfModule mod_headers.c>
+  Header set Content-Security-Policy "default-src 'self'; connect-src 'self' https://*.algolia.net https://*.algolianet.com https://*.algolia.io; script-src 'self' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;"
+</IfModule>


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->
We are still accounting a Content Security Policy (CSP) violation error while accessing the latest Apache Spark documentation at: https://spark.apache.org/docs/latest/ . And currently the doc search feature is broken.

<img width="549" alt="image" src="https://github.com/user-attachments/assets/80f26994-da63-4d45-ae9b-50b613b368f5" />

This PR tries to fix the CSP issues by modifying the `.htaccess` file. The fix is similar to https://github.com/apache/camel-website/blob/main/static/.htaccess#L1384 which also uses algolia as the search service.
