### PR TITLE
website: add declarative pipeline support to Spark SQL highlights

### DIFF
--- a/index.md
+++ b/index.md
@@ -308,16 +308,20 @@ head(select(df, df$name.first))
 <section class="py-5">
     <div class="container">
         <div class="row">
-            <div class="col-12 col-lg-5 order-2 order-lg-1 mt-5 mt-lg-0" style="font-size: 19px;line-height: 33px;">
+            <div class="col-12 col-lg-6 order-2 order-lg-1 mt-5 mt-lg-0" style="font-size: 19px;line-height: 33px;">
                 <div class="scalable-data-science">
                     <a href="{{site.baseurl}}/docs/latest/sql-performance-tuning.html#adaptive-query-execution" alt="Adaptive Query Execution">Adaptive Query Execution</a>
                     <p>Spark SQL adapts the execution plan at runtime, such as automatically setting the number of reducers and join algorithms.</p>
                 </div>
-                <div class="mt-5 scalable-data-science">
+                <div class="mt-4 scalable-data-science">
                     <a href="{{site.baseurl}}/docs/latest/sql-ref-ansi-compliance.html" alt="Support for ANSI SQL">Support for ANSI SQL</a>
                     <p>Use the same SQL you’re already comfortable with.</p>
+                </div> 
+                <div class="mt-4 scalable-data-science">
+                    <a href="{{site.baseurl}}/docs/latest/declarative-pipelines-programming-guide.html" alt="Declarative Pipeline Support">Declarative Pipeline Support</a>
+                    <p>Use SQL with Spark Declarative Pipelines for easier dependency management and views for streaming or batch.</p>
                 </div>
-                <div class="mt-5 scalable-data-science">
+                <div class="mt-4 scalable-data-science">
                     <a href="{{site.baseurl}}/docs/latest/sql-data-sources-json.html" alt="Structured and unstructured data">Structured and unstructured data</a>
                     <p>Spark SQL works on structured tables and unstructured data such as JSON or images.</p>
                 </div>

--- a/site/index.html
+++ b/site/index.html
@@ -455,16 +455,20 @@
 <section class="py-5">
     <div class="container">
         <div class="row">
-            <div class="col-12 col-lg-5 order-2 order-lg-1 mt-5 mt-lg-0" style="font-size: 19px;line-height: 33px;">
+            <div class="col-12 col-lg-6 order-2 order-lg-1 mt-5 mt-lg-0" style="font-size: 19px;line-height: 33px;">
                 <div class="scalable-data-science">
                     <a href="/docs/latest/sql-performance-tuning.html#adaptive-query-execution" alt="Adaptive Query Execution">Adaptive Query Execution</a>
                     <p>Spark SQL adapts the execution plan at runtime, such as automatically setting the number of reducers and join algorithms.</p>
                 </div>
-                <div class="mt-5 scalable-data-science">
+                <div class="mt-4 scalable-data-science">
                     <a href="/docs/latest/sql-ref-ansi-compliance.html" alt="Support for ANSI SQL">Support for ANSI SQL</a>
                     <p>Use the same SQL you’re already comfortable with.</p>
+                </div> 
+                <div class="mt-4 scalable-data-science">
+                    <a href="/docs/latest/declarative-pipelines-programming-guide.html" alt="Declarative Pipeline Support">Declarative Pipeline Support</a>
+                    <p>Use SQL with Spark Declarative Pipelines for easier dependency management and views for streaming or batch.</p>
                 </div>
-                <div class="mt-5 scalable-data-science">
+                <div class="mt-4 scalable-data-science">
                     <a href="/docs/latest/sql-data-sources-json.html" alt="Structured and unstructured data">Structured and unstructured data</a>
                     <p>Spark SQL works on structured tables and unstructured data such as JSON or images.</p>
                 </div>


### PR DESCRIPTION
This PR updates homepage content to highlight declarative pipeline support.