### PR TITLE
Update release window section for Apache Spark 4.3.0

### DIFF
--- a/site/versioning-policy.html
+++ b/site/versioning-policy.html
@@ -294,7 +294,7 @@ improvements, and bug fixes. Major releases occur annually (every 12 months), ty
 changes and dependency upgrades. Maintenance releases happen as needed in between for critical 
 bug fixes and security patches.</p>
 
-<h3>Spark 4.2 release window</h3>
+<h3>Spark 4.3 release window</h3>
 
 <table>
   <thead>
@@ -305,15 +305,15 @@ bug fixes and security patches.</p>
   </thead>
   <tbody>
     <tr>
-      <td>May 1st 2026</td>
+      <td>Aug 1st 2026</td>
       <td>Code freeze. Release branch cut.</td>
     </tr>
     <tr>
-      <td>Mid May 2026</td>
+      <td>Mid Aug 2026</td>
       <td>QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.</td>
     </tr>
     <tr>
-      <td>Late May 2026</td>
+      <td>Late Aug 2026</td>
       <td>Release candidates (RC), voting, etc. until final release passes</td>
     </tr>
   </tbody>

--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -108,13 +108,13 @@ improvements, and bug fixes. Major releases occur annually (every 12 months), ty
 changes and dependency upgrades. Maintenance releases happen as needed in between for critical 
 bug fixes and security patches.
 
-<h3>Spark 4.2 release window</h3>
+<h3>Spark 4.3 release window</h3>
 
 | Date  | Event |
 | ----- | ----- |
-| May 1st 2026 | Code freeze. Release branch cut.|
-| Mid May 2026 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
-| Late May 2026 | Release candidates (RC), voting, etc. until final release passes|
+| Aug 1st 2026 | Code freeze. Release branch cut.|
+| Mid Aug 2026 | QA period. Focus on bug fixes, tests, stability and docs. Generally, no new features merged.|
+| Late Aug 2026 | Release candidates (RC), voting, etc. until final release passes|
 
 <h3>Illustrative transition: 2026 and 2027</h3>
 


### PR DESCRIPTION
Replace the Spark 4.2 release window with the Spark 4.3 release window: code freeze / branch cut Aug 1st 2026, QA period mid Aug 2026, and release candidates late Aug 2026.