### PR TITLE
Change Spark 4.2 release timeline

### DIFF
--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -288,15 +288,15 @@ in between feature releases. Major releases do not happen according to a fixed s
   </thead>
   <tbody>
     <tr>
-      <td>July 15th 2026</td>
+      <td>May 1st 2026</td>
       <td>Code freeze. Release branch cut.</td>
     </tr>
     <tr>
-      <td>Late July 2026</td>
+      <td>Mid May 2026</td>
       <td>QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.</td>
     </tr>
     <tr>
-      <td>August 2026</td>
+      <td>Late May 2026</td>
       <td>Release candidates (RC), voting, etc. until final release passes</td>
     </tr>
   </tbody>

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -104,9 +104,9 @@ in between feature releases. Major releases do not happen according to a fixed s
 
 | Date  | Event |
 | ----- | ----- |
-| July 15th 2026 | Code freeze. Release branch cut.|
-| Late July 2026 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
-| August 2026 | Release candidates (RC), voting, etc. until final release passes|
+| May 1st 2026 | Code freeze. Release branch cut.|
+| Mid May 2026 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
+| Late May 2026 | Release candidates (RC), voting, etc. until final release passes|
 
 <h2>Maintenance releases and EOL</h2>
 


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->
changed Spark 4.2 release time to the agreed time tile in the dev mailing list
```
May 1th 2026 Code freeze. Release branch cut.
Mid May 2026 QA period. Focus on bug fixes, tests, stability and docs.
Generally, no new features merged.
Late May 2026 Release candidates (RC), voting, etc. until final release
passes
```
