### PR TITLE
Fix TOC of release process documentation

### DIFF
--- a/release-process.md
+++ b/release-process.md
@@ -31,13 +31,19 @@ The release manager role in Spark means you are responsible for a few different 
   - [Upload to PyPI](#upload-to-pypi)
   - [Remove RC artifacts from repositories](#remove-rc-artifacts-from-repositories)
   - [Remove old releases from Mirror Network](#remove-old-releases-from-mirror-network)
-  - [Update the Apache Spark<sup>TM</sup> repository](#update-the-apache-spark-repository)
+  - [Update the Apache Spark repository](#update-the-apache-spark-repository)
   - [Update the configuration of Algolia Crawler](#update-the-configuration-of-algolia-crawler)
   - [Update the Spark website](#update-the-spark-website)
     - [Upload generated docs](#upload-generated-docs)
     - [Update the rest of the Spark website](#update-the-rest-of-the-spark-website)
   - [Create and upload Spark Docker Images](#create-and-upload-spark-docker-images)
   - [Create an announcement](#create-an-announcement)
+- [Preparing Spark Releases with GitHub Actions](#preparing-spark-releases-with-github-actions)
+  - [Preparing your GitHub Actions setup](#preparing-your-github-actions-setup)
+  - [Creating release candidates](#create-release-candidates)
+    - [If the workflow fails ...](#if-workflow-fails)
+  - [Publishing the release](#publishing-release)
+    - [If the workflow fails ...](#if-publishing-workflow-fails)
 
 <h2 id="preparing-your-setup">Preparing your setup</h2>
 
@@ -449,7 +455,7 @@ Enjoy an adult beverage of your choice, and congratulations on making a Spark re
 <p align="right"><a href="#top">Return to top</a></p>
 
 
-<h1>Preparing Spark Releases with GitHub Actions</h1>
+<h1 id="preparing-spark-releases-with-github-actions">Preparing Spark Releases with GitHub Actions</h1>
 
 Apache Spark provides a [GitHub Actions workflow](https://github.com/apache/spark/blob/master/.github/workflows/release.yml) for creating official Spark releases. Only Apache Spark PMC members can run this workflow in **their forked repositories**.
 
@@ -514,6 +520,6 @@ cleaned up, follow these steps:
   - [Create an announcement](#create-an-announcement)
 
 
-<h3 id="if-workflow-fails">If the workflow fails ...</h3>
+<h3 id="if-publishing-workflow-fails">If the workflow fails ...</h3>
 
 If the workflow fails here, you will need to manually debug the release script, [`dev/create-release/release-build.sh`](https://github.com/apache/spark/blob/master/dev/create-release/release-build.sh) and then run the remaining commands yourself after the failure.

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -190,7 +190,7 @@
       <li><a href="#upload-to-pypi">Upload to PyPI</a></li>
       <li><a href="#remove-rc-artifacts-from-repositories">Remove RC artifacts from repositories</a></li>
       <li><a href="#remove-old-releases-from-mirror-network">Remove old releases from Mirror Network</a></li>
-      <li><a href="#update-the-apache-spark-repository">Update the Apache Spark<sup>TM</sup> repository</a></li>
+      <li><a href="#update-the-apache-spark-repository">Update the Apache Spark repository</a></li>
       <li><a href="#update-the-configuration-of-algolia-crawler">Update the configuration of Algolia Crawler</a></li>
       <li><a href="#update-the-spark-website">Update the Spark website</a>
         <ul>
@@ -200,6 +200,21 @@
       </li>
       <li><a href="#create-and-upload-spark-docker-images">Create and upload Spark Docker Images</a></li>
       <li><a href="#create-an-announcement">Create an announcement</a></li>
+    </ul>
+  </li>
+  <li><a href="#preparing-spark-releases-with-github-actions">Preparing Spark Releases with GitHub Actions</a>
+    <ul>
+      <li><a href="#preparing-your-github-actions-setup">Preparing your GitHub Actions setup</a></li>
+      <li><a href="#create-release-candidates">Creating release candidates</a>
+        <ul>
+          <li><a href="#if-workflow-fails">If the workflow fails &#8230;</a></li>
+        </ul>
+      </li>
+      <li><a href="#publishing-release">Publishing the release</a>
+        <ul>
+          <li><a href="#if-publishing-workflow-fails">If the workflow fails &#8230;</a></li>
+        </ul>
+      </li>
     </ul>
   </li>
 </ul>
@@ -599,7 +614,7 @@ and then send an e-mail to the mailing list with a subject that looks something 
 
 <p align="right"><a href="#top">Return to top</a></p>
 
-<h1>Preparing Spark Releases with GitHub Actions</h1>
+<h1 id="preparing-spark-releases-with-github-actions">Preparing Spark Releases with GitHub Actions</h1>
 
 <p>Apache Spark provides a <a href="https://github.com/apache/spark/blob/master/.github/workflows/release.yml">GitHub Actions workflow</a> for creating official Spark releases. Only Apache Spark PMC members can run this workflow in <strong>their forked repositories</strong>.</p>
 
@@ -694,7 +709,7 @@ This includes <a href="#finalize-the-release">Finalizing the release</a> with ad
   </li>
 </ul>
 
-<h3 id="if-workflow-fails">If the workflow fails ...</h3>
+<h3 id="if-publishing-workflow-fails">If the workflow fails ...</h3>
 
 <p>If the workflow fails here, you will need to manually debug the release script, <a href="https://github.com/apache/spark/blob/master/dev/create-release/release-build.sh"><code class="language-plaintext highlighter-rouge">dev/create-release/release-build.sh</code></a> and then run the remaining commands yourself after the failure.</p>
 


### PR DESCRIPTION
This PR updates TOC of `release-process.md` and removes trademark symbol as it seems inconsistent with other pars of the document.

This PR was generated with `claude-sonnet-4` and was reviewed manually.

