### PR TITLE
Update `https://spark.apache.org/docs/preview/` to target `4.1.0-preview4`

### DIFF
--- a/site/docs/preview
+++ b/site/docs/preview
@@ -1,1 +1,1 @@
-4.1.0-preview3
+4.1.0-preview4


### PR DESCRIPTION
This PR aims to make `preview` symbolic link up-to-date by pointing to `4.1.0-preview4`.