### PR TITLE
Document how to merge website pull requests on the Committers page

### DIFF
--- a/committers.md
+++ b/committers.md
@@ -244,6 +244,32 @@ can do this automatically in most cases.
 
 Once a PR is merged please leave a comment on the PR stating which branch(es) it has been merged with.
 
+<h4>Merging website pull requests</h4>
+
+Pull requests to the Spark website (the
+<a href="https://github.com/apache/spark-website">apache/spark-website</a> repository) are merged
+separately from the main Spark repo. Unlike `apache/spark`, this repository uses `asf-site` as its
+default branch, and there is no `master` branch.
+
+Website PRs are merged using the
+<a href="https://github.com/apache/spark-website/blob/asf-site/merge_pr.py">merge_pr.py</a> script
+in the root of the `spark-website` repository, which squashes the pull request's changes into one
+commit, just like `merge_spark_pr.py` does for the main repo.
+
+To use it, set up remotes in your local clone of `spark-website` the same way as for the main repo:
+an `apache` remote (the default `PUSH_REMOTE_NAME`, used for pushing the squashed commit) and an
+`apache-github` remote (the default `PR_REMOTE_NAME`, used for pulling the change), both pointing at
+`git@github.com:apache/spark-website.git`. Then run the script from the repository root:
+
+```
+./merge_pr.py
+```
+
+The script is interactive and walks you through selecting the PR and pushing the merge to the
+`asf-site` branch. Before merging, make sure the pull request includes the regenerated HTML under
+`site/` in addition to the Markdown/HTML source changes; see the repository's `README.md` for how
+the site is built.
+
 <h3>Policy on backporting bug fixes</h3>
 
 From <a href="https://www.mail-archive.com/dev@spark.apache.org/msg10284.html">`pwendell`</a>:

--- a/site/committers.html
+++ b/site/committers.html
@@ -708,6 +708,31 @@ can do this automatically in most cases.</p>
 
 <p>Once a PR is merged please leave a comment on the PR stating which branch(es) it has been merged with.</p>
 
+<h4>Merging website pull requests</h4>
+
+<p>Pull requests to the Spark website (the
+<a href="https://github.com/apache/spark-website">apache/spark-website</a> repository) are merged
+separately from the main Spark repo. Unlike <code class="language-plaintext highlighter-rouge">apache/spark</code>, this repository uses <code class="language-plaintext highlighter-rouge">asf-site</code> as its
+default branch, and there is no <code class="language-plaintext highlighter-rouge">master</code> branch.</p>
+
+<p>Website PRs are merged using the
+<a href="https://github.com/apache/spark-website/blob/asf-site/merge_pr.py">merge_pr.py</a> script
+in the root of the <code class="language-plaintext highlighter-rouge">spark-website</code> repository, which squashes the pull request&#8217;s changes into one
+commit, just like <code class="language-plaintext highlighter-rouge">merge_spark_pr.py</code> does for the main repo.</p>
+
+<p>To use it, set up remotes in your local clone of <code class="language-plaintext highlighter-rouge">spark-website</code> the same way as for the main repo:
+an <code class="language-plaintext highlighter-rouge">apache</code> remote (the default <code class="language-plaintext highlighter-rouge">PUSH_REMOTE_NAME</code>, used for pushing the squashed commit) and an
+<code class="language-plaintext highlighter-rouge">apache-github</code> remote (the default <code class="language-plaintext highlighter-rouge">PR_REMOTE_NAME</code>, used for pulling the change), both pointing at
+<code class="language-plaintext highlighter-rouge">git@github.com:apache/spark-website.git</code>. Then run the script from the repository root:</p>
+
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>./merge_pr.py
+</code></pre></div></div>
+
+<p>The script is interactive and walks you through selecting the PR and pushing the merge to the
+<code class="language-plaintext highlighter-rouge">asf-site</code> branch. Before merging, make sure the pull request includes the regenerated HTML under
+<code class="language-plaintext highlighter-rouge">site/</code> in addition to the Markdown/HTML source changes; see the repository&#8217;s <code class="language-plaintext highlighter-rouge">README.md</code> for how
+the site is built.</p>
+
 <h3>Policy on backporting bug fixes</h3>
 
 <p>From <a href="https://www.mail-archive.com/dev@spark.apache.org/msg10284.html"><code class="language-plaintext highlighter-rouge">pwendell</code></a>:</p>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Committers page (`committers.md`) currently only documents how to merge pull requests for the main `apache/spark` repository (the `merge_spark_pr.py` script). It does not explain how a committer merges pull requests to the `apache/spark-website` repository itself.

This PR adds a **"Merging website pull requests"** subsection under "How to merge a pull request" that covers:

- Website PRs are merged with this repo's `merge_pr.py` script (which squashes commits, like `merge_spark_pr.py` does for the main repo).
- This repository uses `asf-site` as its default branch (there is no `master` branch).
- How to set up the `apache` (`PUSH_REMOTE_NAME`) and `apache-github` (`PR_REMOTE_NAME`) remotes.
- A reminder to ensure the PR includes the regenerated `site/` HTML.

The generated `site/committers.html` was rebuilt with `jekyll build` and is included.

## How was this patch tested?

Built the site locally with `jekyll build` and verified the rendered `site/committers.html` shows the new section correctly.