### PR TITLE
Introduce Cursor/VS Code support

### DIFF
--- a/developer-tools.md
+++ b/developer-tools.md
@@ -483,11 +483,12 @@ Initial setup:
 - *Confirm Build Server*: Metals defaults to using Bloop as the build server. Do not change this setting, as Bloop provides the fastest compilation and best integration for local development. Open the Command Palette (Cmd+Shift+P or Ctrl+Shift+P), run `Metals: Run doctor`, and verify the status dashboard. Ensure it shows: `Build definition is coming from sbt` and `Build server currently being used is Bloop`.
 
 If you encounter compilation errors or the IDE fails to recognize symbols, follow these steps to perform a clean import:
-1. *Clean Workspace*: Run the following command in your terminal to remove cached build metadata: `rm -rf .bloop/ .metals/ .bsp/`.
-2. *Reload Window*: Run `Developer: Reload Window` from the Command Palette, and select sbt when the prompt reappears.
-3. *Import Build*: Run `Metals: Import build` and wait for the process to complete.
-4. *Connect to Server*: Run `Metals: Connect to build server` and wait for the process to complete.
-5. *Confirm*: Run `Metals: Run doctor` and verify the status dashboard.
+1. *Stop Bloop Server*: Run the following command in your terminal to stop the bloop server: `pkill -f "bloop.BloopServer"`. If you have installed bloop CLI you can run `bloop exit` instead.
+2. *Clean Workspace*: Run the following command in your terminal to remove cached build metadata: `rm -rf .bloop/ .metals/ .bsp/`.
+3. *Reload Window*: Run `Developer: Reload Window` from the Command Palette, and select sbt when the prompt reappears.
+4. *Import Build*: Run `Metals: Import build` and wait for the process to complete.
+5. *Connect to Server*: Run `Metals: Connect to build server` and wait for the process to complete.
+6. *Confirm*: Run `Metals: Run doctor` and verify the status dashboard.
 
 <h4>Eclipse</h4>
 

