### PR TITLE
Improve build script and instruction

### DIFF
--- a/.dev/build-docs.sh
+++ b/.dev/build-docs.sh
@@ -21,4 +21,4 @@ docker run \
   --mount type=bind,source="$PWD",target="/spark-website" \
   -w /spark-website \
   docs-builder:latest \
-  /bin/bash -c "sh .dev/run-in-container.sh"
+  /bin/bash -c ".dev/run-in-container.sh"

--- a/.dev/run-in-container.sh
+++ b/.dev/run-in-container.sh
@@ -16,20 +16,21 @@
 #
 
 # 1.Set env variable.
-export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-arm64
-export PATH=$JAVA_HOME/bin:$PATH
+export JAVA_HOME="/usr/lib/jvm/$(ls /usr/lib/jvm/ | grep java-17-openjdk | awk '{print $NF}')"
+export PATH="$JAVA_HOME/bin:$PATH"
 
 # 2.Install bundler.
 gem install bundler -v 2.4.22
 bundle install
 
-# 3. Create a user matching the host UID/GID
-groupadd -g $HOST_GID docuser
-useradd -u $HOST_UID -g $HOST_GID -m docuser
+# 3. Create a user matching the host UID/GID, if it doesn't exist
+groupadd -g $HOST_GID docuser || true
+useradd -u $HOST_UID -g $HOST_GID -m docuser || true
+DOC_USER=$(getent passwd "$HOST_UID" | cut -d: -f1)
 
 # We need this link to make sure `python3` points to `python3.11` which contains the prerequisite packages.
 ln -s "$(which python3.11)" "/usr/local/bin/python3"
 
 # Build docs
 rm -rf .jekyll-cache
-su docuser -c "bundle exec jekyll build"
+su "$DOC_USER" -c "bundle exec jekyll build"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker build \
 Once the image is built, navigate to the `spark-website` root directory, run the script which processes
 the Markdown files in the Docker container.
 ```
-SPARK_WEBSITE_PATH="/path/to/spark-website" sh .dev/build-docs.sh
+.dev/build-docs.sh
 ```
 
 ## Docs sub-dir


### PR DESCRIPTION
<!-- *Make sure that you generate site HTML with `bundle exec jekyll build`, and include the changes to the HTML in your pull request. See README.md for more information.* -->

- Grant `x` permission to `.dev/*.sh` scripts so we can execute `foo.sh` directly instead of calling `sh foo.sh`
- Remove unused env var `SPARK_WEBSITE_PATH` in building instruction, it exists neither in this repo nor the main repo
- Correctly set `JAVA_HOME` for both x86_64 and arm platforms (is JAVA_HOME really required? I'm not sure)
- Fix issues when the host machine has the same UID and GID as the container. For example, my host runs Ubuntu 24.04, the default UID is 1000, and the docs image also uses Ubuntu 24.04 and has the user `ubuntu` with the same UID 1000.

### Verification

- Intel CPU, OS Ubuntu 24.04, UID 1000, username chengpan

Before

```shell
$ sh .dev/build-docs.sh 
Successfully installed bundler-2.4.22
Parsing documentation for bundler-2.4.22
Installing ri documentation for bundler-2.4.22
Done installing documentation for bundler after 0 seconds
1 gem installed
Don't run Bundler as root. Installing your bundle as root will break this
application for all non-root users on this machine.
Bundle complete! 4 Gemfile dependencies, 33 gems now installed.
Bundled gems are installed into `./.local_ruby_bundle`
groupadd: GID '1000' already exists
useradd: UID 1000 is not unique
su: user docuser does not exist or the user entry does not contain all the required fields
```

After
```
$ .dev/build-docs.sh
Successfully installed bundler-2.4.22
Parsing documentation for bundler-2.4.22
Installing ri documentation for bundler-2.4.22
Done installing documentation for bundler after 0 seconds
1 gem installed
Don't run Bundler as root. Installing your bundle as root will break this
application for all non-root users on this machine.
Bundle complete! 4 Gemfile dependencies, 33 gems now installed.
Bundled gems are installed into `./.local_ruby_bundle`
groupadd: GID '1000' already exists
useradd: UID 1000 is not unique
Configuration file: /spark-website/_config.yml
            Source: /spark-website
       Destination: /spark-website/site
 Incremental build: disabled. Enable with --incremental
      Generating... 
                    done in 1.737 seconds.
 Auto-regeneration: disabled. Use --watch to enable.
```

- Also tested on a MacBook with Apple Silicon, works fine too.

```
$ .dev/build-docs.sh
Successfully installed bundler-2.4.22
Parsing documentation for bundler-2.4.22
Installing ri documentation for bundler-2.4.22
Done installing documentation for bundler after 0 seconds
1 gem installed
Don't run Bundler as root. Installing your bundle as root will break this
application for all non-root users on this machine.
Bundle complete! 4 Gemfile dependencies, 33 gems now installed.
Bundled gems are installed into `./.local_ruby_bundle`
groupadd: GID '20' already exists
useradd warning: docuser's uid 501 outside of the UID_MIN 1000 and UID_MAX 60000 range.
Configuration file: /spark-website/_config.yml
            Source: /spark-website
       Destination: /spark-website/site
 Incremental build: disabled. Enable with --incremental
      Generating...
                    done in 1.93 seconds.
 Auto-regeneration: disabled. Use --watch to enable.
```