### PR TITLE
Fix a couple of typos in contributing.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -125,7 +125,7 @@ When resolving JIRAs, observe a few useful conventions:
   - In case several people contributed, prefer to assign to the more 'junior', non-committer contributor
 - For issues that can't be reproduced against master as reported, resolve as **Cannot Reproduce**
   - Fixed is reasonable too, if it's clear what other previous pull request resolved it. Link to it.
-- If the issue is the same as or a subset of another issue, resolved as **Duplicate**
+- If the issue is the same as or a subset of another issue, resolve as **Duplicate**
   - Make sure to link to the JIRA it duplicates
   - Prefer to resolve the issue that has less activity or discussion as the duplicate
 - If the issue seems clearly obsolete and applies to issues or components that have changed 
@@ -479,7 +479,7 @@ lines can be up to 100 characters in length, not 79.
 - For R code, Apache Spark follows
 <a href="https://google.github.io/styleguide/Rguide.xml">Google's R Style Guide</a> with three exceptions:
 lines can be up to 100 characters in length, not 80, there is no limit on function name but it has a initial
-lower case latter and S4 objects/methods are allowed.
+lower case letter and S4 objects/methods are allowed.
 - For Java code, Apache Spark follows
 <a href="http://www.oracle.com/technetwork/java/codeconvtoc-136057.html">Oracle's Java code conventions</a> and
 Scala guidelines below. The latter is preferred.

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -278,7 +278,7 @@ who opened the PR that resolved the issue.</li>
       <li>Fixed is reasonable too, if it&#8217;s clear what other previous pull request resolved it. Link to it.</li>
     </ul>
   </li>
-  <li>If the issue is the same as or a subset of another issue, resolved as <strong>Duplicate</strong>
+  <li>If the issue is the same as or a subset of another issue, resolve as <strong>Duplicate</strong>
     <ul>
       <li>Make sure to link to the JIRA it duplicates</li>
       <li>Prefer to resolve the issue that has less activity or discussion as the duplicate</li>
@@ -692,7 +692,7 @@ lines can be up to 100 characters in length, not 79.</li>
   <li>For R code, Apache Spark follows
 <a href="https://google.github.io/styleguide/Rguide.xml">Google&#8217;s R Style Guide</a> with three exceptions:
 lines can be up to 100 characters in length, not 80, there is no limit on function name but it has a initial
-lower case latter and S4 objects/methods are allowed.</li>
+lower case letter and S4 objects/methods are allowed.</li>
   <li>For Java code, Apache Spark follows
 <a href="http://www.oracle.com/technetwork/java/codeconvtoc-136057.html">Oracle&#8217;s Java code conventions</a> and
 Scala guidelines below. The latter is preferred.</li>


### PR DESCRIPTION
1. Match the imperative voice of other bullets in the "Contributing to JIRA maintenance" section.
2. "lower case latter" --> "lower case letter"