--- a/developer-tools.md
+++ b/developer-tools.md
@@ -470,6 +470,25 @@ debug in IntelliJ as usual.
 To exit remote debug mode (so that you don't have to keep starting the remote debugger),
 type "session clear" in SBT console while you're in a project.
 
+
+<h4>Cursor/VS Code</h4>
+
+You can leverage the power of *Cursor* or *VS Code* for Spark development by using the Metals extension. 
+Metals provides robust Scala support through the Build Server Protocol (BSP).
+
+Initial setup:
+- *Install Metals*: Search for and install the Scala (Metals) extension from the Marketplace.
+- *Open Project*: Open your Spark root directory.
+- *Select Build Tool*: When prompted by the popup in the bottom-left corner, select sbt as your build tool.
+- *Confirm Build Server*: Metals defaults to using Bloop as the build server. Do not change this setting, as Bloop provides the fastest compilation and best integration for local development. Run `Metals: Run doctor` in the Command Palette to confirm it.
+
+If you encounter compilation errors or the IDE fails to recognize symbols, follow these steps to perform a clean import:
+1. *Clean Workspace*: Run the following command in your terminal to remove cached build metadata: `rm -rf .bloop/ .metals/ .bsp/`.
+2. *Reload Window*: Open the Command Palette (Cmd+Shift+P or Ctrl+Shift+P), run `Developer: Reload Window`, and select sbt when the prompt reappears.
+3. *Import Build*: Run `Metals: Import build` from the Command Palette and wait for the process to complete.
+4. *Connect to Server*: Run `Metals: Connect to build server` and wait for the process to complete.
+5. *Verify Health*: Run `Metals: Run doctor`. Ensure the status dashboard shows: `Build definition is coming from sbt` and `Build server currently being used is Bloop`.
+
 <h4>Eclipse</h4>
 
 Eclipse can be used to develop and test Spark. The following configuration is known to work:

--- a/developer-tools.md
+++ b/developer-tools.md
@@ -479,7 +479,7 @@ Metals provides robust Scala support through the Build Server Protocol (BSP).
 Initial setup:
 - *Install Metals*: Search for and install the Scala (Metals) extension from the Marketplace.
 - *Open Project*: Open your Spark root directory.
-- *Select Build Tool*: When prompted by the popup in the bottom-left corner, select sbt as your build tool.
+- *Select Build Tool*: When prompted by the popup in the bottom-left corner, select sbt to read build definition.
 - *Confirm Build Server*: Metals defaults to using Bloop as the build server. Do not change this setting, as Bloop provides the fastest compilation and best integration for local development. Open the Command Palette (Cmd+Shift+P or Ctrl+Shift+P), run `Metals: Run doctor`, and verify the status dashboard. Ensure it shows: `Build definition is coming from sbt` and `Build server currently being used is Bloop`.
 
 If you encounter compilation errors or the IDE fails to recognize symbols, follow these steps to perform a clean import:

--- a/developer-tools.md
+++ b/developer-tools.md
@@ -480,14 +480,14 @@ Initial setup:
 - *Install Metals*: Search for and install the Scala (Metals) extension from the Marketplace.
 - *Open Project*: Open your Spark root directory.
 - *Select Build Tool*: When prompted by the popup in the bottom-left corner, select sbt as your build tool.
-- *Confirm Build Server*: Metals defaults to using Bloop as the build server. Do not change this setting, as Bloop provides the fastest compilation and best integration for local development. Run `Metals: Run doctor` in the Command Palette to confirm it.
+- *Confirm Build Server*: Metals defaults to using Bloop as the build server. Do not change this setting, as Bloop provides the fastest compilation and best integration for local development. Open the Command Palette (Cmd+Shift+P or Ctrl+Shift+P), run `Metals: Run doctor`, and verify the status dashboard. Ensure it shows: `Build definition is coming from sbt` and `Build server currently being used is Bloop`.
 
 If you encounter compilation errors or the IDE fails to recognize symbols, follow these steps to perform a clean import:
 1. *Clean Workspace*: Run the following command in your terminal to remove cached build metadata: `rm -rf .bloop/ .metals/ .bsp/`.
-2. *Reload Window*: Open the Command Palette (Cmd+Shift+P or Ctrl+Shift+P), run `Developer: Reload Window`, and select sbt when the prompt reappears.
-3. *Import Build*: Run `Metals: Import build` from the Command Palette and wait for the process to complete.
+2. *Reload Window*: Run `Developer: Reload Window` from the Command Palette, and select sbt when the prompt reappears.
+3. *Import Build*: Run `Metals: Import build` and wait for the process to complete.
 4. *Connect to Server*: Run `Metals: Connect to build server` and wait for the process to complete.
-5. *Verify Health*: Run `Metals: Run doctor`. Ensure the status dashboard shows: `Build definition is coming from sbt` and `Build server currently being used is Bloop`.
+5. *Confirm*: Run `Metals: Run doctor` and verify the status dashboard.
 
 <h4>Eclipse</h4>
 

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -606,6 +606,28 @@ debug in IntelliJ as usual.</p>
 <p>To exit remote debug mode (so that you don&#8217;t have to keep starting the remote debugger),
 type &#8220;session clear&#8221; in SBT console while you&#8217;re in a project.</p>
 
+<h4>Cursor/VS Code</h4>
+
+<p>You can leverage the power of <em>Cursor</em> or <em>VS Code</em> for Spark development by using the Metals extension. 
+Metals provides robust Scala support through the Build Server Protocol (BSP).</p>
+
+<p>Initial setup:</p>
+<ul>
+  <li><em>Install Metals</em>: Search for and install the Scala (Metals) extension from the Marketplace.</li>
+  <li><em>Open Project</em>: Open your Spark root directory.</li>
+  <li><em>Select Build Tool</em>: When prompted by the popup in the bottom-left corner, select sbt as your build tool.</li>
+  <li><em>Confirm Build Server</em>: Metals defaults to using Bloop as the build server. Do not change this setting, as Bloop provides the fastest compilation and best integration for local development. Run <code class="language-plaintext highlighter-rouge">Metals: Run doctor</code> in the Command Palette to confirm it.</li>
+</ul>
+
+<p>If you encounter compilation errors or the IDE fails to recognize symbols, follow these steps to perform a clean import:</p>
+<ol>
+  <li><em>Clean Workspace</em>: Run the following command in your terminal to remove cached build metadata: <code class="language-plaintext highlighter-rouge">rm -rf .bloop/ .metals/ .bsp/</code>.</li>
+  <li><em>Reload Window</em>: Open the Command Palette (Cmd+Shift+P or Ctrl+Shift+P), run <code class="language-plaintext highlighter-rouge">Developer: Reload Window</code>, and select sbt when the prompt reappears.</li>
+  <li><em>Import Build</em>: Run <code class="language-plaintext highlighter-rouge">Metals: Import build</code> from the Command Palette and wait for the process to complete.</li>
+  <li><em>Connect to Server</em>: Run <code class="language-plaintext highlighter-rouge">Metals: Connect to build server</code> and wait for the process to complete.</li>
+  <li><em>Verify Health</em>: Run <code class="language-plaintext highlighter-rouge">Metals: Run doctor</code>. Ensure the status dashboard shows: <code class="language-plaintext highlighter-rouge">Build definition is coming from sbt</code> and <code class="language-plaintext highlighter-rouge">Build server currently being used is Bloop</code>.</li>
+</ol>
+
 <h4>Eclipse</h4>
 
 <p>Eclipse can be used to develop and test Spark. The following configuration is known to work:</p>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -615,7 +615,7 @@ Metals provides robust Scala support through the Build Server Protocol (BSP).</p
 <ul>
   <li><em>Install Metals</em>: Search for and install the Scala (Metals) extension from the Marketplace.</li>
   <li><em>Open Project</em>: Open your Spark root directory.</li>
-  <li><em>Select Build Tool</em>: When prompted by the popup in the bottom-left corner, select sbt as your build tool.</li>
+  <li><em>Select Build Tool</em>: When prompted by the popup in the bottom-left corner, select sbt to read build definition.</li>
   <li><em>Confirm Build Server</em>: Metals defaults to using Bloop as the build server. Do not change this setting, as Bloop provides the fastest compilation and best integration for local development. Open the Command Palette (Cmd+Shift+P or Ctrl+Shift+P), run <code class="language-plaintext highlighter-rouge">Metals: Run doctor</code>, and verify the status dashboard. Ensure it shows: <code class="language-plaintext highlighter-rouge">Build definition is coming from sbt</code> and <code class="language-plaintext highlighter-rouge">Build server currently being used is Bloop</code>.</li>
 </ul>
 

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -621,6 +621,7 @@ Metals provides robust Scala support through the Build Server Protocol (BSP).</p
 
 <p>If you encounter compilation errors or the IDE fails to recognize symbols, follow these steps to perform a clean import:</p>
 <ol>
+  <li><em>Stop Bloop Server</em>: Run the following command in your terminal to stop the bloop server: <code class="language-plaintext highlighter-rouge">pkill -f "bloop.BloopServer"</code>. If you have installed bloop CLI you can run <code class="language-plaintext highlighter-rouge">bloop exit</code> instead.</li>
   <li><em>Clean Workspace</em>: Run the following command in your terminal to remove cached build metadata: <code class="language-plaintext highlighter-rouge">rm -rf .bloop/ .metals/ .bsp/</code>.</li>
   <li><em>Reload Window</em>: Run <code class="language-plaintext highlighter-rouge">Developer: Reload Window</code> from the Command Palette, and select sbt when the prompt reappears.</li>
   <li><em>Import Build</em>: Run <code class="language-plaintext highlighter-rouge">Metals: Import build</code> and wait for the process to complete.</li>

--- a/site/developer-tools.html
+++ b/site/developer-tools.html
@@ -616,16 +616,16 @@ Metals provides robust Scala support through the Build Server Protocol (BSP).</p
   <li><em>Install Metals</em>: Search for and install the Scala (Metals) extension from the Marketplace.</li>
   <li><em>Open Project</em>: Open your Spark root directory.</li>
   <li><em>Select Build Tool</em>: When prompted by the popup in the bottom-left corner, select sbt as your build tool.</li>
-  <li><em>Confirm Build Server</em>: Metals defaults to using Bloop as the build server. Do not change this setting, as Bloop provides the fastest compilation and best integration for local development. Run <code class="language-plaintext highlighter-rouge">Metals: Run doctor</code> in the Command Palette to confirm it.</li>
+  <li><em>Confirm Build Server</em>: Metals defaults to using Bloop as the build server. Do not change this setting, as Bloop provides the fastest compilation and best integration for local development. Open the Command Palette (Cmd+Shift+P or Ctrl+Shift+P), run <code class="language-plaintext highlighter-rouge">Metals: Run doctor</code>, and verify the status dashboard. Ensure it shows: <code class="language-plaintext highlighter-rouge">Build definition is coming from sbt</code> and <code class="language-plaintext highlighter-rouge">Build server currently being used is Bloop</code>.</li>
 </ul>
 
 <p>If you encounter compilation errors or the IDE fails to recognize symbols, follow these steps to perform a clean import:</p>
 <ol>
   <li><em>Clean Workspace</em>: Run the following command in your terminal to remove cached build metadata: <code class="language-plaintext highlighter-rouge">rm -rf .bloop/ .metals/ .bsp/</code>.</li>
-  <li><em>Reload Window</em>: Open the Command Palette (Cmd+Shift+P or Ctrl+Shift+P), run <code class="language-plaintext highlighter-rouge">Developer: Reload Window</code>, and select sbt when the prompt reappears.</li>
-  <li><em>Import Build</em>: Run <code class="language-plaintext highlighter-rouge">Metals: Import build</code> from the Command Palette and wait for the process to complete.</li>
+  <li><em>Reload Window</em>: Run <code class="language-plaintext highlighter-rouge">Developer: Reload Window</code> from the Command Palette, and select sbt when the prompt reappears.</li>
+  <li><em>Import Build</em>: Run <code class="language-plaintext highlighter-rouge">Metals: Import build</code> and wait for the process to complete.</li>
   <li><em>Connect to Server</em>: Run <code class="language-plaintext highlighter-rouge">Metals: Connect to build server</code> and wait for the process to complete.</li>
-  <li><em>Verify Health</em>: Run <code class="language-plaintext highlighter-rouge">Metals: Run doctor</code>. Ensure the status dashboard shows: <code class="language-plaintext highlighter-rouge">Build definition is coming from sbt</code> and <code class="language-plaintext highlighter-rouge">Build server currently being used is Bloop</code>.</li>
+  <li><em>Confirm</em>: Run <code class="language-plaintext highlighter-rouge">Metals: Run doctor</code> and verify the status dashboard.</li>
 </ol>
 
 <h4>Eclipse</h4>


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->

Cursor/VS Code is well supported now after https://github.com/apache/spark/pull/53621 . This PR introduces the steps to use Cursor/VS Code.