### PR TITLE
Update `rexml` to version 3.4.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.4.1)
+    rexml (3.4.4)
     rouge (3.26.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)
@@ -77,4 +77,4 @@ RUBY VERSION
    ruby 3.2.3p157
 
 BUNDLED WITH
-   2.4.19
+   2.6.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,4 +77,4 @@ RUBY VERSION
    ruby 3.2.3p157
 
 BUNDLED WITH
-   2.6.3
+   2.4.19

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1125,7 +1125,7 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/mllib/</loc>
+  <loc>https://spark.apache.org/spark-connect/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
@@ -1133,11 +1133,11 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/spark-connect/</loc>
+  <loc>https://spark.apache.org/graphx/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/sql/</loc>
+  <loc>https://spark.apache.org/mllib/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
@@ -1145,15 +1145,15 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
+  <loc>https://spark.apache.org/news/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/screencasts/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/graphx/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
-  <loc>https://spark.apache.org/news/</loc>
+  <loc>https://spark.apache.org/sql/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1125,7 +1125,7 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/spark-connect/</loc>
+  <loc>https://spark.apache.org/mllib/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
@@ -1133,11 +1133,11 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/graphx/</loc>
+  <loc>https://spark.apache.org/spark-connect/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/mllib/</loc>
+  <loc>https://spark.apache.org/sql/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
@@ -1145,15 +1145,15 @@
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/news/</loc>
-  <changefreq>weekly</changefreq>
-</url>
-<url>
   <loc>https://spark.apache.org/screencasts/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>
-  <loc>https://spark.apache.org/sql/</loc>
+  <loc>https://spark.apache.org/graphx/</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/news/</loc>
   <changefreq>weekly</changefreq>
 </url>
 <url>


### PR DESCRIPTION

```
~/github/spark-website$ bundle update rexml
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
Resolving dependencies...
Using rexml 3.4.4 (was 3.4.1)
Installing sassc 2.4.0 with native extensions
Fetching jekyll-sass-converter 2.2.0
Installing jekyll-sass-converter 2.2.0
Fetching jekyll 4.4.1
Installing jekyll 4.4.1
Bundle updated!
bjorn@128:~/github/spark-website$ bundle exec jekyll build
/home/bjorn/github/spark-website/.local_ruby_bundle/ruby/3.3.0/gems/liquid-4.0.4/lib/liquid.rb:72: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add bigdecimal to your Gemfile or gemspec to silence this warning.
Configuration file: /home/bjorn/github/spark-website/_config.yml
            Source: /home/bjorn/github/spark-website
       Destination: /home/bjorn/github/spark-website/site
 Incremental build: disabled. Enable with --incremental
      Generating... 
                    done in 1.388 seconds.
 Auto-regeneration: disabled. Use --watch to enable.
```

I get this now 

<img width="1341" height="774" alt="image" src="https://github.com/user-attachments/assets/f08e116f-bb52-4b24-bfe2-ae04fe432f31" />



