### PR TITLE
Make versioning-policy up-to-date with Spark 4.2.0

### DIFF
--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -277,7 +277,7 @@ available APIs.</p>
 Hence, Spark 2.3.0 would generally be released about 6 months after 2.2.0. Maintenance releases happen as needed
 in between feature releases. Major releases do not happen according to a fixed schedule.</p>
 
-<h3>Spark 4.1 release window</h3>
+<h3>Spark 4.2 release window</h3>
 
 <table>
   <thead>
@@ -288,15 +288,15 @@ in between feature releases. Major releases do not happen according to a fixed s
   </thead>
   <tbody>
     <tr>
-      <td>November 1st 2025</td>
+      <td>July 15th 2026</td>
       <td>Code freeze. Release branch cut.</td>
     </tr>
     <tr>
-      <td>November 15th 2025</td>
+      <td>Late July 2026</td>
       <td>QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.</td>
     </tr>
     <tr>
-      <td>November 23th 2025</td>
+      <td>August 2026</td>
       <td>Release candidates (RC), voting, etc. until final release passes</td>
     </tr>
   </tbody>

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -100,13 +100,14 @@ The branch is cut every January and July, so feature ("minor") releases occur ab
 Hence, Spark 2.3.0 would generally be released about 6 months after 2.2.0. Maintenance releases happen as needed
 in between feature releases. Major releases do not happen according to a fixed schedule.
 
-<h3>Spark 4.1 release window</h3>
+<h3>Spark 4.2 release window</h3>
 
 | Date  | Event |
 | ----- | ----- |
-| November 1st 2025 | Code freeze. Release branch cut.|
-| November 15th 2025 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
-| November 23th 2025 | Release candidates (RC), voting, etc. until final release passes|
+| July 15th 2026 | Code freeze. Release branch cut.|
+| Late July 2026 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
+| August 2026 | Release candidates (RC), voting, etc. until final release passes|
+
 
 <h2>Maintenance releases and EOL</h2>
 

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -108,7 +108,6 @@ in between feature releases. Major releases do not happen according to a fixed s
 | Late July 2026 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
 | August 2026 | Release candidates (RC), voting, etc. until final release passes|
 
-
 <h2>Maintenance releases and EOL</h2>
 
 Feature release branches will, generally, be maintained with bug fix releases for a period of 18 months. 


### PR DESCRIPTION
Apache Spark Versioning Policy page is outdated. This PR aims to make it up-to-date with Spark 4.2.0 schedule.

Note that this is the last release before applying [SPIP: Accelerating Apache Spark Release Cadence](https://lists.apache.org/thread/31rx0xmwbhloljsowc9ksl6kk5vbb3r4). We decided to keep the existing policy for Spark 4.2.x.

> Spark 4.2.x must also follow the current policy because development has already progressed under that assumption.