### PR TITLE
Update Spark 4.2.0 website metadata

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -32,7 +32,7 @@ Spark artifacts are [hosted in Maven Central](https://search.maven.org/search?q=
 
     groupId: org.apache.spark
     artifactId: spark-core_2.13
-    version: 4.1.0
+    version: 4.2.0
 
 ### Installing with PyPi
 <a href="https://pypi.org/project/pyspark/">PySpark</a> is now available in pypi. To install just run `pip install pyspark`.

--- a/site/downloads.html
+++ b/site/downloads.html
@@ -189,7 +189,7 @@ window.onload = function () {
 
 <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>groupId: org.apache.spark
 artifactId: spark-core_2.13
-version: 4.1.0
+version: 4.2.0
 </code></pre></div></div>
 
 <h3 id="installing-with-pypi">Installing with PyPi</h3>

--- a/site/static/versions.json
+++ b/site/static/versions.json
@@ -1,5 +1,10 @@
 [
     {
+        "name": "4.2.0",
+        "version": "4.2.0",
+        "url": "https://spark.apache.org/docs/4.2.0/api/python/"
+    },
+    {
         "name": "4.0.1",
         "version": "4.0.1",
         "url": "https://spark.apache.org/docs/4.0.1/api/python/"


### PR DESCRIPTION
Following the Apache Spark 4.2.0 release, this PR updates two pieces of
website metadata that the release tooling does not update automatically:
- `downloads.md`: bump the Maven dependency coordinate example from
  `4.1.0` to `4.2.0`.
- `site/static/versions.json`: add a `4.2.0` entry (at the top) to the
  documentation version switcher.
