### PR TITLE
Update `Gemfile` to allow Ruby 3.0+ explicitly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+ruby ">= 3.0.0"
 source "https://rubygems.org"
 
 gem "jekyll", "4.4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,5 +73,8 @@ DEPENDENCIES
   rouge (= 3.26.0)
   webrick (~> 1.8.2)
 
+RUBY VERSION
+   ruby 3.2.3p157
+
 BUNDLED WITH
    2.4.19

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 In this directory you will find text files formatted using Markdown, with an `.md` suffix.
 
-Building the site requires [Jekyll](http://jekyllrb.com/docs)
+Building the site requires [Ruby 3](https://www.ruby-lang.org), [Jekyll](http://jekyllrb.com/docs), and
 [Rouge](https://github.com/rouge-ruby/rouge).
 The easiest way to install the right version of these tools is using
 [Bundler](https://bundler.io/) and running `bundle install` in this directory.


### PR DESCRIPTION
We had better match `spark-website` with Apache Spark main repository.

- https://github.com/apache/spark/pull/52258

Since #610 , `spark-website` repository CI has been using only `Ruby 3` via `Ubuntu 24.04` CI too.
- https://github.com/apache/spark-website/pull/610

```
$ docker run -it --rm ubuntu:24.04 bash
root@80f44c120f0f:/# apt-get update -y

root@80f44c120f0f:/# ruby --version
ruby 3.2.3 (2024-01-18 revision 52bb2ac0a6) [aarch64-linux-gnu]
```

Ruby 3.1 and below have been in the EOL status technically. So, it's not a surprise when one of our Ruby dependencies drops Ruby 3.1 and older support completely at any point of time.

https://www.ruby-lang.org/en/downloads/branches/

```
Ruby 3.1
status: eol
release date: 2021-12-25
normal maintenance until: 2024-04-01
EOL: 2025-03-26
```