### PR TITLE
Add Spark 3.5.7 release notes

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -14,6 +14,7 @@ navigation:
 <ul>
   <li><a href="{{site.baseurl}}/docs/4.0.1/">Spark 4.0.1</a></li>
   <li><a href="{{site.baseurl}}/docs/4.0.0/">Spark 4.0.0</a></li>
+  <li><a href="{{site.baseurl}}/docs/3.5.7/">Spark 3.5.7</a></li>
   <li><a href="{{site.baseurl}}/docs/3.5.6/">Spark 3.5.6</a></li>
   <li><a href="{{site.baseurl}}/docs/3.5.5/">Spark 3.5.5</a></li>
   <li><a href="{{site.baseurl}}/docs/3.5.4/">Spark 3.5.4</a></li>

--- a/js/downloads.js
+++ b/js/downloads.js
@@ -24,7 +24,7 @@ var packagesV14 = [hadoop3p, hadoop3pscala213, hadoopFree, sources];
 var packagesV15 = [hadoop34p, hadoop34pSparkConnect, hadoopFree, sources];
 
 addRelease("4.0.1", new Date("09/06/2025"), packagesV15, true);
-addRelease("3.5.6", new Date("05/29/2025"), packagesV14, true);
+addRelease("3.5.7", new Date("09/24/2025"), packagesV14, true);
 
 function append(el, contents) {
   el.innerHTML += contents;

--- a/news/_posts/2025-09-24-spark-3-5-7-released.md
+++ b/news/_posts/2025-09-24-spark-3-5-7-released.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: Spark 3.5.7 released
+categories:
+- News
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+We are happy to announce the availability of <a href="{{site.baseurl}}/releases/spark-release-3-5-7.html" title="Spark Release 3.5.7">Spark 3.5.7</a>! Visit the <a href="{{site.baseurl}}/releases/spark-release-3-5-7.html" title="Spark Release 3.5.7">release notes</a> to read about the new features, or <a href="{{site.baseurl}}/downloads.html">download</a> the release today.

--- a/releases/_posts/2025-09-24-spark-release-3-5-7.md
+++ b/releases/_posts/2025-09-24-spark-release-3-5-7.md
@@ -1,0 +1,51 @@
+---
+layout: post
+title: Spark Release 3.5.7
+categories: []
+tags: []
+status: publish
+type: post
+published: true
+meta:
+  _edit_last: '4'
+  _wpas_done_all: '1'
+---
+
+Spark 3.5.7 is the seventh maintenance release containing security and correctness fixes. This release is based on the branch-3.5 maintenance branch of Spark. We strongly recommend all 3.5 users to upgrade to this stable release.
+
+### Notable changes
+
+- [[SPARK-52721]](https://issues.apache.org/jira/browse/SPARK-52721): Wrong message parameter for CANNOT_PARSE_DATATYPE
+- [[SPARK-52749]](https://issues.apache.org/jira/browse/SPARK-52749): Replace preview1 to dev1 in its PyPI package name
+- [[SPARK-53518]](https://issues.apache.org/jira/browse/SPARK-53518): catalogString of User Defined Type should not be truncated
+- [[SPARK-46941]](https://issues.apache.org/jira/browse/SPARK-46941): Can't insert window group limit node for top-k computation if contains SizeBasedWindowFunction
+- [[SPARK-49872]](https://issues.apache.org/jira/browse/SPARK-49872): Spark History UI -- StreamConstraintsException: String length (20054016) exceeds the maximum length (20000000)
+- [[SPARK-52023]](https://issues.apache.org/jira/browse/SPARK-52023): udaf returning Option can cause data corruption and crashes
+- [[SPARK-52032]](https://issues.apache.org/jira/browse/SPARK-52032): ORC filter pushdown causes incorrect results with eqNullSafe (<=>) in DataFrame filter
+- [[SPARK-52240]](https://issues.apache.org/jira/browse/SPARK-52240): VectorizedDeltaLengthByteArrayReader throws ParquetDecodingException: Failed to read X bytes
+- [[SPARK-52339]](https://issues.apache.org/jira/browse/SPARK-52339): Relations may appear equal even though they are different
+- [[SPARK-52516]](https://issues.apache.org/jira/browse/SPARK-52516): Memory Leak with coalesce foreachpartitions and v2 datasources
+- [[SPARK-52611]](https://issues.apache.org/jira/browse/SPARK-52611): Fix SQLConf version for excludeSubqueryRefsFromRemoveRedundantAliases configuration
+- [[SPARK-52684]](https://issues.apache.org/jira/browse/SPARK-52684): Make CACHE TABLE Commands atomic while encounting execution errors
+- [[SPARK-52737]](https://issues.apache.org/jira/browse/SPARK-52737): SHS performance regression when visiting homepage
+- [[SPARK-52776]](https://issues.apache.org/jira/browse/SPARK-52776): ProcfsMetricsGetter splits the comm field if it contains space characters
+- [[SPARK-52791]](https://issues.apache.org/jira/browse/SPARK-52791): Inferring a UDT errors when first element is null
+- [[SPARK-52809]](https://issues.apache.org/jira/browse/SPARK-52809): Don't hold reader and iterator references for all partitions in task completion listeners for metric update
+- [[SPARK-52873]](https://issues.apache.org/jira/browse/SPARK-52873): Hint causes semi join results to vary
+- [[SPARK-53054]](https://issues.apache.org/jira/browse/SPARK-53054): The Scala Spark Connect DataFrameReader does not use the correct default format
+- [[SPARK-53094]](https://issues.apache.org/jira/browse/SPARK-53094): Cube-related data quality problem
+- [[SPARK-53155]](https://issues.apache.org/jira/browse/SPARK-53155): Global lower agggregation should not be removed
+- [[SPARK-53435]](https://issues.apache.org/jira/browse/SPARK-53435): race condition in CachedRDDBuilder
+- [[SPARK-53560]](https://issues.apache.org/jira/browse/SPARK-53560): Crash looping when retrying uncommitted batch in Kafka source and AvailableNow trigger
+- [[SPARK-53581]](https://issues.apache.org/jira/browse/SPARK-53581): Potential thread-safety issue for mapTaskIds.add() in IndexShuffleBlockResolver
+
+### Dependency changes
+
+While being a maintenance release we did still upgrade some dependencies in this release they are:
+- [[SPARK-52635]](https://issues.apache.org/jira/browse/SPARK-52635): Upgrade ORC to 1.9.7
+- [[SPARK-53532]](https://issues.apache.org/jira/browse/SPARK-53532): Upgrade Jetty to 9.4.58.v20250814
+
+You can consult JIRA for the [detailed changes](https://s.apache.org/spark-3.5.7).
+
+We would like to acknowledge all community members for contributing patches to this release.
+

--- a/site/404.html
+++ b/site/404.html
@@ -178,6 +178,9 @@ to find the information you need.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -186,9 +189,6 @@ to find the information you need.</p>
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/committers.html
+++ b/site/committers.html
@@ -725,6 +725,9 @@ of the immediate bug being fixed.</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -733,9 +736,6 @@ of the immediate bug being fixed.</li>
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/community.html
+++ b/site/community.html
@@ -374,6 +374,9 @@ Add yours by emailing `dev@spark.apache.org`.
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -382,9 +385,6 @@ Add yours by emailing `dev@spark.apache.org`.
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -721,6 +721,9 @@ to ask on the <code class="language-plaintext highlighter-rouge">dev@spark.apach
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -729,9 +732,6 @@ to ask on the <code class="language-plaintext highlighter-rouge">dev@spark.apach
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -707,6 +707,9 @@ compatible with usage in an Open Source project and inclusion of the generated c
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -715,9 +718,6 @@ compatible with usage in an Open Source project and inclusion of the generated c
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -159,6 +159,7 @@
 <ul>
   <li><a href="/docs/4.0.1/">Spark 4.0.1</a></li>
   <li><a href="/docs/4.0.0/">Spark 4.0.0</a></li>
+  <li><a href="/docs/3.5.7/">Spark 3.5.7</a></li>
   <li><a href="/docs/3.5.6/">Spark 3.5.6</a></li>
   <li><a href="/docs/3.5.5/">Spark 3.5.5</a></li>
   <li><a href="/docs/3.5.4/">Spark 3.5.4</a></li>
@@ -386,6 +387,9 @@ The <a href="/research.html">research page</a> lists some of the original motiva
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -394,9 +398,6 @@ The <a href="/research.html">research page</a> lists some of the original motiva
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -218,6 +218,9 @@ before deciding to use it.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -226,9 +229,6 @@ before deciding to use it.</p>
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/error-message-guidelines.html
+++ b/site/error-message-guidelines.html
@@ -555,6 +555,9 @@ be redundant; you may skip an explicit explanation in this case.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -563,9 +566,6 @@ be redundant; you may skip an explicit explanation in this case.</p>
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/examples.html
+++ b/site/examples.html
@@ -503,6 +503,9 @@ counts = (
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -511,9 +514,6 @@ counts = (
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/faq.html
+++ b/site/faq.html
@@ -225,6 +225,9 @@ Please also refer to our
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -233,9 +236,6 @@ Please also refer to our
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/graphx/index.html
+++ b/site/graphx/index.html
@@ -270,6 +270,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -278,9 +281,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/history.html
+++ b/site/history.html
@@ -179,6 +179,9 @@ You can get involved in Apache Spark development by reading
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -187,9 +190,6 @@ You can get involved in Apache Spark development by reading
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/improvement-proposals.html
+++ b/site/improvement-proposals.html
@@ -251,6 +251,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -259,9 +262,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/js/downloads.js
+++ b/site/js/downloads.js
@@ -24,7 +24,7 @@ var packagesV14 = [hadoop3p, hadoop3pscala213, hadoopFree, sources];
 var packagesV15 = [hadoop34p, hadoop34pSparkConnect, hadoopFree, sources];
 
 addRelease("4.0.1", new Date("09/06/2025"), packagesV15, true);
-addRelease("3.5.6", new Date("05/29/2025"), packagesV14, true);
+addRelease("3.5.7", new Date("09/24/2025"), packagesV14, true);
 
 function append(el, contents) {
   el.innerHTML += contents;

--- a/site/mailing-lists.html
+++ b/site/mailing-lists.html
@@ -163,6 +163,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -171,9 +174,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/mllib/index.html
+++ b/site/mllib/index.html
@@ -316,6 +316,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -324,9 +327,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/3-1-3-released.html
+++ b/site/news/3-1-3-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/amp-camp-2013-registration-ope.html
+++ b/site/news/amp-camp-2013-registration-ope.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/announcing-the-first-spark-summit.html
+++ b/site/news/announcing-the-first-spark-summit.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/fourth-spark-screencast-published.html
+++ b/site/news/fourth-spark-screencast-published.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/index.html
+++ b/site/news/index.html
@@ -156,6 +156,15 @@
 
 <article class="hentry">
     <header class="entry-header">
+      <h3 class="entry-title"><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a></h3>
+      <div class="entry-date">September 24, 2025</div>
+    </header>
+    <div class="entry-content"><p>We are happy to announce the availability of <a href="/releases/spark-release-3-5-7.html" title="Spark Release 3.5.7">Spark 3.5.7</a>! Visit the <a href="/releases/spark-release-3-5-7.html" title="Spark Release 3.5.7">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
+</div>
+  </article>
+
+<article class="hentry">
+    <header class="entry-header">
       <h3 class="entry-title"><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a></h3>
       <div class="entry-date">September 6, 2025</div>
     </header>
@@ -1491,6 +1500,9 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -1499,9 +1511,6 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/new-repository-service.html
+++ b/site/news/new-repository-service.html
@@ -175,6 +175,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -183,9 +186,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/next-official-release-spark-3.1.1.html
+++ b/site/news/next-official-release-spark-3.1.1.html
@@ -181,6 +181,9 @@ are no guarantees on using it such as binary compatibility.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -189,9 +192,6 @@ are no guarantees on using it such as binary compatibility.</p>
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/nsdi-paper.html
+++ b/site/news/nsdi-paper.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/one-month-to-spark-summit-2015.html
+++ b/site/news/one-month-to-spark-summit-2015.html
@@ -175,6 +175,9 @@ online to attend in person. We hope you enjoy the event!</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -183,9 +186,6 @@ online to attend in person. We hope you enjoy the event!</p>
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/plan-for-dropping-python-2-support.html
+++ b/site/news/plan-for-dropping-python-2-support.html
@@ -185,6 +185,9 @@ Python 2. However, after Python 2 EOL, we might not take patches that are specif
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -193,9 +196,6 @@ Python 2. However, after Python 2 EOL, we might not take patches that are specif
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/proposals-open-for-spark-summit-east.html
+++ b/site/news/proposals-open-for-spark-summit-east.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/registration-open-for-spark-summit-east.html
+++ b/site/news/registration-open-for-spark-summit-east.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/run-spark-and-shark-on-amazon-emr.html
+++ b/site/news/run-spark-and-shark-on-amazon-emr.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/sigmod-system-award.html
+++ b/site/news/sigmod-system-award.html
@@ -180,6 +180,9 @@ the whole community earned together.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -188,9 +191,6 @@ the whole community earned together.</p>
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-1-and-0-5-2-released.html
+++ b/site/news/spark-0-6-1-and-0-5-2-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-6-2-released.html
+++ b/site/news/spark-0-6-2-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-0-released.html
+++ b/site/news/spark-0-7-0-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-2-released.html
+++ b/site/news/spark-0-7-2-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-7-3-released.html
+++ b/site/news/spark-0-7-3-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-0-released.html
+++ b/site/news/spark-0-8-0-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-8-1-released.html
+++ b/site/news/spark-0-8-1-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-0-released.html
+++ b/site/news/spark-0-9-0-released.html
@@ -176,6 +176,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -184,9 +187,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-1-released.html
+++ b/site/news/spark-0-9-1-released.html
@@ -175,6 +175,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -183,9 +186,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-0-9-2-released.html
+++ b/site/news/spark-0-9-2-released.html
@@ -174,6 +174,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -182,9 +185,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-0-released.html
+++ b/site/news/spark-1-0-0-released.html
@@ -172,6 +172,9 @@ This release expands Spark&#8217;s standard libraries, introducing a new SQL pac
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -180,9 +183,6 @@ This release expands Spark&#8217;s standard libraries, introducing a new SQL pac
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-1-released.html
+++ b/site/news/spark-1-0-1-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-0-2-released.html
+++ b/site/news/spark-1-0-2-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-0-released.html
+++ b/site/news/spark-1-1-0-released.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-1-1-released.html
+++ b/site/news/spark-1-1-1-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-0-released.html
+++ b/site/news/spark-1-2-0-released.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-2-1-released.html
+++ b/site/news/spark-1-2-1-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-3-0-released.html
+++ b/site/news/spark-1-3-0-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-0-released.html
+++ b/site/news/spark-1-4-0-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-4-1-released.html
+++ b/site/news/spark-1-4-1-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-0-released.html
+++ b/site/news/spark-1-5-0-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-1-released.html
+++ b/site/news/spark-1-5-1-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-5-2-released.html
+++ b/site/news/spark-1-5-2-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-0-released.html
+++ b/site/news/spark-1-6-0-released.html
@@ -175,6 +175,9 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -183,9 +186,6 @@ to read about the new features, or <a href="/downloads.html">download</a> the re
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-1-released.html
+++ b/site/news/spark-1-6-1-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-2-released.html
+++ b/site/news/spark-1-6-2-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-1-6-3-released.html
+++ b/site/news/spark-1-6-3-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-0-released.html
+++ b/site/news/spark-2-0-0-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-1-released.html
+++ b/site/news/spark-2-0-1-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-0-2-released.html
+++ b/site/news/spark-2-0-2-released.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-0-released.html
+++ b/site/news/spark-2-1-0-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-1-released.html
+++ b/site/news/spark-2-1-1-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-2-released.html
+++ b/site/news/spark-2-1-2-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-1-3-released.html
+++ b/site/news/spark-2-1-3-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-0-released.html
+++ b/site/news/spark-2-2-0-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-1-released.html
+++ b/site/news/spark-2-2-1-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-2-2-released.html
+++ b/site/news/spark-2-2-2-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-0-released.html
+++ b/site/news/spark-2-3-0-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-1-released.html
+++ b/site/news/spark-2-3-1-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-2-released.html
+++ b/site/news/spark-2-3-2-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-3-released.html
+++ b/site/news/spark-2-3-3-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-3-4-released.html
+++ b/site/news/spark-2-3-4-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-0-released.html
+++ b/site/news/spark-2-4-0-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-1-released.html
+++ b/site/news/spark-2-4-1-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-2-released.html
+++ b/site/news/spark-2-4-2-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-3-released.html
+++ b/site/news/spark-2-4-3-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-4-released.html
+++ b/site/news/spark-2-4-4-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-5-released.html
+++ b/site/news/spark-2-4-5-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-6.html
+++ b/site/news/spark-2-4-6.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-7-released.html
+++ b/site/news/spark-2-4-7-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2-4-8-released.html
+++ b/site/news/spark-2-4-8-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-2.0.0-preview.html
+++ b/site/news/spark-2.0.0-preview.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-0-released.html
+++ b/site/news/spark-3-0-0-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-1-released.html
+++ b/site/news/spark-3-0-1-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-2-released.html
+++ b/site/news/spark-3-0-2-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-0-3-released.html
+++ b/site/news/spark-3-0-3-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-1-released.html
+++ b/site/news/spark-3-1-1-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-1-2-released.html
+++ b/site/news/spark-3-1-2-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-0-released.html
+++ b/site/news/spark-3-2-0-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-1-released.html
+++ b/site/news/spark-3-2-1-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-2-released.html
+++ b/site/news/spark-3-2-2-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-3-released.html
+++ b/site/news/spark-3-2-3-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-2-4-released.html
+++ b/site/news/spark-3-2-4-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-0-released.html
+++ b/site/news/spark-3-3-0-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-1-released.html
+++ b/site/news/spark-3-3-1-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-2-released.html
+++ b/site/news/spark-3-3-2-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-3-released.html
+++ b/site/news/spark-3-3-3-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-3-4-released.html
+++ b/site/news/spark-3-3-4-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-4-0-released.html
+++ b/site/news/spark-3-4-0-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-4-1-released.html
+++ b/site/news/spark-3-4-1-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-4-2-released.html
+++ b/site/news/spark-3-4-2-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-4-3-released.html
+++ b/site/news/spark-3-4-3-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-4-4-released.html
+++ b/site/news/spark-3-4-4-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-5-0-released.html
+++ b/site/news/spark-3-5-0-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-5-1-released.html
+++ b/site/news/spark-3-5-1-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-5-2-released.html
+++ b/site/news/spark-3-5-2-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-5-3-released.html
+++ b/site/news/spark-3-5-3-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-5-4-released.html
+++ b/site/news/spark-3-5-4-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-5-5-released.html
+++ b/site/news/spark-3-5-5-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-5-6-released.html
+++ b/site/news/spark-3-5-6-released.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3-5-7-released.html
+++ b/site/news/spark-3-5-7-released.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark 1.2.2 and 1.3.1 released | Apache Spark
+     Spark 3.5.7 released | Apache Spark
     
   </title>
 
@@ -152,12 +152,10 @@
 <div class="container">
   <div class="row mt-4">
     <div class="col-12 col-md-9">
-      <h2>Spark 1.2.2 and 1.3.1 released</h2>
+      <h2>Spark 3.5.7 released</h2>
 
 
-<p>We are happy to announce the availability of <a href="/releases/spark-release-1-2-2.html" title="Spark Release 1.2.2">Spark 1.2.2</a> and <a href="/releases/spark-release-1-3-1.html" title="Spark Release 1.3.1">Spark 1.3.1</a>! These are both maintenance releases that collectively feature the work of more than 90 developers.</p>
-
-<p>To download either release, visit the <a href="/downloads.html">downloads</a> page.</p>
+<p>We are happy to announce the availability of <a href="/releases/spark-release-3-5-7.html" title="Spark Release 3.5.7">Spark 3.5.7</a>! Visit the <a href="/releases/spark-release-3-5-7.html" title="Spark Release 3.5.7">release notes</a> to read about the new features, or <a href="/downloads.html">download</a> the release today.</p>
 
 
 <p>

--- a/site/news/spark-3.0.0-preview.html
+++ b/site/news/spark-3.0.0-preview.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-3.0.0-preview2.html
+++ b/site/news/spark-3.0.0-preview2.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-4-0-0-released.html
+++ b/site/news/spark-4-0-0-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-4-0-1-released.html
+++ b/site/news/spark-4-0-1-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-4-1-0-preview1-released.html
+++ b/site/news/spark-4-1-0-preview1-released.html
@@ -178,6 +178,9 @@ The documentation is available at the <a href="https://spark.apache.org/docs/4.1
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -186,9 +189,6 @@ The documentation is available at the <a href="https://spark.apache.org/docs/4.1
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-4.0.0-preview1.html
+++ b/site/news/spark-4.0.0-preview1.html
@@ -182,6 +182,9 @@ It&#8217;s also available in PyPI, with version name &#8220;4.0.0.dev1&#8221;.</
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -190,9 +193,6 @@ It&#8217;s also available in PyPI, with version name &#8220;4.0.0.dev1&#8221;.</
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-4.0.0-preview2.html
+++ b/site/news/spark-4.0.0-preview2.html
@@ -183,6 +183,9 @@ been possible without you.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -191,9 +194,6 @@ been possible without you.</p>
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-accepted-into-apache-incubator.html
+++ b/site/news/spark-accepted-into-apache-incubator.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-apr-2019-agenda-posted.html
+++ b/site/news/spark-ai-summit-apr-2019-agenda-posted.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-ai-summit-june-2020-agenda-posted.html
+++ b/site/news/spark-ai-summit-june-2020-agenda-posted.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-and-shark-in-the-news.html
+++ b/site/news/spark-and-shark-in-the-news.html
@@ -179,6 +179,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -187,9 +190,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-becomes-tlp.html
+++ b/site/news/spark-becomes-tlp.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-featured-in-wired.html
+++ b/site/news/spark-featured-in-wired.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-mailing-lists-moving-to-apache.html
+++ b/site/news/spark-mailing-lists-moving-to-apache.html
@@ -180,6 +180,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -188,9 +191,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-meetups.html
+++ b/site/news/spark-meetups.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-release-2-2-3.html
+++ b/site/news/spark-release-2-2-3.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-screencasts-published.html
+++ b/site/news/spark-screencasts-published.html
@@ -175,6 +175,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -183,9 +186,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2013-is-a-wrap.html
+++ b/site/news/spark-summit-2013-is-a-wrap.html
@@ -175,6 +175,9 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -183,9 +186,6 @@ Over 450 Spark developers and enthusiasts from 13 countries and more than 180 co
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2014-videos-posted.html
+++ b/site/news/spark-summit-2014-videos-posted.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-2015-videos-posted.html
+++ b/site/news/spark-summit-2015-videos-posted.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-agenda-posted.html
+++ b/site/news/spark-summit-agenda-posted.html
@@ -177,6 +177,9 @@ about the latest happenings in Spark.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -185,9 +188,6 @@ about the latest happenings in Spark.</p>
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2015-videos-posted.html
+++ b/site/news/spark-summit-east-2015-videos-posted.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2016-cfp-closing.html
+++ b/site/news/spark-summit-east-2016-cfp-closing.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-2017-agenda-posted.html
+++ b/site/news/spark-summit-east-2017-agenda-posted.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2015.html
+++ b/site/news/spark-summit-east-agenda-posted-2015.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-east-agenda-posted-2016.html
+++ b/site/news/spark-summit-east-agenda-posted-2016.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-eu-2017-agenda-posted.html
+++ b/site/news/spark-summit-eu-2017-agenda-posted.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe-agenda-posted.html
+++ b/site/news/spark-summit-europe-agenda-posted.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-europe.html
+++ b/site/news/spark-summit-europe.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2016-agenda-posted.html
+++ b/site/news/spark-summit-june-2016-agenda-posted.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2017-agenda-posted.html
+++ b/site/news/spark-summit-june-2017-agenda-posted.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-june-2018-agenda-posted.html
+++ b/site/news/spark-summit-june-2018-agenda-posted.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-summit-oct-2018-agenda-posted.html
+++ b/site/news/spark-summit-oct-2018-agenda-posted.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-tips-from-quantifind.html
+++ b/site/news/spark-tips-from-quantifind.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-user-survey-and-powered-by-page.html
+++ b/site/news/spark-user-survey-and-powered-by-page.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-version-0-6-0-released.html
+++ b/site/news/spark-version-0-6-0-released.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-cloudsort-100tb-benchmark.html
+++ b/site/news/spark-wins-cloudsort-100tb-benchmark.html
@@ -176,6 +176,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -184,9 +187,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
+++ b/site/news/spark-wins-daytona-gray-sort-100tb-benchmark.html
@@ -175,6 +175,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -183,9 +186,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/strata-exercises-now-available-online.html
+++ b/site/news/strata-exercises-now-available-online.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2014.html
+++ b/site/news/submit-talks-to-spark-summit-2014.html
@@ -178,6 +178,9 @@ on Spark.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -186,9 +189,6 @@ on Spark.</p>
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-2016.html
+++ b/site/news/submit-talks-to-spark-summit-2016.html
@@ -170,6 +170,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -178,9 +181,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-east-2016.html
+++ b/site/news/submit-talks-to-spark-summit-east-2016.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/submit-talks-to-spark-summit-eu-2016.html
+++ b/site/news/submit-talks-to-spark-summit-eu-2016.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/two-weeks-to-spark-summit-2014.html
+++ b/site/news/two-weeks-to-spark-summit-2014.html
@@ -179,6 +179,9 @@ online to attend in person. Otherwise, the Summit will offer a free live video s
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -187,9 +190,6 @@ online to attend in person. Otherwise, the Summit will offer a free live video s
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/news/video-from-first-spark-development-meetup.html
+++ b/site/news/video-from-first-spark-development-meetup.html
@@ -169,6 +169,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -177,9 +180,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/pandas-on-spark/index.html
+++ b/site/pandas-on-spark/index.html
@@ -351,6 +351,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -359,9 +362,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/powered-by.html
+++ b/site/powered-by.html
@@ -520,6 +520,9 @@ to process islands identified from a search robor</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -528,9 +531,6 @@ to process islands identified from a search robor</li>
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/release-process.html
+++ b/site/release-process.html
@@ -704,6 +704,9 @@ This includes <a href="#finalize-the-release">Finalizing the release</a> with ad
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -712,9 +715,6 @@ This includes <a href="#finalize-the-release">Finalizing the release</a> with ad
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-3.html
+++ b/site/releases/spark-release-0-3.html
@@ -220,6 +220,9 @@ squares.saveAsSequenceFile(<span class="string">"hdfs://..."</span>)
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -228,9 +231,6 @@ squares.saveAsSequenceFile(<span class="string">"hdfs://..."</span>)
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-0.html
+++ b/site/releases/spark-release-0-5-0.html
@@ -192,6 +192,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -200,9 +203,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-1.html
+++ b/site/releases/spark-release-0-5-1.html
@@ -202,6 +202,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -210,9 +213,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-5-2.html
+++ b/site/releases/spark-release-0-5-2.html
@@ -171,6 +171,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -179,9 +182,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-0.html
+++ b/site/releases/spark-release-0-6-0.html
@@ -246,6 +246,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -254,9 +257,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-1.html
+++ b/site/releases/spark-release-0-6-1.html
@@ -186,6 +186,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -194,9 +197,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-6-2.html
+++ b/site/releases/spark-release-0-6-2.html
@@ -199,6 +199,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -207,9 +210,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-0.html
+++ b/site/releases/spark-release-0-7-0.html
@@ -268,6 +268,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -276,9 +279,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-2.html
+++ b/site/releases/spark-release-0-7-2.html
@@ -210,6 +210,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -218,9 +221,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-7-3.html
+++ b/site/releases/spark-release-0-7-3.html
@@ -204,6 +204,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -212,9 +215,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-0.html
+++ b/site/releases/spark-release-0-8-0.html
@@ -299,6 +299,9 @@ We’d especially like to thank Patrick Wendell for acting as the release manage
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -307,9 +310,6 @@ We’d especially like to thank Patrick Wendell for acting as the release manage
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-8-1.html
+++ b/site/releases/spark-release-0-8-1.html
@@ -263,6 +263,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -271,9 +274,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-0.html
+++ b/site/releases/spark-release-0-9-0.html
@@ -357,6 +357,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -365,9 +368,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-1.html
+++ b/site/releases/spark-release-0-9-1.html
@@ -275,6 +275,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -283,9 +286,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-0-9-2.html
+++ b/site/releases/spark-release-0-9-2.html
@@ -248,6 +248,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -256,9 +259,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-0.html
+++ b/site/releases/spark-release-1-0-0.html
@@ -341,6 +341,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -349,9 +352,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-1.html
+++ b/site/releases/spark-release-1-0-1.html
@@ -299,6 +299,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -307,9 +310,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-0-2.html
+++ b/site/releases/spark-release-1-0-2.html
@@ -256,6 +256,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -264,9 +267,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-0.html
+++ b/site/releases/spark-release-1-1-0.html
@@ -392,6 +392,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -400,9 +403,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-1-1.html
+++ b/site/releases/spark-release-1-1-1.html
@@ -278,6 +278,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -286,9 +289,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-0.html
+++ b/site/releases/spark-release-1-2-0.html
@@ -406,6 +406,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -414,9 +417,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-1.html
+++ b/site/releases/spark-release-1-2-1.html
@@ -278,6 +278,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -286,9 +289,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-2-2.html
+++ b/site/releases/spark-release-1-2-2.html
@@ -238,6 +238,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -246,9 +249,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-0.html
+++ b/site/releases/spark-release-1-3-0.html
@@ -383,6 +383,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -391,9 +394,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-3-1.html
+++ b/site/releases/spark-release-1-3-1.html
@@ -270,6 +270,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -278,9 +281,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-0.html
+++ b/site/releases/spark-release-1-4-0.html
@@ -497,6 +497,9 @@ Python coverage. MLlib also adds several new algorithms.</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -505,9 +508,6 @@ Python coverage. MLlib also adds several new algorithms.</p>
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-4-1.html
+++ b/site/releases/spark-release-1-4-1.html
@@ -302,6 +302,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -310,9 +313,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-0.html
+++ b/site/releases/spark-release-1-5-0.html
@@ -435,6 +435,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -443,9 +446,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-1.html
+++ b/site/releases/spark-release-1-5-1.html
@@ -174,6 +174,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -182,9 +185,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-5-2.html
+++ b/site/releases/spark-release-1-5-2.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-0.html
+++ b/site/releases/spark-release-1-6-0.html
@@ -311,6 +311,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -319,9 +322,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-1.html
+++ b/site/releases/spark-release-1-6-1.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-2.html
+++ b/site/releases/spark-release-1-6-2.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-1-6-3.html
+++ b/site/releases/spark-release-1-6-3.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-0.html
+++ b/site/releases/spark-release-2-0-0.html
@@ -407,6 +407,9 @@ yzhou2001, zhonghaihua, zhuol, zlpmichelle, Örjan Lundberg, Łukasz Gieroń</p>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -415,9 +418,6 @@ yzhou2001, zhonghaihua, zhuol, zlpmichelle, Örjan Lundberg, Łukasz Gieroń</p>
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-1.html
+++ b/site/releases/spark-release-2-0-1.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-0-2.html
+++ b/site/releases/spark-release-2-0-2.html
@@ -175,6 +175,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -183,9 +186,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-0.html
+++ b/site/releases/spark-release-2-1-0.html
@@ -319,6 +319,9 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Roberts, Adrian Petrescu, Ahmed Mahran
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -327,9 +330,6 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Roberts, Adrian Petrescu, Ahmed Mahran
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-1.html
+++ b/site/releases/spark-release-2-1-1.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-2.html
+++ b/site/releases/spark-release-2-1-2.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-1-3.html
+++ b/site/releases/spark-release-2-1-3.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-0.html
+++ b/site/releases/spark-release-2-2-0.html
@@ -385,6 +385,9 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Budde, Adam Roberts, Adrian Ionescu, A
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -393,9 +396,6 @@ ALeksander Eskilson, Aaditya Ramesh, Adam Budde, Adam Roberts, Adrian Ionescu, A
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-1.html
+++ b/site/releases/spark-release-2-2-1.html
@@ -183,6 +183,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -191,9 +194,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-2.html
+++ b/site/releases/spark-release-2-2-2.html
@@ -175,6 +175,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -183,9 +186,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-2-3.html
+++ b/site/releases/spark-release-2-2-3.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-0.html
+++ b/site/releases/spark-release-2-3-0.html
@@ -395,6 +395,9 @@ ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Albe
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -403,9 +406,6 @@ ALeksander Eskilson, Adrian Ionescu, Ajay Saini, Ala Luszczak, Albert Jang, Albe
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-1.html
+++ b/site/releases/spark-release-2-3-1.html
@@ -183,6 +183,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -191,9 +194,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-2.html
+++ b/site/releases/spark-release-2-3-2.html
@@ -183,6 +183,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -191,9 +194,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-3.html
+++ b/site/releases/spark-release-2-3-3.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-3-4.html
+++ b/site/releases/spark-release-2-3-4.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-0.html
+++ b/site/releases/spark-release-2-4-0.html
@@ -401,6 +401,9 @@ Achuth17, Adam Bradbury, Adamyuanyuan, Adelbert Chang, Ala Luszczak, Aleksandr K
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -409,9 +412,6 @@ Achuth17, Adam Bradbury, Adamyuanyuan, Adelbert Chang, Ala Luszczak, Aleksandr K
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-1.html
+++ b/site/releases/spark-release-2-4-1.html
@@ -211,6 +211,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -219,9 +222,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-2.html
+++ b/site/releases/spark-release-2-4-2.html
@@ -183,6 +183,9 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -191,9 +194,6 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-3.html
+++ b/site/releases/spark-release-2-4-3.html
@@ -181,6 +181,9 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -189,9 +192,6 @@ Spark is still cross-published for 2.11 and 2.12 in Maven Central, and can be bu
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-4.html
+++ b/site/releases/spark-release-2-4-4.html
@@ -187,6 +187,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -195,9 +198,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-5.html
+++ b/site/releases/spark-release-2-4-5.html
@@ -201,6 +201,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -209,9 +212,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-6.html
+++ b/site/releases/spark-release-2-4-6.html
@@ -209,6 +209,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -217,9 +220,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-7.html
+++ b/site/releases/spark-release-2-4-7.html
@@ -251,6 +251,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -259,9 +262,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-2-4-8.html
+++ b/site/releases/spark-release-2-4-8.html
@@ -252,6 +252,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -260,9 +263,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-0.html
+++ b/site/releases/spark-release-3-0-0.html
@@ -561,6 +561,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -569,9 +572,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-1.html
+++ b/site/releases/spark-release-3-0-1.html
@@ -210,6 +210,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -218,9 +221,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-2.html
+++ b/site/releases/spark-release-3-0-2.html
@@ -220,6 +220,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -228,9 +231,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-0-3.html
+++ b/site/releases/spark-release-3-0-3.html
@@ -237,6 +237,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -245,9 +248,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-1.html
+++ b/site/releases/spark-release-3-1-1.html
@@ -598,6 +598,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -606,9 +609,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-2.html
+++ b/site/releases/spark-release-3-1-2.html
@@ -285,6 +285,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -293,9 +296,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-1-3.html
+++ b/site/releases/spark-release-3-1-3.html
@@ -199,6 +199,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -207,9 +210,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-0.html
+++ b/site/releases/spark-release-3-2-0.html
@@ -571,6 +571,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -579,9 +582,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-1.html
+++ b/site/releases/spark-release-3-2-1.html
@@ -204,6 +204,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -212,9 +215,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-2.html
+++ b/site/releases/spark-release-3-2-2.html
@@ -279,6 +279,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -287,9 +290,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-3.html
+++ b/site/releases/spark-release-3-2-3.html
@@ -252,6 +252,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -260,9 +263,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-2-4.html
+++ b/site/releases/spark-release-3-2-4.html
@@ -214,6 +214,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -222,9 +225,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-0.html
+++ b/site/releases/spark-release-3-3-0.html
@@ -751,6 +751,9 @@ Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</sp
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -759,9 +762,6 @@ Support the GCM mode by <span style="text-decoration:underline;">aes_encrypt</sp
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-1.html
+++ b/site/releases/spark-release-3-3-1.html
@@ -261,6 +261,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -269,9 +272,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-2.html
+++ b/site/releases/spark-release-3-3-2.html
@@ -338,6 +338,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -346,9 +349,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-3.html
+++ b/site/releases/spark-release-3-3-3.html
@@ -193,6 +193,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -201,9 +204,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-3-4.html
+++ b/site/releases/spark-release-3-3-4.html
@@ -220,6 +220,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -228,9 +231,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-4-0.html
+++ b/site/releases/spark-release-3-4-0.html
@@ -579,6 +579,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -587,9 +590,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-4-1.html
+++ b/site/releases/spark-release-3-4-1.html
@@ -266,6 +266,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -274,9 +277,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-4-2.html
+++ b/site/releases/spark-release-3-4-2.html
@@ -262,6 +262,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -270,9 +273,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-4-3.html
+++ b/site/releases/spark-release-3-4-3.html
@@ -240,6 +240,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -248,9 +251,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-4-4.html
+++ b/site/releases/spark-release-3-4-4.html
@@ -241,6 +241,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -249,9 +252,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-5-0.html
+++ b/site/releases/spark-release-3-5-0.html
@@ -548,6 +548,9 @@ Adam Binford, Ahmed Hussein, Alex Jing, Alice Sayutina, Alkis Evlogimenos, Allan
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -556,9 +559,6 @@ Adam Binford, Ahmed Hussein, Alex Jing, Alice Sayutina, Alkis Evlogimenos, Allan
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-5-1.html
+++ b/site/releases/spark-release-3-5-1.html
@@ -308,6 +308,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -316,9 +319,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-5-2.html
+++ b/site/releases/spark-release-3-5-2.html
@@ -315,6 +315,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -323,9 +326,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-5-3.html
+++ b/site/releases/spark-release-3-5-3.html
@@ -212,6 +212,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -220,9 +223,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-5-4.html
+++ b/site/releases/spark-release-3-5-4.html
@@ -223,6 +223,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -231,9 +234,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-5-5.html
+++ b/site/releases/spark-release-3-5-5.html
@@ -216,6 +216,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -224,9 +227,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-5-6.html
+++ b/site/releases/spark-release-3-5-6.html
@@ -200,6 +200,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -208,9 +211,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-3-5-7.html
+++ b/site/releases/spark-release-3-5-7.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>
-     Spark 1.2.2 and 1.3.1 released | Apache Spark
+     Spark Release 3.5.7 | Apache Spark
     
   </title>
 
@@ -152,12 +152,51 @@
 <div class="container">
   <div class="row mt-4">
     <div class="col-12 col-md-9">
-      <h2>Spark 1.2.2 and 1.3.1 released</h2>
+      <h2>Spark Release 3.5.7</h2>
 
 
-<p>We are happy to announce the availability of <a href="/releases/spark-release-1-2-2.html" title="Spark Release 1.2.2">Spark 1.2.2</a> and <a href="/releases/spark-release-1-3-1.html" title="Spark Release 1.3.1">Spark 1.3.1</a>! These are both maintenance releases that collectively feature the work of more than 90 developers.</p>
+<p>Spark 3.5.7 is the seventh maintenance release containing security and correctness fixes. This release is based on the branch-3.5 maintenance branch of Spark. We strongly recommend all 3.5 users to upgrade to this stable release.</p>
 
-<p>To download either release, visit the <a href="/downloads.html">downloads</a> page.</p>
+<h3 id="notable-changes">Notable changes</h3>
+
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-52721">[SPARK-52721]</a>: Wrong message parameter for CANNOT_PARSE_DATATYPE</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-52749">[SPARK-52749]</a>: Replace preview1 to dev1 in its PyPI package name</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-53518">[SPARK-53518]</a>: catalogString of User Defined Type should not be truncated</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-46941">[SPARK-46941]</a>: Can&#8217;t insert window group limit node for top-k computation if contains SizeBasedWindowFunction</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-49872">[SPARK-49872]</a>: Spark History UI &#8211; StreamConstraintsException: String length (20054016) exceeds the maximum length (20000000)</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-52023">[SPARK-52023]</a>: udaf returning Option can cause data corruption and crashes</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-52032">[SPARK-52032]</a>: ORC filter pushdown causes incorrect results with eqNullSafe (&lt;=&gt;) in DataFrame filter</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-52240">[SPARK-52240]</a>: VectorizedDeltaLengthByteArrayReader throws ParquetDecodingException: Failed to read X bytes</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-52339">[SPARK-52339]</a>: Relations may appear equal even though they are different</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-52516">[SPARK-52516]</a>: Memory Leak with coalesce foreachpartitions and v2 datasources</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-52611">[SPARK-52611]</a>: Fix SQLConf version for excludeSubqueryRefsFromRemoveRedundantAliases configuration</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-52684">[SPARK-52684]</a>: Make CACHE TABLE Commands atomic while encounting execution errors</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-52737">[SPARK-52737]</a>: SHS performance regression when visiting homepage</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-52776">[SPARK-52776]</a>: ProcfsMetricsGetter splits the comm field if it contains space characters</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-52791">[SPARK-52791]</a>: Inferring a UDT errors when first element is null</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-52809">[SPARK-52809]</a>: Don&#8217;t hold reader and iterator references for all partitions in task completion listeners for metric update</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-52873">[SPARK-52873]</a>: Hint causes semi join results to vary</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-53054">[SPARK-53054]</a>: The Scala Spark Connect DataFrameReader does not use the correct default format</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-53094">[SPARK-53094]</a>: Cube-related data quality problem</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-53155">[SPARK-53155]</a>: Global lower agggregation should not be removed</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-53435">[SPARK-53435]</a>: race condition in CachedRDDBuilder</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-53560">[SPARK-53560]</a>: Crash looping when retrying uncommitted batch in Kafka source and AvailableNow trigger</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-53581">[SPARK-53581]</a>: Potential thread-safety issue for mapTaskIds.add() in IndexShuffleBlockResolver</li>
+</ul>
+
+<h3 id="dependency-changes">Dependency changes</h3>
+
+<p>While being a maintenance release we did still upgrade some dependencies in this release they are:</p>
+<ul>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-52635">[SPARK-52635]</a>: Upgrade ORC to 1.9.7</li>
+  <li><a href="https://issues.apache.org/jira/browse/SPARK-53532">[SPARK-53532]</a>: Upgrade Jetty to 9.4.58.v20250814</li>
+</ul>
+
+<p>You can consult JIRA for the <a href="https://s.apache.org/spark-3.5.7">detailed changes</a>.</p>
+
+<p>We would like to acknowledge all community members for contributing patches to this release.</p>
+
 
 
 <p>

--- a/site/releases/spark-release-4-0-0.html
+++ b/site/releases/spark-release-4-0-0.html
@@ -1792,6 +1792,9 @@ Aleksei Shishkin, Adam Binford, Aiden Dong, Albert Ziegler, Alden Lau, Aleksanda
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -1800,9 +1803,6 @@ Aleksei Shishkin, Adam Binford, Aiden Dong, Albert Ziegler, Alden Lau, Aleksanda
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/releases/spark-release-4-0-1.html
+++ b/site/releases/spark-release-4-0-1.html
@@ -272,6 +272,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -280,9 +283,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/research.html
+++ b/site/research.html
@@ -217,6 +217,9 @@ Spark offers an abstraction called <a href="http://people.csail.mit.edu/matei/pa
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -225,9 +228,6 @@ Spark offers an abstraction called <a href="http://people.csail.mit.edu/matei/pa
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/1-first-steps-with-spark.html
+++ b/site/screencasts/1-first-steps-with-spark.html
@@ -179,6 +179,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -187,9 +190,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/2-spark-documentation-overview.html
+++ b/site/screencasts/2-spark-documentation-overview.html
@@ -179,6 +179,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -187,9 +190,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/3-transformations-and-caching.html
+++ b/site/screencasts/3-transformations-and-caching.html
@@ -175,6 +175,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -183,9 +186,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/4-a-standalone-job-in-spark.html
+++ b/site/screencasts/4-a-standalone-job-in-spark.html
@@ -173,6 +173,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -181,9 +184,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/screencasts/index.html
+++ b/site/screencasts/index.html
@@ -201,6 +201,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -209,9 +212,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/security.html
+++ b/site/security.html
@@ -707,6 +707,9 @@ PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -715,9 +718,6 @@ PGh0bWw+PHNjcmlwdD5hbGVydCgiWFNTIik8L3NjcmlwdD48L2h0bWw+
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -144,6 +144,14 @@
 </url>
 <!-- Auto-generate sitemap for rest of site content -->
 <url>
+  <loc>https://spark.apache.org/releases/spark-release-3-5-7.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
+  <loc>https://spark.apache.org/news/spark-3-5-7-released.html</loc>
+  <changefreq>weekly</changefreq>
+</url>
+<url>
   <loc>https://spark.apache.org/releases/spark-release-4-0-1.html</loc>
   <changefreq>weekly</changefreq>
 </url>

--- a/site/spark-connect/index.html
+++ b/site/spark-connect/index.html
@@ -305,6 +305,9 @@ df.Show(100, false)
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -313,9 +316,6 @@ df.Show(100, false)
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/sql/index.html
+++ b/site/sql/index.html
@@ -315,6 +315,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -323,9 +326,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/static/versions.json
+++ b/site/static/versions.json
@@ -5,6 +5,11 @@
         "url": "https://spark.apache.org/docs/4.0.0/api/python/"
     },
     {
+        "name": "3.5.7",
+        "version": "3.5.7",
+        "url": "https://spark.apache.org/docs/3.5.7/api/python/"
+    },
+    {
         "name": "3.5.5",
         "version": "3.5.5",
         "url": "https://spark.apache.org/docs/3.5.5/api/python/"

--- a/site/streaming/index.html
+++ b/site/streaming/index.html
@@ -257,6 +257,9 @@
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -265,9 +268,6 @@
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/third-party-projects.html
+++ b/site/third-party-projects.html
@@ -274,6 +274,9 @@ transforming, and analyzing genomic data using Apache Spark</li>
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -282,9 +285,6 @@ transforming, and analyzing genomic data using Apache Spark</li>
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/trademarks.html
+++ b/site/trademarks.html
@@ -219,6 +219,9 @@ If you have any questions about the Apache trademark policy, please email
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -227,9 +230,6 @@ If you have any questions about the Apache trademark policy, please email
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>

--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -317,6 +317,9 @@ For example, 3.5.0 was released on September 13th 2023 and will be maintained fo
         <h5>Latest News</h5>
         <ul class="list-unstyled">
           
+          <li><a href="/news/spark-3-5-7-released.html">Spark 3.5.7 released</a>
+            <span class="small">(Sep 24, 2025)</span></li>
+          
           <li><a href="/news/spark-4-0-1-released.html">Spark 4.0.1 released</a>
             <span class="small">(Sep 06, 2025)</span></li>
           
@@ -325,9 +328,6 @@ For example, 3.5.0 was released on September 13th 2023 and will be maintained fo
           
           <li><a href="/news/spark-3-5-6-released.html">Spark 3.5.6 released</a>
             <span class="small">(May 29, 2025)</span></li>
-          
-          <li><a href="/news/spark-4-0-0-released.html">Spark 4.0.0 released</a>
-            <span class="small">(May 23, 2025)</span></li>
           
         </ul>
         <p class="small" style="text-align: right;"><a href="/news/index.html">Archive</a></p>


### PR DESCRIPTION

<img width="1475" height="1189" alt="spark-3 5 7-download" src="https://github.com/user-attachments/assets/8a331c60-a85d-4c96-ba89-aeaf8c20ce0b" />
<img width="1434" height="334" alt="spark-3 5 7 -news" src="https://github.com/user-attachments/assets/c83e97ba-e35c-43f7-91a0-0df43b1d1782" />
<img width="1473" height="700" alt="spark-3 5 7-documentation-versions" src="https://github.com/user-attachments/assets/9dc52631-7731-489a-9019-78e735572a38" />
<img width="1398" height="1124" alt="spark-3 5 7-release-notes" src="https://github.com/user-attachments/assets/045f5de4-5974-417d-968f-a6faa4ca6b77" />
