### PR TITLE
[DOC] Add ts-spark-connector to Spark Connect index and third-party projects

### DIFF
--- a/site/spark-connect/index.html
+++ b/site/spark-connect/index.html
@@ -250,6 +250,7 @@ GlobalLimit 5
   <li><a href="https://github.com/apache/spark-connect-rust">Spark Connect Rust</a></li>
   <li><a href="https://github.com/apache/spark-connect-swift">Spark Connect Swift</a></li>
   <li><a href="https://github.com/GoEddie/spark-connect-dotnet">Spark Connect .NET</a> (third-party project)</li>
+  <li><a href="https://github.com/BaldrVivaldelli/ts-spark-connector">Spark Connect Typescript</a> (third-party project)</li>
 </ul>
 
 <p>For example, the Apache Spark Connect Client for Golang, <a href="https://github.com/apache/spark-connect-go">spark-connect-go</a>, implements the Spark Connect protocol and does not rely on Java.  You can use this Spark Connect Client to develop Spark applications with Go without installing Java or Spark.</p>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -263,6 +263,13 @@ transforming, and analyzing genomic data using Apache Spark</li>
   <li><a href="https://github.com/JetBrains/kotlin-spark-api">Kotlin for Apache Spark</a></li>
 </ul>
 
+
+<h3>Typescript</h3>
+<ul>
+  <li><a href="https://github.com/BaldrVivaldelli/ts-spark-connector">TS spark connector</a> - TypeScript client for Spark .</li>
+</ul>
+
+
 <h2 id="adding-new-projects">Adding new projects</h2>
 
 <p>To add a project, open a pull request against the <a href="https://github.com/apache/spark-website">spark-website</a>  repository. Add an entry to  <a href="https://github.com/apache/spark-website/blob/asf-site/third-party-projects.md">this markdown file</a>,  then run <code class="language-plaintext highlighter-rouge">jekyll build</code> to generate the HTML too. Include both in your pull request. See the README in this repo for more information.</p>


### PR DESCRIPTION
- Added ts-spark-connector to spark-connect/index.md to highlight it as a TypeScript client implementation
- Included ts-spark-connector in third-party-projects.md under client libraries
- add html files
