### PR TITLE
[MINOR] Fix indentation on versioning policy

### DIFF
--- a/versioning-policy.md
+++ b/versioning-policy.md
@@ -30,7 +30,7 @@ projects, feature releases have the following compatibility:
   changes that alter results are not. Exceptions might occur case by case (e.g., security issues).
   - Public APIs may be added but not changed or removed.
 
-Each feature release will have a merge window where new patches can be merged, a QA window when 
+  Each feature release will have a merge window where new patches can be merged, a QA window when 
 only fixes can be merged, then a final period where voting occurs on release candidates. These 
 windows will be announced immediately after the previous feature release to give people plenty 
 of time.


### PR DESCRIPTION
If you look at the [versioning policy](https://spark.apache.org/versioning-policy.html) you'll see that one of the paragraphs breaks the indentation of the bulleted lists.

This PR just fixes the indentation so the paragraph is correctly grouped under the "FEATURE" bullet.