### PR TITLE
Add Spark 4.0.1 to versions.json

### DIFF
--- a/site/static/versions.json
+++ b/site/static/versions.json
@@ -1,5 +1,10 @@
 [
     {
+        "name": "4.0.1",
+        "version": "4.0.1",
+        "url": "https://spark.apache.org/docs/4.0.1/api/python/"
+    },
+    {
         "name": "4.0.0",
         "version": "4.0.0",
         "url": "https://spark.apache.org/docs/4.0.0/api/python/"


### PR DESCRIPTION
This PR aims to fix a missing link for Apache Spark 4.1.0 PySpark docs.

According to 4.1.0-preview3 PySpark API docs, we are missing 4.0.1 currently.

- https://spark.apache.org/docs/4.1.0-preview3/api/python/index.html

<img width="179" height="226" alt="Screenshot 2025-11-07 at 14 16 33" src="https://github.com/user-attachments/assets/8fcf20ba-38fb-4251-ab11-01d5e00c416d" />
