### PR TITLE
Point security reporting address at the ASF Security Team

### DIFF
--- a/security.md
+++ b/security.md
@@ -18,10 +18,23 @@ Apache Spark uses the standard process outlined by the [Apache Security Team](ht
 for reporting vulnerabilities. Note that vulnerabilities should not be publicly disclosed until the project has
 responded.
 
-To report a possible security vulnerability, please email `security@spark.apache.org`. This is a
-non-public list that will reach the Apache Security team, as well as the Spark PMC.
+Before submitting a report,
+confirm that the deployment under test is configured according to the [Spark Security](https://spark.apache.org/docs/latest/security.html) documentation:
+Spark's security features are opt-in,
+no deployment mode is secure by default,
+and reports against deployments that do not follow that guidance are out of scope.
+Review also the [Frequently Asked Questions](#faq) below,
+which document behavior that is by design
+and has been reported and rejected repeatedly.
 
-<h2>Frequently Asked Questions</h2>
+To report a possible security vulnerability,
+please email [`security@apache.org`](mailto:security@apache.org?subject=%5BSECURITY%5D%20Spark).
+This is the non-public list of the ASF Security Team, which will involve the Spark PMC.
+
+Please send one plain-text, unencrypted email per vulnerability,
+and describe the issue in the message body rather than as an image, HTML, or PDF attachment.
+
+<h2 id="faq">Frequently Asked Questions</h2>
 
 <h3>During a security analysis of Apache Spark, I noticed that Spark allows for remote code execution, is this an issue?</h3> 
 

--- a/site/security.html
+++ b/site/security.html
@@ -167,10 +167,23 @@ documentation.</p>
 for reporting vulnerabilities. Note that vulnerabilities should not be publicly disclosed until the project has
 responded.</p>
 
-<p>To report a possible security vulnerability, please email <code class="language-plaintext highlighter-rouge">security@spark.apache.org</code>. This is a
-non-public list that will reach the Apache Security team, as well as the Spark PMC.</p>
+<p>Before submitting a report,
+confirm that the deployment under test is configured according to the <a href="https://spark.apache.org/docs/latest/security.html">Spark Security</a> documentation:
+Spark&#8217;s security features are opt-in,
+no deployment mode is secure by default,
+and reports against deployments that do not follow that guidance are out of scope.
+Review also the <a href="#faq">Frequently Asked Questions</a> below,
+which document behavior that is by design
+and has been reported and rejected repeatedly.</p>
 
-<h2>Frequently Asked Questions</h2>
+<p>To report a possible security vulnerability,
+please email <a href="mailto:security@apache.org?subject=%5BSECURITY%5D%20Spark"><code class="language-plaintext highlighter-rouge">security@apache.org</code></a>.
+This is the non-public list of the ASF Security Team, which will involve the Spark PMC.</p>
+
+<p>Please send one plain-text, unencrypted email per vulnerability,
+and describe the issue in the message body rather than as an image, HTML, or PDF attachment.</p>
+
+<h2 id="faq">Frequently Asked Questions</h2>
 
 <h3>During a security analysis of Apache Spark, I noticed that Spark allows for remote code execution, is this an issue?</h3>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`security.md`, in the "Reporting security issues" section:

- Point the reporting address at the ASF Security Team, [`security@apache.org`](mailto:security@apache.org?subject=%5BSECURITY%5D%20Spark), replacing `security@spark.apache.org`.
- Ask reporters, before submitting, to confirm that the deployment under test is configured according to the [Spark Security](https://spark.apache.org/docs/latest/security.html) documentation, and to review the FAQ below.
- Restate the ASF request for one plain-text, unencrypted email per vulnerability, described in the message body rather than as an attachment.
- Give the "Frequently Asked Questions" heading an `id`, so the new text can link to it. The CVE headings on the same page already carry explicit ids.

`site/security.html` is the regenerated Jekyll output for that page.

### Why are the changes needed?

The page currently says:

> To report a possible security vulnerability, please email `security@spark.apache.org`. This is a non-public list that will reach the Apache Security team, as well as the Spark PMC.

That list was sunset at the beginning of 2026, and mail addressed to it is redirected to `security@apache.org`. Reports are therefore not lost, but the page advertises an address that survives only by redirect, and it disagrees with [security.apache.org/projects](https://security.apache.org/projects/), which gives Spark's security contact as `security@apache.org` while linking this page as Spark's advisories page. Naming the ASF Security Team directly removes the discrepancy.

The two pre-report checks address the most common categories of invalid report the project receives: findings against deployments left in their insecure-by-default state, and findings that amount to "Spark executes the code it was given", which the FAQ on this page has documented as by design for some time. Pointing at both before the reporting address should cut down on reports that have to be rejected.

A companion change to `SECURITY.md` in the main repository is at apache/spark#57844.

### Does this PR introduce _any_ user-facing change?

Yes, to the website only: the reporting address on <https://spark.apache.org/security.html> changes, and the section gains the pre-report checks.

### How was this patch tested?

`site/security.html` was regenerated with the pinned toolchain from `Gemfile.lock` (Jekyll 4.4.1, Rouge 3.26.0, Ruby 3.2) and the rendered page was checked in a browser.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
