### PR TITLE
Update `.asf.yaml` with new `README.md` link

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# See https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features
+# See https://github.com/apache/infrastructure-asfyaml/blob/main/README.md
 
 staging:
   profile: ~


### PR DESCRIPTION
This PR aims to update `.asf.yaml` with new `README.md` link.

ASF Infra team archived the old page in favor of GitHub README.md.

> The authoritative version of this material is now at https://github.com/apache/infrastructure-asfyaml/blob/main/README.md, and this page is ARCHIVED. This means that improvements to the README page may not show up immediately on this page.