### PR TITLE
Remove duplicated files

### DIFF
--- a/site/docs/3.5.6/api/R/reference/groupedData.html
+++ b/site/docs/3.5.6/api/R/reference/groupedData.html
@@ -1,8 +1,0 @@
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0;URL=https://spark.apache.org/docs/3.5.6/api/R/reference/GroupedData.html" />
-    <meta name="robots" content="noindex">
-    <link rel="canonical" href="https://spark.apache.org/docs/3.5.6/api/R/reference/GroupedData.html">
-  </head>
-</html>
-

--- a/site/docs/3.5.6/api/R/reference/isnan.html
+++ b/site/docs/3.5.6/api/R/reference/isnan.html
@@ -1,8 +1,0 @@
-<html>
-  <head>
-    <meta http-equiv="refresh" content="0;URL=https://spark.apache.org/docs/3.5.6/api/R/reference/column_nonaggregate_functions.html" />
-    <meta name="robots" content="noindex">
-    <link rel="canonical" href="https://spark.apache.org/docs/3.5.6/api/R/reference/column_nonaggregate_functions.html">
-  </head>
-</html>
-


### PR DESCRIPTION
Currently, there are two duplicated files which causes misleading errors on MacOS.

<img width="634" height="76" alt="Screenshot 2025-09-08 at 09 30 53" src="https://github.com/user-attachments/assets/19ea7591-885b-4743-b0ef-0ff7c910851b" />

<img width="626" height="68" alt="Screenshot 2025-09-08 at 09 31 21" src="https://github.com/user-attachments/assets/1cabca0c-c7a6-4727-9568-943dde4099ab" />
