### PR TITLE
Remove Spark 3.4.4 release from download dropdown list

### DIFF
--- a/js/downloads.js
+++ b/js/downloads.js
@@ -25,7 +25,6 @@ var packagesV15 = [hadoop34p, hadoop34pSparkConnect, hadoopFree, sources];
 
 addRelease("4.0.0", new Date("05/23/2025"), packagesV15, true);
 addRelease("3.5.6", new Date("05/29/2025"), packagesV14, true);
-addRelease("3.4.4", new Date("10/27/2024"), packagesV14, true);
 
 function append(el, contents) {
   el.innerHTML += contents;

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -25,7 +25,6 @@ var packagesV15 = [hadoop34p, hadoop34pSparkConnect, hadoopFree, sources];
 
 addRelease("4.0.0", new Date("05/23/2025"), packagesV15, true);
 addRelease("3.5.6", new Date("05/29/2025"), packagesV14, true);
-addRelease("3.4.4", new Date("10/27/2024"), packagesV14, true);
 
 function append(el, contents) {
   el.innerHTML += contents;


### PR DESCRIPTION
Apache Spark 3.4.4 was the EOL release on last year (10/27/2024).
We had better lead the users toward Spark 4.x and 3.5 (LTS).