### PR TITLE
Make versioning-policy up-to-date with Spark 4.1.0

### DIFF
--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -277,7 +277,7 @@ available APIs.</p>
 Hence, Spark 2.3.0 would generally be released about 6 months after 2.2.0. Maintenance releases happen as needed
 in between feature releases. Major releases do not happen according to a fixed schedule.</p>
 
-<h3>Spark 4.0 release window</h3>
+<h3>Spark 4.1 release window</h3>
 
 <table>
   <thead>
@@ -288,15 +288,15 @@ in between feature releases. Major releases do not happen according to a fixed s
   </thead>
   <tbody>
     <tr>
-      <td>January 15th 2025</td>
+      <td>November 1st 2025</td>
       <td>Code freeze. Release branch cut.</td>
     </tr>
     <tr>
-      <td>February 1st 2025</td>
+      <td>November 15th 2025</td>
       <td>QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.</td>
     </tr>
     <tr>
-      <td>February 15th 2025</td>
+      <td>November 23th 2025</td>
       <td>Release candidates (RC), voting, etc. until final release passes</td>
     </tr>
   </tbody>

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -100,13 +100,13 @@ The branch is cut every January and July, so feature ("minor") releases occur ab
 Hence, Spark 2.3.0 would generally be released about 6 months after 2.2.0. Maintenance releases happen as needed
 in between feature releases. Major releases do not happen according to a fixed schedule.
 
-<h3>Spark 4.0 release window</h3>
+<h3>Spark 4.1 release window</h3>
 
 | Date  | Event |
 | ----- | ----- |
-| January 15th 2025 | Code freeze. Release branch cut.|
-| February 1st 2025 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
-| February 15th 2025 | Release candidates (RC), voting, etc. until final release passes|
+| November 1st 2025 | Code freeze. Release branch cut.|
+| November 15th 2025 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
+| November 23th 2025 | Release candidates (RC), voting, etc. until final release passes|
 
 <h2>Maintenance releases and EOL</h2>
 


### PR DESCRIPTION
Apache Spark Versioning Policy page is outdated.

Since Apache Spark 4.0.0 was announced on May 23, 2025, 4.1.0 is expected after 6 months from that. It means November 23, 2025.

This PR aims to make it up-to-date with Spark 4.1.0 schedule.