### PR TITLE
Remove redundant forward slash from Spark URL

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -12,5 +12,5 @@ navigation:
 <p>Setup instructions, programming guides, and other documentation are available for each stable version of Spark below:</p>
 
 <ul>
-  <li><a href="{{site.baseurl}}/docs//">Spark </a></li>
+  <li><a href="{{site.baseurl}}/docs/">Spark </a></li>
   <li><a href="{{site.baseurl}}/docs/4.1.0/">Spark 4.1.0</a></li>

--- a/site/documentation.html
+++ b/site/documentation.html
@@ -157,7 +157,7 @@
 <p>Setup instructions, programming guides, and other documentation are available for each stable version of Spark below:</p>
 
 <ul>
-  <li><a href="/docs//">Spark </a></li>
+  <li><a href="/docs/">Spark </a></li>
   <li><a href="/docs/4.1.0/">Spark 4.1.0</a></li>
 </ul>
 


### PR DESCRIPTION
Remove redundant slash introduced by [PR](https://github.com/apache/spark-website/commit/e94b6c4786da5ba6c06af6320585b84fa889da7f).