### PR TITLE
Move llms.txt under docs

### DIFF
--- a/site/docs/llms.txt
+++ b/site/docs/llms.txt
@@ -1,6 +1,6 @@
 # Apache Spark
 
-> Apache Spark™ is a unified analytics engine for large-scale data processing. It provides high-level APIs in Java, Scala, Python, and R, and an optimized engine that supports general execution graphs. It also supports a rich set of higher-level tools including Spark SQL for SQL and structured data processing, MLlib for machine learning, GraphX for graph processing, and Structured Streaming for incremental computation and stream processing.
+> Apache Spark is a unified analytics engine for large-scale data processing. It provides high-level APIs in Java, Scala, Python, and R, and an optimized engine that supports general execution graphs. It also supports a rich set of higher-level tools including Spark SQL for SQL and structured data processing, MLlib for machine learning, GraphX for graph processing, and Structured Streaming for incremental computation and stream processing.
 
 Documentation home: https://spark.apache.org/docs/latest/
 


### PR DESCRIPTION
This PR moves llms.txt to docs/llms.txt as it brings to the whole doc instead of the site itself.