### PR TITLE
Update redirected links in contributing.md to canonical URLs

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -359,7 +359,7 @@ and every run burdens the limited resources of GitHub Actions in Apache Spark re
 Below steps will take your through the process.
 
 
-1. <a href="https://help.github.com/articles/fork-a-repo/">Fork</a> the GitHub repository at 
+1. <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo">Fork</a> the GitHub repository at 
 <a href="https://github.com/apache/spark">https://github.com/apache/spark</a> if you haven't already
 1. Go to "Actions" tab on your forked repository and enable "Build and test" and "Report test results" workflows  
 1. Clone your fork and create a new branch
@@ -400,7 +400,7 @@ passes style checks.
 If style checks fail, review the Code Style Guide below.
 1. Push commits to your branch. This will trigger "Build and test" and "Report test results" workflows 
 on your forked repository and start testing and validating your changes.
-1. <a href="https://help.github.com/articles/using-pull-requests/">Open a pull request</a> against 
+1. <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests">Open a pull request</a> against 
 the `master` branch of `apache/spark`. (Only in special cases would the PR be opened against other branches). This 
 will trigger workflows "On pull request*" (on Spark repo) that will look/watch for successful workflow runs on "your" forked repository (it will wait if one is running). 
      1. The PR title should be of the form `[SPARK-xxxx][COMPONENT] Title`, where `SPARK-xxxx` is 
@@ -473,17 +473,17 @@ resolve the JIRA.
 Please follow the style of the existing codebase.
 
 - For Python code, Apache Spark follows 
-<a href="http://legacy.python.org/dev/peps/pep-0008/">PEP 8</a> with one exception: 
+<a href="https://peps.python.org/pep-0008/">PEP 8</a> with one exception: 
 lines can be up to 100 characters in length, not 79.
 - For R code, Apache Spark follows
 <a href="https://google.github.io/styleguide/Rguide.xml">Google's R Style Guide</a> with three exceptions:
 lines can be up to 100 characters in length, not 80, there is no limit on function name but it has a initial
 lower case letter and S4 objects/methods are allowed.
 - For Java code, Apache Spark follows
-<a href="http://www.oracle.com/technetwork/java/codeconvtoc-136057.html">Oracle's Java code conventions</a> and
+<a href="https://www.oracle.com/java/technologies/javase/codeconventions-contents.html">Oracle's Java code conventions</a> and
 Scala guidelines below. The latter is preferred.
 - For Scala code, Apache Spark follows the official 
-<a href="http://docs.scala-lang.org/style/">Scala style guide</a> and
+<a href="https://docs.scala-lang.org/style/">Scala style guide</a> and
 <a href="https://github.com/databricks/scala-style-guide">Databricks Scala guide</a>. The latter is preferred. To format Scala code, run ./dev/scalafmt prior to submitting a PR.
 
 <h3>If in doubt</h3>

--- a/site/contributing.html
+++ b/site/contributing.html
@@ -551,7 +551,7 @@ and every run burdens the limited resources of GitHub Actions in Apache Spark re
 Below steps will take your through the process.</p>
 
 <ol>
-  <li><a href="https://help.github.com/articles/fork-a-repo/">Fork</a> the GitHub repository at 
+  <li><a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo">Fork</a> the GitHub repository at
 <a href="https://github.com/apache/spark">https://github.com/apache/spark</a> if you haven&#8217;t already</li>
   <li>Go to &#8220;Actions&#8221; tab on your forked repository and enable &#8220;Build and test&#8221; and &#8220;Report test results&#8221; workflows</li>
   <li>Clone your fork and create a new branch</li>
@@ -598,7 +598,7 @@ passes style checks.
 If style checks fail, review the Code Style Guide below.</li>
   <li>Push commits to your branch. This will trigger &#8220;Build and test&#8221; and &#8220;Report test results&#8221; workflows 
 on your forked repository and start testing and validating your changes.</li>
-  <li><a href="https://help.github.com/articles/using-pull-requests/">Open a pull request</a> against 
+  <li><a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests">Open a pull request</a> against
 the <code class="language-plaintext highlighter-rouge">master</code> branch of <code class="language-plaintext highlighter-rouge">apache/spark</code>. (Only in special cases would the PR be opened against other branches). This 
 will trigger workflows &#8220;On pull request*&#8221; (on Spark repo) that will look/watch for successful workflow runs on &#8220;your&#8221; forked repository (it will wait if one is running).
     <ol>
@@ -686,17 +686,17 @@ resolve the JIRA.</li>
 
 <ul>
   <li>For Python code, Apache Spark follows 
-<a href="http://legacy.python.org/dev/peps/pep-0008/">PEP 8</a> with one exception: 
+<a href="https://peps.python.org/pep-0008/">PEP 8</a> with one exception: 
 lines can be up to 100 characters in length, not 79.</li>
   <li>For R code, Apache Spark follows
 <a href="https://google.github.io/styleguide/Rguide.xml">Google&#8217;s R Style Guide</a> with three exceptions:
 lines can be up to 100 characters in length, not 80, there is no limit on function name but it has a initial
 lower case letter and S4 objects/methods are allowed.</li>
   <li>For Java code, Apache Spark follows
-<a href="http://www.oracle.com/technetwork/java/codeconvtoc-136057.html">Oracle&#8217;s Java code conventions</a> and
+<a href="https://www.oracle.com/java/technologies/javase/codeconventions-contents.html">Oracle&#8217;s Java code conventions</a> and
 Scala guidelines below. The latter is preferred.</li>
   <li>For Scala code, Apache Spark follows the official 
-<a href="http://docs.scala-lang.org/style/">Scala style guide</a> and
+<a href="https://docs.scala-lang.org/style/">Scala style guide</a> and
 <a href="https://github.com/databricks/scala-style-guide">Databricks Scala guide</a>. The latter is preferred. To format Scala code, run ./dev/scalafmt prior to submitting a PR.</li>
 </ul>
 


### PR DESCRIPTION
Five external links in `contributing.md` (and the rendered `site/contributing.html`) currently return 200 only via redirect to canonical destinations:

| Link | New canonical URL |
|------|-------------------|
| `https://help.github.com/articles/fork-a-repo/` | `https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo` |
| `https://help.github.com/articles/using-pull-requests/` | `https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests` |
| `http://legacy.python.org/dev/peps/pep-0008/` | `https://peps.python.org/pep-0008/` |
| `http://www.oracle.com/technetwork/java/codeconvtoc-136057.html` | `https://www.oracle.com/java/technologies/javase/codeconventions-contents.html` |
| `http://docs.scala-lang.org/style/` | `https://docs.scala-lang.org/style/` |

GitHub deprecated `help.github.com` in favor of `docs.github.com`, Oracle deprecated `technetwork`, and the two HTTP URLs upgrade to HTTPS. The redirects work today but the canonical URLs are stable forever.

The change touches both `contributing.md` and `site/contributing.html` to keep the source and rendered files in sync, matching the convention from PR #679 (`Fix a couple of typos in contributing.md`).

Generated-by: Claude Opus 4.7 (1M context) (claude-opus-4-7)