### PR TITLE
Update `GraphX` menu according to the deprecation

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -76,7 +76,7 @@
           <li><a class="dropdown-item" href="{{site.baseurl}}/streaming/">Spark Streaming</a></li>
           <li><a class="dropdown-item" href="{{site.baseurl}}/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="{{site.baseurl}}/mllib/">MLlib (machine learning)</a></li>
-          <li><a class="dropdown-item" href="{{site.baseurl}}/graphx/">GraphX (graph)</a></li>
+          <li><a class="dropdown-item" href="{{site.baseurl}}/graphx/">GraphX (deprecated)</a></li>
           <li>
             <hr class="dropdown-divider">
           </li>

--- a/site/index.html
+++ b/site/index.html
@@ -72,7 +72,7 @@
           <li><a class="dropdown-item" href="/streaming/">Spark Streaming</a></li>
           <li><a class="dropdown-item" href="/pandas-on-spark/">pandas on Spark</a></li>
           <li><a class="dropdown-item" href="/mllib/">MLlib (machine learning)</a></li>
-          <li><a class="dropdown-item" href="/graphx/">GraphX (graph)</a></li>
+          <li><a class="dropdown-item" href="/graphx/">GraphX (deprecated)</a></li>
           <li>
             <hr class="dropdown-divider">
           </li>


### PR DESCRIPTION
This PR aims to update `GraphX` menu to be clear and consistent with [the previous vote result on dev@spark mailing list](https://lists.apache.org/thread/2nd08qpr8nwbtog5bgnpfgkn1r42cd5m) .

**AFTER**
<img width="251" height="272" alt="Screenshot 2025-09-09 at 09 33 52" src="https://github.com/user-attachments/assets/6ecfc08e-ee0d-4a8e-87af-7f077c314e7c" />
