### PR TITLE
Update the guidance for pinging interested parties on PRs

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -411,8 +411,7 @@ will trigger workflows "On pull request*" (on Spark repo) that will look/watch f
      but needs to be pushed to GitHub to facilitate review, then add `[WIP]` after the component.
      1. Consider identifying committers or other contributors who have worked on the code being 
      changed. Find the file(s) in GitHub and click "Blame" to see a line-by-line annotation of 
-     who changed the code last. You can add `@username` in the PR description to ping them 
-     immediately.
+     who changed the code last. You can add `@username` in a comment on the PR to ping them.
      1. Please state that the contribution is your original work and that you license the work 
      to the project under the project's open source license.
 1. The related JIRA, if any, will be marked as "In Progress" and your pull request will 

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -610,8 +610,7 @@ will trigger workflows &#8220;On pull request*&#8221; (on Spark repo) that will 
   but needs to be pushed to GitHub to facilitate review, then add <code class="language-plaintext highlighter-rouge">[WIP]</code> after the component.</li>
       <li>Consider identifying committers or other contributors who have worked on the code being 
   changed. Find the file(s) in GitHub and click &#8220;Blame&#8221; to see a line-by-line annotation of 
-  who changed the code last. You can add <code class="language-plaintext highlighter-rouge">@username</code> in the PR description to ping them 
-  immediately.</li>
+  who changed the code last. You can add <code class="language-plaintext highlighter-rouge">@username</code> in a comment on the PR to ping them.</li>
       <li>Please state that the contribution is your original work and that you license the work 
   to the project under the project&#8217;s open source license.</li>
     </ol>


### PR DESCRIPTION
Pinging interested parties in the PR description is not customary on GitHub or the Spark project, as the PR description often becomes the commit message. Pinging in a separate comment is the expectation.
